### PR TITLE
fix: Enable multi-domain OAuth login support

### DIFF
--- a/apps/editor/app/api/organizations/[orgId]/billing/checkout/route.ts
+++ b/apps/editor/app/api/organizations/[orgId]/billing/checkout/route.ts
@@ -4,6 +4,7 @@ import { hasUserRoleInOrganization } from "@/lib/organizations";
 import { prisma } from "@/lib/prisma";
 import { serverEnv } from "@/lib/env/server";
 import Stripe from "stripe";
+import { getBaseUrl } from "@/lib/utils/url";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
   apiVersion: "2025-11-17.clover",
@@ -136,8 +137,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           quantity: 1,
         },
       ],
-      success_url: `${process.env.NEXTAUTH_URL}/org/${orgId}/billing?success=true`,
-      cancel_url: `${process.env.NEXTAUTH_URL}/org/${orgId}/billing?canceled=true`,
+      success_url: `${getBaseUrl(request)}/org/${orgId}/billing?success=true`,
+      cancel_url: `${getBaseUrl(request)}/org/${orgId}/billing?canceled=true`,
       metadata: {
         organizationId: orgId,
         planCode: planCode,

--- a/apps/editor/app/api/organizations/create-checkout/route.ts
+++ b/apps/editor/app/api/organizations/create-checkout/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { serverEnv } from "@/lib/env/server";
 import Stripe from "stripe";
 import { isGodUser } from "@/lib/config/godusers";
+import { getBaseUrl } from "@/lib/utils/url";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
   apiVersion: "2025-11-17.clover",
@@ -146,7 +147,7 @@ export async function POST(request: NextRequest) {
 
       // Return success URL instead of Stripe checkout URL
       return NextResponse.json({
-        url: `${process.env.NEXTAUTH_URL}/org/${organization.id}/dashboard?org_created=true`,
+        url: `${getBaseUrl(request)}/org/${organization.id}/dashboard?org_created=true`,
         bypassed: true,
       });
     }
@@ -176,8 +177,8 @@ export async function POST(request: NextRequest) {
           quantity: 1,
         },
       ],
-      success_url: `${process.env.NEXTAUTH_URL}/dashboard?org_created=true`,
-      cancel_url: `${process.env.NEXTAUTH_URL}/dashboard?org_canceled=true`,
+      success_url: `${getBaseUrl(request)}/dashboard?org_created=true`,
+      cancel_url: `${getBaseUrl(request)}/dashboard?org_canceled=true`,
       metadata: {
         userId: userId,
         orgName: orgName.trim(),

--- a/apps/editor/auth.ts
+++ b/apps/editor/auth.ts
@@ -12,6 +12,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
   secret: process.env.SECRET,
+  trustHost: true, // Allow NextAuth to auto-detect base URL from request headers
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID,

--- a/apps/editor/lib/env/server.ts
+++ b/apps/editor/lib/env/server.ts
@@ -24,7 +24,7 @@ const serverEnvSchema = z.object({
 
   // Authentication
   SECRET: z.string().min(1, "SECRET is required"),
-  NEXTAUTH_URL: z.string().min(1, "NEXTAUTH_URL is required"),
+  NEXTAUTH_URL: z.string().optional(), // Optional - NextAuth will auto-detect from request headers
   NEXTAUTH_COOKIE_DOMAIN: z
     .string()
     .min(1, "NEXTAUTH_COOKIE_DOMAIN is required"),

--- a/apps/editor/lib/utils/url.ts
+++ b/apps/editor/lib/utils/url.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+
+/**
+ * Get the base URL from a Next.js request
+ * Falls back to NEXTAUTH_URL env var if available, otherwise constructs from request
+ * This enables multi-domain support by dynamically detecting the domain
+ */
+export function getBaseUrl(request: NextRequest): string {
+  // Try environment variable first (for backwards compatibility)
+  if (process.env.NEXTAUTH_URL) {
+    return process.env.NEXTAUTH_URL;
+  }
+
+  // Construct from request headers (works for multi-domain setups)
+  const protocol = request.headers.get("x-forwarded-proto") || "https";
+  const host =
+    request.headers.get("host") || request.headers.get("x-forwarded-host");
+
+  if (host) {
+    return `${protocol}://${host}`;
+  }
+
+  // Fallback (should not happen in production)
+  return process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+}

--- a/packages/dev-audits/src/profiles/klorad/audits/env.audit.ts
+++ b/packages/dev-audits/src/profiles/klorad/audits/env.audit.ts
@@ -13,9 +13,9 @@ import type {
 
 const REQUIRED_ENV_VARS = {
   NEXTAUTH_URL: {
-    required: true,
+    required: false, // Optional - NextAuth will auto-detect from request headers when trustHost: true
     pattern: /^https?:\/\//,
-    description: "NextAuth base URL",
+    description: "NextAuth base URL (optional - auto-detected when not set)",
   },
   DATABASE_URL: {
     required: true,


### PR DESCRIPTION
- Make NEXTAUTH_URL optional in environment validation to allow auto-detection
- Add trustHost: true to NextAuth config for automatic base URL detection
- Create getBaseUrl utility function to dynamically detect domain from request headers
- Update Stripe checkout routes to use dynamic base URL instead of hardcoded NEXTAUTH_URL

This enables Google OAuth login to work on both platform.klorad.com and psm.klorad.com by automatically detecting the correct domain from request headers.

After deployment:
- Remove or leave empty NEXTAUTH_URL in Vercel
- Ensure NEXTAUTH_COOKIE_DOMAIN is set to .klorad.com
- Add both redirect URIs in Google OAuth Console

Made-with: Cursor

### What changed?

-

### Audit status

- [ ] `audit:light` passes locally
- [ ] If touching build or deps, I ran `pnpm build:editor`
- [ ] New client/server boundaries respected (no 3D libs in server files)

### Screenshots / bundle diff (if UI)

-

### Notes

-

