### PR TITLE
Design system kit + campus migration off MUI

### DIFF
--- a/apps/campus/app/(auth-only)/auth/signin/page.tsx
+++ b/apps/campus/app/(auth-only)/auth/signin/page.tsx
@@ -2,21 +2,74 @@
 
 import { signIn } from "next-auth/react";
 import GitHubIcon from "@mui/icons-material/GitHub";
-import { GoogleIcon, OAuthSignInCard } from "@klorad/ui";
+import { Button, KloradMark, Panel } from "@klorad/design-system";
 
 const PROVIDERS = [
   { id: "google", label: "Google", icon: <GoogleIcon /> },
-  { id: "github", label: "GitHub", icon: <GitHubIcon /> },
+  { id: "github", label: "GitHub", icon: <GitHubIcon sx={{ fontSize: 18 }} /> },
 ];
 
 export default function SignInPage() {
   return (
-    <OAuthSignInCard
-      appName="Klorad Campus"
-      tagline="Sign in to manage your campus maps"
-      providers={PROVIDERS}
-      onProviderClick={(id) => signIn(id, { callbackUrl: "/" })}
-      legalText="By signing in you agree to our Terms of Service and Privacy Policy."
-    />
+    <div className="flex min-h-screen items-center justify-center bg-bg px-6 text-text-primary">
+      <Panel className="w-full max-w-sm rounded-2xl p-6">
+        <div className="flex flex-col items-center text-center">
+          <KloradMark className="h-10 w-auto" />
+          <h1 className="mt-4 text-lg font-semibold text-text-primary">
+            Klorad Campus
+          </h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            Sign in to manage your campus maps
+          </p>
+        </div>
+
+        <div className="mt-6 space-y-2">
+          {PROVIDERS.map((p) => (
+            <Button
+              key={p.id}
+              variant="secondary"
+              className="w-full"
+              onClick={() => signIn(p.id, { callbackUrl: "/" })}
+            >
+              {p.icon}
+              Continue with {p.label}
+            </Button>
+          ))}
+        </div>
+
+        <p className="mt-6 text-center text-xs text-text-tertiary">
+          By signing in you agree to our Terms of Service and Privacy Policy.
+        </p>
+      </Panel>
+    </div>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
   );
 }

--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -1,19 +1,72 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
-import { AppShell, type NavItem } from "@klorad/design-system";
+import { AppShell, KloradMark, type NavItem } from "@klorad/design-system";
 import {
   OrganizationSwitcher,
   UserAccountMenu,
   DashboardIcon,
   MapIcon,
   SettingsIcon,
+  useThemeMode,
 } from "@klorad/ui";
 import { signOut, useSession } from "next-auth/react";
 import { useOrganization, useOrganizations } from "@/app/hooks/useOrganizations";
+
+/** Light/dark toggle, driven by @klorad/ui's ThemeModeProvider. */
+function ThemeToggleButton() {
+  const { mode, toggle } = useThemeMode();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const isDark = mode === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="Toggle color theme"
+      className="flex h-9 w-9 items-center justify-center rounded-full border border-line-soft text-text-secondary transition-colors hover:border-accent hover:text-text-primary"
+    >
+      {mounted ? (
+        isDark ? (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+          </svg>
+        ) : (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
+          </svg>
+        )
+      ) : (
+        <span className="block h-4 w-4" />
+      )}
+    </button>
+  );
+}
 
 export default function DashboardShell({ children }: { children: ReactNode }) {
   const { data: session } = useSession();
@@ -60,16 +113,12 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
         <Link
           href={orgId ? `/org/${orgId}/dashboard` : "/"}
           aria-label="Klorad Campus"
-          className="flex items-center"
+          className="flex items-center gap-2.5"
         >
-          <Image
-            src="/images/logo/klorad-campus-logo-white.svg"
-            alt="Klorad Campus"
-            width={140}
-            height={32}
-            priority
-            className="h-8 w-auto"
-          />
+          <KloradMark className="h-7 w-auto" />
+          <span className="text-sm font-semibold tracking-tight text-text-primary">
+            Klorad Campus
+          </span>
         </Link>
       }
       sidebarHeader={
@@ -83,6 +132,7 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
         />
       }
       nav={nav}
+      actions={<ThemeToggleButton />}
       sidebarFooter={
         <UserAccountMenu
           name={session?.user?.name ?? undefined}

--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -4,16 +4,14 @@ import type { ReactNode } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import { Box } from "@mui/material";
+import { AppShell, type NavItem } from "@klorad/design-system";
 import {
-  AppSidebar,
   OrganizationSwitcher,
   UserAccountMenu,
   DashboardIcon,
   MapIcon,
   SettingsIcon,
 } from "@klorad/ui";
-import type { AppSidebarNavItem } from "@klorad/ui";
 import { signOut, useSession } from "next-auth/react";
 import { useOrganization, useOrganizations } from "@/app/hooks/useOrganizations";
 
@@ -25,88 +23,81 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
   const orgId = params?.orgId ?? "";
   const pathPrefix = orgId ? `/org/${orgId}` : "";
   const { organizations, loadingOrganizations } = useOrganizations();
-  const { organization: currentOrganization, loadingOrganization } = useOrganization(orgId);
+  const { organization: currentOrganization, loadingOrganization } =
+    useOrganization(orgId);
 
-  // Builder routes have their own dedicated left panel.
+  // Builder routes have their own dedicated layout — no dashboard shell.
   const isBuilder = pathname?.includes("/builder") ?? false;
   if (isBuilder) {
-    return (
-      <Box component="main" sx={{ minHeight: "100vh" }}>
-        {children}
-      </Box>
-    );
+    return <main className="min-h-screen">{children}</main>;
   }
 
-  const NAV_ITEMS: AppSidebarNavItem[] = [
-    { label: "Dashboard", icon: <DashboardIcon fontSize="small" />, path: "/dashboard" },
-    { label: "Campuses", icon: <MapIcon fontSize="small" />, path: "/maps" },
+  const nav: NavItem[] = [
+    {
+      label: "Dashboard",
+      href: `${pathPrefix}/dashboard`,
+      icon: <DashboardIcon fontSize="small" />,
+      active: pathname?.includes("/dashboard") ?? false,
+    },
+    {
+      label: "Campuses",
+      href: `${pathPrefix}/maps`,
+      icon: <MapIcon fontSize="small" />,
+      active: pathname?.includes("/maps") ?? false,
+    },
     {
       label: "Settings",
+      href: `${pathPrefix}/settings/general`,
       icon: <SettingsIcon fontSize="small" />,
-      path: "/settings",
-      subItems: [
-        { label: "General", path: "/settings/general" },
-        { label: "Members", path: "/settings/members" },
-        { label: "Usage", path: "/settings/usage" },
-        { label: "Billing", path: "/settings/billing", comingSoon: true },
-      ],
+      active: pathname?.includes("/settings") ?? false,
     },
   ];
 
   return (
-    <>
-      <AppSidebar
-        pathname={pathname ?? null}
-        navItems={NAV_ITEMS}
-        pathPrefix={pathPrefix}
-        linkComponent={Link}
-        preNav={
-          <OrganizationSwitcher
-            organizations={organizations}
-            currentOrgId={orgId}
-            currentOrganization={currentOrganization}
-            loading={loadingOrganizations || loadingOrganization}
-            buildHref={(id) => `/org/${id}/dashboard`}
-            linkComponent={Link}
+    <AppShell
+      linkComponent={Link}
+      brand={
+        <Link
+          href={orgId ? `/org/${orgId}/dashboard` : "/"}
+          aria-label="Klorad Campus"
+          className="flex items-center"
+        >
+          <Image
+            src="/images/logo/klorad-campus-logo-white.svg"
+            alt="Klorad Campus"
+            width={140}
+            height={32}
+            priority
+            className="h-8 w-auto"
           />
-        }
-        header={
-          <Link
-            href={orgId ? `/org/${orgId}/dashboard` : "/"}
-            aria-label="Klorad"
-            style={{ textDecoration: "none", display: "flex", alignItems: "center" }}
-          >
-            <Image
-              src="/images/logo/klorad-campus-logo-white.svg"
-              alt="Klorad Campus"
-              width={140}
-              height={32}
-              priority
-              style={{
-                objectFit: "contain",
-                height: "auto",
-              }}
-            />
-          </Link>
-        }
-        footer={
-          <UserAccountMenu
-            name={session?.user?.name ?? undefined}
-            email={session?.user?.email ?? undefined}
-            image={session?.user?.image ?? undefined}
-            profileHref={orgId ? `/org/${orgId}/profile` : "/profile"}
-            onLogout={async () => {
-              await signOut({ callbackUrl: "/auth/signin" });
-              router.refresh();
-            }}
-            profileActive={pathname?.includes("/profile") ?? false}
-          />
-        }
-      />
-
-      <Box component="main" sx={{ minHeight: "100vh" }}>
-        {children}
-      </Box>
-    </>
+        </Link>
+      }
+      sidebarHeader={
+        <OrganizationSwitcher
+          organizations={organizations}
+          currentOrgId={orgId}
+          currentOrganization={currentOrganization}
+          loading={loadingOrganizations || loadingOrganization}
+          buildHref={(id) => `/org/${id}/dashboard`}
+          linkComponent={Link}
+        />
+      }
+      nav={nav}
+      sidebarFooter={
+        <UserAccountMenu
+          name={session?.user?.name ?? undefined}
+          email={session?.user?.email ?? undefined}
+          image={session?.user?.image ?? undefined}
+          profileHref={orgId ? `/org/${orgId}/profile` : "/profile"}
+          onLogout={async () => {
+            await signOut({ callbackUrl: "/auth/signin" });
+            router.refresh();
+          }}
+          profileActive={pathname?.includes("/profile") ?? false}
+        />
+      }
+    >
+      {children}
+    </AppShell>
   );
 }

--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -113,11 +113,16 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
         <Link
           href={orgId ? `/org/${orgId}/dashboard` : "/"}
           aria-label="Klorad Campus"
-          className="flex items-center gap-2.5"
+          className="flex items-center gap-2.5 no-underline"
         >
-          <KloradMark className="h-7 w-auto" />
-          <span className="text-sm font-semibold tracking-tight text-text-primary">
-            Klorad Campus
+          <KloradMark className="h-8 w-auto" />
+          <span className="flex flex-col leading-none">
+            <span className="text-sm font-semibold uppercase tracking-[0.18em] text-text-primary">
+              Klorad
+            </span>
+            <span className="mt-1 text-[10px] font-medium uppercase tracking-[0.26em] text-text-tertiary">
+              Campus
+            </span>
           </span>
         </Link>
       }

--- a/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
@@ -1,24 +1,14 @@
 "use client";
 
 import { useMemo } from "react";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Box, Button, Stack, Typography } from "@mui/material";
-import { alpha } from "@mui/material/styles";
 import MapIcon from "@mui/icons-material/Map";
 import PlaceIcon from "@mui/icons-material/Place";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import AccessibleIcon from "@mui/icons-material/Accessible";
-import AddIcon from "@mui/icons-material/Add";
-import {
-  MetricCard,
-  Page,
-  PageCard,
-  PageContent,
-  PageSection,
-  DashboardProjectCard,
-} from "@klorad/ui";
-import { Skeleton } from "@mui/material";
+import { Panel, Button } from "@klorad/design-system";
 import { useMaps } from "@/app/hooks/useMaps";
 import LocationsHeader from "../maps/LocationsHeader";
 
@@ -34,150 +24,181 @@ export default function DashboardClient({ orgId }: Props) {
   const showSkeleton = isLoading && maps.length === 0;
 
   return (
-    <Page>
-      <PageContent sx={{ mt: 0 }}>
-        <Box>
-          <LocationsHeader maps={maps} />
-        </Box>
+    <div className="mx-auto w-full max-w-6xl space-y-10 px-6 py-8 md:px-8">
+      <LocationsHeader maps={maps} />
 
-        {/* KPI row */}
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: {
-              xs: "1fr",
-              sm: "repeat(2, 1fr)",
-              md: "repeat(4, 1fr)",
-            },
-          }}
-        >
-          <MetricCard icon={<MapIcon fontSize="small" />} value={maps.length} label="Campus maps" />
-          <MetricCard icon={<PlaceIcon fontSize="small" />} value="—" label="POIs across maps" />
-          <MetricCard icon={<VisibilityIcon fontSize="small" />} value="—" label="Public views (30d)" />
-          <MetricCard icon={<AccessibleIcon fontSize="small" />} value="—" label="Accessibility coverage" />
-        </Box>
+      {/* KPI row */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={<MapIcon fontSize="small" />}
+          value={String(maps.length)}
+          label="Campus maps"
+        />
+        <StatCard
+          icon={<PlaceIcon fontSize="small" />}
+          value="—"
+          label="POIs across maps"
+        />
+        <StatCard
+          icon={<VisibilityIcon fontSize="small" />}
+          value="—"
+          label="Public views (30d)"
+        />
+        <StatCard
+          icon={<AccessibleIcon fontSize="small" />}
+          value="—"
+          label="Accessibility coverage"
+        />
+      </div>
 
-        <PageSection title="Recent campuses" spacing="tight">
-          {showSkeleton ? (
-            <Box
-              sx={{
-                display: "grid",
-                gap: 2,
-                gridTemplateColumns: {
-                  xs: "1fr",
-                  sm: "repeat(2, 1fr)",
-                  md: "repeat(3, 1fr)",
-                },
-              }}
+      {/* Recent campuses */}
+      <section className="space-y-4">
+        <SectionTitle>Recent campuses</SectionTitle>
+        {showSkeleton ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {[0, 1, 2].map((i) => (
+              <div
+                key={i}
+                className="h-[208px] animate-pulse rounded-xl bg-surface-2"
+              />
+            ))}
+          </div>
+        ) : recentMaps.length === 0 ? (
+          <Panel className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+            <MapIcon className="text-accent opacity-60" fontSize="large" />
+            <p className="text-base font-medium text-text-primary">
+              No campuses yet
+            </p>
+            <p className="max-w-sm text-sm text-text-secondary">
+              Create your first campus map. Drop some POIs, share the URL —
+              it&apos;s a five-minute setup.
+            </p>
+            <Button
+              className="mt-1"
+              onClick={() => router.push(`/org/${orgId}/maps`)}
             >
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Skeleton key={i} variant="rounded" height={260} />
+              Create a campus
+            </Button>
+          </Panel>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {recentMaps.map((m) => (
+                <CampusCard
+                  key={m.id}
+                  name={m.name}
+                  updatedAt={m.updatedAt}
+                  thumbnail={m.thumbnail ?? undefined}
+                  href={`/org/${orgId}/maps/${m.id}`}
+                />
               ))}
-            </Box>
-          ) : recentMaps.length === 0 ? (
-            <PageCard>
-              <Box
-                sx={{
-                  textAlign: "center",
-                  py: 5,
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  gap: 1.5,
-                }}
+            </div>
+            <div className="flex justify-end">
+              <Link
+                href={`/org/${orgId}/maps`}
+                className="text-sm font-medium text-accent transition-colors hover:text-accent-hover"
               >
-                <MapIcon sx={{ fontSize: 48, color: "primary.main", opacity: 0.5 }} />
-                <Typography variant="subtitle1" fontWeight={600}>
-                  No campuses yet
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 420 }}>
-                  Create your first campus map. Drop some POIs, share the URL — it&apos;s a
-                  five-minute setup.
-                </Typography>
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => router.push(`/org/${orgId}/maps`)}
-                  sx={{ mt: 1, textTransform: "none" }}
-                >
-                  Create a campus
-                </Button>
-              </Box>
-            </PageCard>
-          ) : (
-            <Stack spacing={2}>
-              <Box
-                sx={{
-                  display: "grid",
-                  gap: 2,
-                  gridTemplateColumns: {
-                    xs: "1fr",
-                    sm: "repeat(2, 1fr)",
-                    md: "repeat(3, 1fr)",
-                  },
-                }}
-              >
-                {recentMaps.map((m) => (
-                  <DashboardProjectCard
-                    key={m.id}
-                    project={{
-                      id: m.id,
-                      title: m.name,
-                      updatedAt: m.updatedAt,
-                      createdAt: m.createdAt,
-                      thumbnail: m.thumbnail ?? undefined,
-                    }}
-                    onGoToBuilder={(id) => router.push(`/org/${orgId}/maps/${id}`)}
-                    onMenuOpen={() => {}}
-                  />
-                ))}
-              </Box>
-              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-                <Button
-                  component={Link}
-                  href={`/org/${orgId}/maps`}
-                  size="small"
-                  sx={{ textTransform: "none" }}
-                >
-                  View all campuses →
-                </Button>
-              </Box>
-            </Stack>
-          )}
-        </PageSection>
+                View all campuses →
+              </Link>
+            </div>
+          </div>
+        )}
+      </section>
 
-        <PageSection title="Quick actions" spacing="tight">
-          <Box
-            sx={{
-              display: "grid",
-              gap: 2,
-              gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
-            }}
-          >
-            <QuickActionCard
-              title="Create a new campus"
-              description="Start with a blank 3D map. Drop POIs in seconds."
-              href={`/org/${orgId}/maps`}
-            />
-            <QuickActionCard
-              title="Invite a teammate"
-              description="Bring marketing or facilities staff into the org."
-              href={`/org/${orgId}/settings/members`}
-            />
-            <QuickActionCard
-              title="Review usage"
-              description="See plan limits, POI counts, and view analytics."
-              href={`/org/${orgId}/settings/usage`}
-            />
-          </Box>
-        </PageSection>
-      </PageContent>
-    </Page>
+      {/* Quick actions */}
+      <section className="space-y-4">
+        <SectionTitle>Quick actions</SectionTitle>
+        <div className="grid gap-4 md:grid-cols-3">
+          <QuickAction
+            title="Create a new campus"
+            description="Start with a blank 3D map. Drop POIs in seconds."
+            href={`/org/${orgId}/maps`}
+          />
+          <QuickAction
+            title="Invite a teammate"
+            description="Bring marketing or facilities staff into the org."
+            href={`/org/${orgId}/settings/members`}
+          />
+          <QuickAction
+            title="Review usage"
+            description="See plan limits, POI counts, and view analytics."
+            href={`/org/${orgId}/settings/usage`}
+          />
+        </div>
+      </section>
+    </div>
   );
 }
 
-function QuickActionCard({
+function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+      {children}
+    </h2>
+  );
+}
+
+function StatCard({
+  icon,
+  value,
+  label,
+}: {
+  icon: ReactNode;
+  value: string;
+  label: string;
+}) {
+  return (
+    <Panel className="p-5">
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
+        {icon}
+      </div>
+      <div className="mt-4 text-2xl font-light text-text-primary">{value}</div>
+      <div className="mt-0.5 text-sm text-text-secondary">{label}</div>
+    </Panel>
+  );
+}
+
+function CampusCard({
+  name,
+  updatedAt,
+  thumbnail,
+  href,
+}: {
+  name: string;
+  updatedAt: string | number | Date;
+  thumbnail?: string;
+  href: string;
+}) {
+  const updated = new Date(updatedAt).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return (
+    <Link href={href} className="group block">
+      <Panel className="overflow-hidden transition-colors group-hover:border-accent">
+        <div className="aspect-video bg-surface-2">
+          {thumbnail ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={thumbnail}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : null}
+        </div>
+        <div className="p-4">
+          <div className="font-medium text-text-primary">{name}</div>
+          <div className="mt-1 text-xs text-text-tertiary">
+            Updated {updated}
+          </div>
+        </div>
+      </Panel>
+    </Link>
+  );
+}
+
+function QuickAction({
   title,
   description,
   href,
@@ -187,31 +208,13 @@ function QuickActionCard({
   href: string;
 }) {
   return (
-    <Box
-      component={Link}
-      href={href}
-      sx={(t) => ({
-        display: "block",
-        p: 2.5,
-        borderRadius: 1,
-        textDecoration: "none",
-        color: "inherit",
-        bgcolor: "#161B20",
-        border: "1px solid",
-        borderColor: "divider",
-        transition: "all 0.15s ease",
-        "&:hover": {
-          borderColor: alpha(t.palette.primary.main, 0.5),
-          backgroundColor: alpha(t.palette.primary.main, 0.04),
-        },
-      })}
-    >
-      <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 0.5 }}>
-        {title}
-      </Typography>
-      <Typography variant="caption" color="text.secondary">
-        {description}
-      </Typography>
-    </Box>
+    <Link href={href} className="group block">
+      <Panel className="h-full p-5 transition-colors group-hover:border-accent group-hover:bg-accent-soft">
+        <div className="text-sm font-semibold text-text-primary">{title}</div>
+        <div className="mt-1 text-xs leading-relaxed text-text-secondary">
+          {description}
+        </div>
+      </Panel>
+    </Link>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
@@ -176,7 +176,7 @@ function CampusCard({
   });
   return (
     <Link href={href} className="group block">
-      <Panel className="overflow-hidden rounded-2xl transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-accent group-hover:shadow-glass">
+      <Panel className="overflow-hidden rounded-2xl transition-colors duration-200 group-hover:border-line-strong">
         <div className="aspect-video bg-surface-2">
           {thumbnail ? (
             // eslint-disable-next-line @next/next/no-img-element
@@ -209,7 +209,7 @@ function QuickAction({
 }) {
   return (
     <Link href={href} className="group block">
-      <Panel className="h-full rounded-2xl p-5 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-accent group-hover:shadow-glass">
+      <Panel className="h-full rounded-2xl p-5 transition-colors duration-200 group-hover:border-line-strong">
         <div className="text-sm font-semibold text-text-primary">{title}</div>
         <div className="mt-1 text-xs leading-relaxed text-text-secondary">
           {description}

--- a/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
@@ -24,7 +24,7 @@ export default function DashboardClient({ orgId }: Props) {
   const showSkeleton = isLoading && maps.length === 0;
 
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-10 px-6 py-8 md:px-8">
+    <div className="w-full space-y-10 px-6 py-8 md:px-10">
       <LocationsHeader maps={maps} />
 
       {/* KPI row */}
@@ -148,7 +148,7 @@ function StatCard({
   label: string;
 }) {
   return (
-    <Panel className="p-5">
+    <Panel className="rounded-2xl p-5">
       <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
         {icon}
       </div>
@@ -176,7 +176,7 @@ function CampusCard({
   });
   return (
     <Link href={href} className="group block">
-      <Panel className="overflow-hidden transition-colors group-hover:border-accent">
+      <Panel className="overflow-hidden rounded-2xl transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-accent group-hover:shadow-glass">
         <div className="aspect-video bg-surface-2">
           {thumbnail ? (
             // eslint-disable-next-line @next/next/no-img-element
@@ -209,7 +209,7 @@ function QuickAction({
 }) {
   return (
     <Link href={href} className="group block">
-      <Panel className="h-full p-5 transition-colors group-hover:border-accent group-hover:bg-accent-soft">
+      <Panel className="h-full rounded-2xl p-5 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-accent group-hover:shadow-glass">
         <div className="text-sm font-semibold text-text-primary">{title}</div>
         <div className="mt-1 text-xs leading-relaxed text-text-secondary">
           {description}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/LocationsHeader.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/LocationsHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Button, Chip, Stack, Typography, useTheme } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
 import mapboxgl, { type Map as MapboxMap, type Marker } from "mapbox-gl";
 import type { CampusMap } from "@/app/hooks/useMaps";
@@ -140,9 +141,10 @@ export default function LocationsHeader({ maps }: Props) {
           px: 1.5,
           py: 0.75,
           borderRadius: 999,
-          backgroundColor: "rgba(15,23,42,0.78)",
-          color: "#fff",
-          backdropFilter: "blur(6px)",
+          backgroundColor: alpha(theme.palette.background.paper, 0.9),
+          color: theme.palette.text.primary,
+          border: `1px solid ${theme.palette.divider}`,
+          backdropFilter: "blur(8px)",
         }}
       >
         <Typography variant="caption" sx={{ fontWeight: 600 }}>
@@ -154,8 +156,8 @@ export default function LocationsHeader({ maps }: Props) {
           sx={{
             height: 18,
             fontSize: "0.7rem",
-            backgroundColor: "rgba(255,255,255,0.18)",
-            color: "#fff",
+            backgroundColor: alpha(theme.palette.primary.main, 0.16),
+            color: theme.palette.primary.main,
             "& .MuiChip-label": { px: 1 },
           }}
         />

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/LocationsHeader.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/LocationsHeader.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Box, Button, Chip, Stack, Typography, useTheme } from "@mui/material";
-import { alpha } from "@mui/material/styles";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
 import mapboxgl, { type Map as MapboxMap, type Marker } from "mapbox-gl";
+import { Button } from "@klorad/design-system";
 import type { CampusMap } from "@/app/hooks/useMaps";
 
 interface Props {
@@ -13,10 +12,10 @@ interface Props {
 
 const FALLBACK_CENTER: [number, number] = [23.7275, 37.9838]; // Athens
 const FALLBACK_ZOOM = 4;
+// Brand accent — constant across themes (mirrors --accent in tokens.css).
+const PIN_COLOR = "#158ca3";
 
 export default function LocationsHeader({ maps }: Props) {
-  const theme = useTheme();
-  const pinColor = theme.palette.primary.main;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapboxMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
@@ -29,10 +28,10 @@ export default function LocationsHeader({ maps }: Props) {
           (m): m is CampusMap & { center: [number, number] } =>
             Array.isArray(m.center) &&
             typeof m.center[0] === "number" &&
-            typeof m.center[1] === "number"
+            typeof m.center[1] === "number",
         )
         .map((m) => ({ id: m.id, name: m.name, center: m.center })),
-    [maps]
+    [maps],
   );
 
   const fitToExtent = () => {
@@ -85,101 +84,45 @@ export default function LocationsHeader({ maps }: Props) {
       el.style.width = "14px";
       el.style.height = "14px";
       el.style.borderRadius = "50%";
-      el.style.background = pinColor;
+      el.style.background = PIN_COLOR;
       el.style.border = "2px solid #fff";
       el.style.boxShadow = "0 1px 4px rgba(0,0,0,0.35)";
       el.title = pin.name;
-      const marker = new mapboxgl.Marker(el).setLngLat(pin.center).addTo(mapRef.current);
+      const marker = new mapboxgl.Marker(el)
+        .setLngLat(pin.center)
+        .addTo(mapRef.current);
       markersRef.current.push(marker);
     }
 
     fitToExtent();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pins, ready, pinColor]);
+  }, [pins, ready]);
 
   const hasToken = Boolean(process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN);
 
   return (
-    <Box
-      sx={(theme) => ({
-        position: "relative",
-        width: "100%",
-        height: 200,
-        borderRadius: 2,
-        overflow: "hidden",
-        border: `1px solid ${theme.palette.divider}`,
-        backgroundColor: theme.palette.background.paper,
-        mb: 3,
-      })}
-    >
-      <Box ref={containerRef} sx={{ position: "absolute", inset: 0 }} />
+    <div className="relative mb-6 h-[200px] w-full overflow-hidden rounded-2xl border border-line-soft bg-surface-1">
+      <div ref={containerRef} className="absolute inset-0" />
       {!hasToken && (
-        <Box
-          sx={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            color: "text.secondary",
-            fontSize: "0.875rem",
-            px: 2,
-            textAlign: "center",
-          }}
-        >
+        <div className="absolute inset-0 flex items-center justify-center px-4 text-center text-sm text-text-secondary">
           Set NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN to see campus locations on a map.
-        </Box>
+        </div>
       )}
-      <Stack
-        direction="row"
-        spacing={1}
-        alignItems="center"
-        sx={{
-          position: "absolute",
-          top: 12,
-          left: 12,
-          px: 1.5,
-          py: 0.75,
-          borderRadius: 999,
-          backgroundColor: alpha(theme.palette.background.paper, 0.9),
-          color: theme.palette.text.primary,
-          border: `1px solid ${theme.palette.divider}`,
-          backdropFilter: "blur(8px)",
-        }}
-      >
-        <Typography variant="caption" sx={{ fontWeight: 600 }}>
-          Campus locations
-        </Typography>
-        <Chip
-          size="small"
-          label={pins.length}
-          sx={{
-            height: 18,
-            fontSize: "0.7rem",
-            backgroundColor: alpha(theme.palette.primary.main, 0.16),
-            color: theme.palette.primary.main,
-            "& .MuiChip-label": { px: 1 },
-          }}
-        />
-      </Stack>
+      <div className="glass-panel absolute left-3 top-3 inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium text-text-primary">
+        <span>Campus locations</span>
+        <span className="inline-flex items-center rounded-full bg-accent-soft px-2 py-0.5 text-[0.7rem] font-semibold text-accent">
+          {pins.length}
+        </span>
+      </div>
       <Button
-        size="small"
-        variant="contained"
+        size="sm"
         onClick={fitToExtent}
-        startIcon={<CenterFocusStrongIcon sx={{ fontSize: 16 }} />}
         disabled={pins.length === 0}
-        sx={{
-          position: "absolute",
-          top: 12,
-          right: 12,
-          textTransform: "none",
-          fontSize: "0.75rem",
-          py: 0.5,
-          px: 1.25,
-        }}
+        className="absolute right-3 top-3"
       >
+        <CenterFocusStrongIcon sx={{ fontSize: 16 }} />
         Fit to extent
       </Button>
-    </Box>
+    </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/MapsPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/MapsPageClient.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Grid, Button, Skeleton } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import {
-  Page,
-  PageContent,
-  DashboardProjectCard,
-  DashboardCreateProjectCard,
-  DashboardOptionsMenu,
-  DashboardDeleteConfirmationDialog,
-  RightDrawer,
-  TextField,
-  FormField,
-} from "@klorad/ui";
+  Button,
+  Field,
+  IconButton,
+  Input,
+  Menu,
+  MenuItem,
+  Modal,
+  Panel,
+} from "@klorad/design-system";
 import { useMaps } from "@/app/hooks/useMaps";
 import LocationsHeader from "./LocationsHeader";
 
@@ -28,9 +29,11 @@ export default function MapsPageClient({ orgId }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [menuMapId, setMenuMapId] = useState<string | null>(null);
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const closeCreate = () => {
     if (creating) return;
@@ -39,7 +42,7 @@ export default function MapsPageClient({ orgId }: Props) {
   };
 
   const handleCreate = async () => {
-    if (!newName.trim()) return;
+    if (!newName.trim() || creating) return;
     setCreating(true);
     const map = await createMap(newName.trim());
     setCreating(false);
@@ -48,123 +51,179 @@ export default function MapsPageClient({ orgId }: Props) {
     if (map) router.push(`/org/${orgId}/maps/${map.id}`);
   };
 
-  const handleMenuOpen = (e: React.MouseEvent, id: string) => {
-    setMenuAnchor(e.currentTarget as HTMLElement);
-    setMenuMapId(id);
-  };
-
-  const handleMenuClose = () => {
-    setMenuAnchor(null);
-    setMenuMapId(null);
-  };
-
-  const handleRequestDelete = () => {
-    if (menuMapId) setConfirmDeleteId(menuMapId);
-    handleMenuClose();
-  };
-
   const handleConfirmDelete = async () => {
-    if (!confirmDeleteId) return;
-    await deleteMap(confirmDeleteId);
-    setConfirmDeleteId(null);
+    if (!confirmDelete) return;
+    setDeleting(true);
+    await deleteMap(confirmDelete.id);
+    setDeleting(false);
+    setConfirmDelete(null);
   };
 
   const showSkeleton = isLoading && maps.length === 0;
 
   return (
-    <Page>
-      <PageContent sx={{ mt: 0 }}>
-        <LocationsHeader maps={maps} />
-        <Grid container spacing={2}>
-          <Grid item xs={12} sm={6} md={4} lg={3}>
-            <DashboardCreateProjectCard
-              onClick={() => setCreateOpen(true)}
-              label="New Map"
-              description="Create a new campus map"
-            />
-          </Grid>
-          {showSkeleton
-            ? Array.from({ length: 3 }).map((_, i) => (
-                <Grid item xs={12} sm={6} md={4} lg={3} key={`skeleton-${i}`}>
-                  <Skeleton variant="rounded" height={260} />
-                </Grid>
-              ))
-            : maps.map((map) => (
-                <Grid item xs={12} sm={6} md={4} lg={3} key={map.id}>
-                  <DashboardProjectCard
-                    project={{
-                      id: map.id,
-                      title: map.name,
-                      updatedAt: map.updatedAt,
-                      createdAt: map.createdAt,
-                      thumbnail: map.thumbnail ?? undefined,
-                    }}
-                    onGoToBuilder={(id) => router.push(`/org/${orgId}/maps/${id}`)}
-                    onMenuOpen={handleMenuOpen}
-                  />
-                </Grid>
-              ))}
-        </Grid>
-      </PageContent>
+    <div className="w-full space-y-8 px-6 py-8 md:px-10">
+      <LocationsHeader maps={maps} />
 
-      <DashboardOptionsMenu
-        anchorEl={menuAnchor}
-        open={Boolean(menuAnchor)}
-        onClose={handleMenuClose}
-        onEdit={() => {
-          if (menuMapId) router.push(`/org/${orgId}/maps/${menuMapId}`);
-          handleMenuClose();
-        }}
-        onDelete={handleRequestDelete}
-      />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <button
+          type="button"
+          onClick={() => setCreateOpen(true)}
+          className="group flex min-h-[208px] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-line-strong bg-surface-1 text-text-secondary transition-colors hover:border-accent hover:text-accent"
+        >
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent">
+            <AddIcon fontSize="small" />
+          </span>
+          <span className="text-sm font-medium">New map</span>
+          <span className="text-xs text-text-tertiary">
+            Create a new campus map
+          </span>
+        </button>
 
-      <DashboardDeleteConfirmationDialog
-        open={Boolean(confirmDeleteId)}
-        onCancel={() => setConfirmDeleteId(null)}
-        onConfirm={handleConfirmDelete}
-        title="Delete map?"
-        message="This map and all its POIs will be permanently removed. This cannot be undone."
-      />
+        {showSkeleton
+          ? [0, 1, 2].map((i) => (
+              <div
+                key={i}
+                className="h-[208px] animate-pulse rounded-2xl bg-surface-2"
+              />
+            ))
+          : maps.map((map) => (
+              <CampusCard
+                key={map.id}
+                name={map.name}
+                updatedAt={map.updatedAt}
+                thumbnail={map.thumbnail ?? undefined}
+                href={`/org/${orgId}/maps/${map.id}`}
+                onEdit={() => router.push(`/org/${orgId}/maps/${map.id}`)}
+                onDelete={() =>
+                  setConfirmDelete({ id: map.id, name: map.name })
+                }
+              />
+            ))}
+      </div>
 
-      <RightDrawer
+      <Modal
         open={createOpen}
         onClose={closeCreate}
-        title="New Campus Map"
-        actions={
+        title="New campus map"
+        footer={
           <>
             <Button
-              variant="outlined"
+              variant="secondary"
               onClick={closeCreate}
               disabled={creating}
-              fullWidth
-              sx={{ textTransform: "none" }}
             >
               Cancel
             </Button>
             <Button
-              variant="contained"
               onClick={handleCreate}
               disabled={!newName.trim() || creating}
-              fullWidth
-              sx={{ textTransform: "none" }}
             >
               {creating ? "Creating…" : "Create map"}
             </Button>
           </>
         }
       >
-        <FormField label="Map name" gutterBottom>
-          <TextField
+        <Field label="Map name">
+          <Input
             autoFocus
-            fullWidth
-            size="small"
             placeholder="e.g. Main Campus"
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleCreate()}
           />
-        </FormField>
-      </RightDrawer>
-    </Page>
+        </Field>
+      </Modal>
+
+      <Modal
+        open={confirmDelete !== null}
+        onClose={() => !deleting && setConfirmDelete(null)}
+        title="Delete map?"
+        description={`"${confirmDelete?.name ?? ""}" and all its POIs will be permanently removed. This cannot be undone.`}
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => setConfirmDelete(null)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Deleting…" : "Delete map"}
+            </Button>
+          </>
+        }
+      />
+    </div>
+  );
+}
+
+function CampusCard({
+  name,
+  updatedAt,
+  thumbnail,
+  href,
+  onEdit,
+  onDelete,
+}: {
+  name: string;
+  updatedAt: string | number | Date;
+  thumbnail?: string;
+  href: string;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const updated = new Date(updatedAt).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return (
+    <div className="group relative">
+      <Link href={href} className="block">
+        <Panel className="overflow-hidden rounded-2xl transition-colors duration-200 group-hover:border-line-strong">
+          <div className="aspect-video bg-surface-2">
+            {thumbnail ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={thumbnail}
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            ) : null}
+          </div>
+          <div className="p-4">
+            <div className="truncate font-medium text-text-primary">{name}</div>
+            <div className="mt-1 text-xs text-text-tertiary">
+              Updated {updated}
+            </div>
+          </div>
+        </Panel>
+      </Link>
+      <div className="absolute right-2 top-2">
+        <Menu
+          trigger={
+            <IconButton
+              variant="secondary"
+              size="sm"
+              aria-label="Map options"
+              className="bg-surface-1"
+            >
+              <MoreVertIcon fontSize="small" />
+            </IconButton>
+          }
+        >
+          <MenuItem onClick={onEdit}>Edit</MenuItem>
+          <MenuItem tone="danger" onClick={onDelete}>
+            Delete
+          </MenuItem>
+        </Menu>
+      </div>
+    </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
@@ -1,19 +1,9 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
 import useSWR from "swr";
-import {
-  Box,
-  Button,
-  Chip,
-  Tab,
-  Tabs,
-  Typography,
-} from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
-import { Page, PageContent } from "@klorad/ui";
-import { Skeleton } from "@mui/material";
+import { Badge, Button, cn } from "@klorad/design-system";
 import OverviewTab from "./tabs/OverviewTab";
 import SettingsTab from "./tabs/SettingsTab";
 import IntegrationsTab from "./tabs/IntegrationsTab";
@@ -48,9 +38,14 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const tabParam = searchParams.get("tab") as TabKey | null;
-  const activeTab: TabKey = TABS.some((t) => t.key === tabParam) ? (tabParam as TabKey) : "overview";
+  const activeTab: TabKey = TABS.some((t) => t.key === tabParam)
+    ? (tabParam as TabKey)
+    : "overview";
 
-  const { data: map, isLoading } = useSWR<CampusMap>(`/api/maps/${mapId}`, fetcher);
+  const { data: map, isLoading } = useSWR<CampusMap>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
 
   const setTab = (key: TabKey) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -62,78 +57,66 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
 
   if (!map && isLoading) {
     return (
-      <Page>
-        <PageContent sx={{ mt: 0 }}>
-          <Skeleton variant="rounded" height={48} sx={{ mb: 2 }} />
-          <Skeleton variant="rounded" height={320} />
-        </PageContent>
-      </Page>
+      <div className="w-full space-y-3 px-6 py-8 md:px-10">
+        <div className="h-12 animate-pulse rounded-xl bg-surface-2" />
+        <div className="h-80 animate-pulse rounded-xl bg-surface-2" />
+      </div>
     );
   }
+
   if (!map) {
     return (
-      <Page>
-        <PageContent sx={{ mt: 0 }}>
-          <Typography color="error">Map not found.</Typography>
-        </PageContent>
-      </Page>
+      <div className="w-full px-6 py-8 md:px-10">
+        <p className="text-sm text-red-600">Map not found.</p>
+      </div>
     );
   }
 
   return (
-    <Page>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mt: 2, mb: 3 }}>
-        <Chip
-          label="Live"
-          size="small"
-          sx={{
-            height: 24,
-            fontSize: "0.75rem",
-            fontWeight: 600,
-            bgcolor: (th) => th.palette.success.main + "22",
-            color: "success.main",
-            "& .MuiChip-label": { px: 1.25 },
-          }}
-        />
-        <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+    <div className="w-full px-6 py-8 md:px-10">
+      <div className="flex items-center gap-3">
+        <Badge tone="success">Live</Badge>
+        <span className="flex-1 text-sm text-text-secondary">
           Last updated {new Date(map.updatedAt).toLocaleDateString()}
-        </Typography>
+        </span>
         <Button
-          variant="contained"
-          startIcon={<EditIcon />}
-          component={Link}
-          href={`/org/${orgId}/maps/${mapId}/builder`}
-          sx={{ textTransform: "none" }}
+          onClick={() => router.push(`/org/${orgId}/maps/${mapId}/builder`)}
         >
+          <EditIcon fontSize="small" />
           Enter Studio
         </Button>
-      </Box>
+      </div>
 
-      <Tabs
-        value={activeTab}
-        onChange={(_e, v) => setTab(v)}
-        sx={{
-          borderBottom: "1px solid",
-          borderColor: "divider",
-          "& .MuiTab-root": {
-            fontSize: "0.875rem",
-            textTransform: "none",
-            fontWeight: 500,
-            minHeight: 44,
-          },
-          "& .Mui-selected": { color: "primary.main" },
-        }}
-      >
+      <div className="mt-6 flex gap-1 border-b border-line-soft">
         {TABS.map((t) => (
-          <Tab key={t.key} value={t.key} label={t.label} />
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            className={cn(
+              "relative px-3 py-2.5 text-sm font-medium transition-colors",
+              activeTab === t.key
+                ? "text-text-primary"
+                : "text-text-secondary hover:text-text-primary",
+            )}
+          >
+            {t.label}
+            {activeTab === t.key && (
+              <span className="absolute inset-x-0 -bottom-px h-0.5 rounded-full bg-accent" />
+            )}
+          </button>
         ))}
-      </Tabs>
+      </div>
 
-      <PageContent>
-        {activeTab === "overview" && <OverviewTab orgId={orgId} mapId={mapId} map={map} />}
-        {activeTab === "settings" && <SettingsTab orgId={orgId} mapId={mapId} map={map} />}
+      <div className="pt-2">
+        {activeTab === "overview" && (
+          <OverviewTab orgId={orgId} mapId={mapId} map={map} />
+        )}
+        {activeTab === "settings" && (
+          <SettingsTab orgId={orgId} mapId={mapId} map={map} />
+        )}
         {activeTab === "integrations" && <IntegrationsTab />}
-      </PageContent>
-    </Page>
+      </div>
+    </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IntegrationsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IntegrationsTab.tsx
@@ -1,18 +1,17 @@
 "use client";
 
-import { Box, Button, Chip, Stack, Typography } from "@mui/material";
-import { alpha } from "@mui/material/styles";
+import type { ReactNode } from "react";
 import EventIcon from "@mui/icons-material/Event";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import RssFeedIcon from "@mui/icons-material/RssFeed";
 import FacebookIcon from "@mui/icons-material/Facebook";
-import { PageCard, PageSection } from "@klorad/ui";
+import { Badge, Button, Panel } from "@klorad/design-system";
 
 interface Integration {
   id: string;
   name: string;
   description: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   status: "available" | "deferred";
 }
 
@@ -20,28 +19,32 @@ const INTEGRATIONS: Integration[] = [
   {
     id: "google",
     name: "Google Calendar",
-    description: "Sync events from any Google Calendar. Attach calendars to POIs so events appear at the right building.",
+    description:
+      "Sync events from any Google Calendar. Attach calendars to POIs so events appear at the right building.",
     icon: <CalendarMonthIcon />,
     status: "available",
   },
   {
     id: "outlook",
     name: "Outlook / Microsoft 365",
-    description: "Pull events from your institution's Exchange or Microsoft 365 tenant.",
+    description:
+      "Pull events from your institution's Exchange or Microsoft 365 tenant.",
     icon: <EventIcon />,
     status: "available",
   },
   {
     id: "ics",
     name: "ICS feeds",
-    description: "Subscribe to any public ICS URL. Universal fallback for calendars that don't expose a formal API.",
+    description:
+      "Subscribe to any public ICS URL. Universal fallback for calendars that don't expose a formal API.",
     icon: <RssFeedIcon />,
     status: "available",
   },
   {
     id: "facebook",
     name: "Facebook Events",
-    description: "Surface your page's public events on the map. Coming in a later phase.",
+    description:
+      "Surface your page's public events on the map. Coming in a later phase.",
     icon: <FacebookIcon />,
     status: "deferred",
   },
@@ -49,53 +52,33 @@ const INTEGRATIONS: Integration[] = [
 
 export default function IntegrationsTab() {
   return (
-    <Stack spacing={4} sx={{ mt: 3 }}>
-      <PageSection title="Event feeds" spacing="tight">
-        <Stack spacing={2}>
-          {INTEGRATIONS.map((int) => (
-            <PageCard key={int.id}>
-              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-                <Box
-                  sx={(t) => ({
-                    width: 44,
-                    height: 44,
-                    borderRadius: 1,
-                    bgcolor: alpha(t.palette.primary.main, 0.12),
-                    color: "primary.main",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    flexShrink: 0,
-                  })}
-                >
-                  {int.icon}
-                </Box>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
-                    <Typography variant="subtitle2" fontWeight={700}>
-                      {int.name}
-                    </Typography>
-                    {int.status === "deferred" && (
-                      <Chip label="Later" size="small" sx={{ height: 18, fontSize: "0.65rem" }} />
-                    )}
-                  </Box>
-                  <Typography variant="body2" color="text.secondary">
-                    {int.description}
-                  </Typography>
-                </Box>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  disabled
-                  sx={{ textTransform: "none", flexShrink: 0 }}
-                >
-                  {int.status === "deferred" ? "Not yet" : "Connect"}
-                </Button>
-              </Box>
-            </PageCard>
-          ))}
-        </Stack>
-      </PageSection>
-    </Stack>
+    <div className="space-y-4 pt-6">
+      <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+        Event feeds
+      </h2>
+      <div className="space-y-3">
+        {INTEGRATIONS.map((int) => (
+          <Panel key={int.id} className="flex items-center gap-4 rounded-2xl p-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              {int.icon}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-text-primary">
+                  {int.name}
+                </span>
+                {int.status === "deferred" && <Badge>Later</Badge>}
+              </div>
+              <p className="mt-0.5 text-sm text-text-secondary">
+                {int.description}
+              </p>
+            </div>
+            <Button variant="secondary" size="sm" disabled className="shrink-0">
+              {int.status === "deferred" ? "Not yet" : "Connect"}
+            </Button>
+          </Panel>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/OverviewTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/OverviewTab.tsx
@@ -1,19 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
-import Link from "next/link";
-import {
-  Box,
-  Button,
-  Stack,
-  Typography,
-} from "@mui/material";
-import { alpha } from "@mui/material/styles";
+import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
 import PlaceIcon from "@mui/icons-material/Place";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import SearchIcon from "@mui/icons-material/Search";
 import AccessibleIcon from "@mui/icons-material/Accessible";
-import { MetricCard, PageCard, PageSection } from "@klorad/ui";
+import { Button, Panel } from "@klorad/design-system";
 
 interface Props {
   orgId: string;
@@ -39,19 +33,28 @@ interface Poi {
 }
 
 export default function OverviewTab({ orgId, mapId, map }: Props) {
+  const router = useRouter();
+  const studioHref = `/org/${orgId}/maps/${mapId}/builder`;
+
   // Derive simple stats from the scene data — no analytics backend yet.
   const stats = useMemo(() => {
     const scene = map.sceneData as
-      | { objects?: Poi[]; mapboxScene?: { center?: [number, number] }; center?: [number, number] }
+      | {
+          objects?: Poi[];
+          mapboxScene?: { center?: [number, number] };
+          center?: [number, number];
+        }
       | undefined;
     const objects = scene?.objects ?? [];
     const pois = objects.filter((o) => o?.meta?.poi);
     const accessible = pois.filter(
-      (p) => p?.meta?.poi?.accessibility?.wheelchairAccessible
+      (p) => p?.meta?.poi?.accessibility?.wheelchairAccessible,
     );
     const linked = pois.filter((p) => p?.meta?.poi?.linkedBuilding);
     const complianceScore =
-      pois.length > 0 ? Math.round((accessible.length / pois.length) * 100) : 0;
+      pois.length > 0
+        ? Math.round((accessible.length / pois.length) * 100)
+        : 0;
     const rawCenter = scene?.mapboxScene?.center ?? scene?.center ?? null;
     const center =
       Array.isArray(rawCenter) &&
@@ -71,225 +74,156 @@ export default function OverviewTab({ orgId, mapId, map }: Props) {
   }, [map.sceneData]);
 
   return (
-    <Stack spacing={4} sx={{ mt: 3 }}>
-      {/* Top row: thumbnail (left) + 2×2 KPI grid (right). Collapses to a
-          single column below md. */}
-      <Box
-        sx={{
-          display: "grid",
-          gap: 2,
-          gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
-          alignItems: "stretch",
-        }}
-      >
-        <Box
-          sx={(t) => ({
-            position: "relative",
-            borderRadius: 1,
-            overflow: "hidden",
-            border: `1px solid ${t.palette.divider}`,
-            bgcolor: alpha(t.palette.primary.main, 0.04),
-            aspectRatio: "16 / 10",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          })}
-        >
+    <div className="space-y-8 pt-6">
+      {/* Thumbnail (left) + 2×2 KPI grid (right). */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="relative flex aspect-[16/10] items-center justify-center overflow-hidden rounded-2xl border border-line-soft bg-accent-soft">
           {map.thumbnail ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={map.thumbnail}
               alt={map.name}
-              style={{
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                display: "block",
-              }}
+              className="h-full w-full object-cover"
             />
           ) : (
-            <Stack alignItems="center" spacing={1} sx={{ textAlign: "center", p: 3 }}>
-              <PlaceIcon sx={{ fontSize: 48, color: "primary.main", opacity: 0.5 }} />
-              <Typography variant="body2" color="text.secondary">
+            <div className="flex flex-col items-center gap-2 p-6 text-center">
+              <PlaceIcon
+                sx={{ fontSize: 48 }}
+                className="text-accent opacity-50"
+              />
+              <p className="text-sm text-text-secondary">
                 No thumbnail yet — capture one from the Studio Location tab.
-              </Typography>
-            </Stack>
+              </p>
+            </div>
           )}
-          <Box
-            sx={{
-              position: "absolute",
-              left: 0,
-              right: 0,
-              bottom: 0,
-              px: 2,
-              py: 1.5,
-              background:
-                "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.75) 100%)",
-              color: "#fff",
-              display: "flex",
-              alignItems: "flex-end",
-              justifyContent: "space-between",
-              gap: 2,
-            }}
-          >
-            <Box sx={{ minWidth: 0 }}>
-              <Typography
-                variant="subtitle1"
-                sx={{
-                  fontWeight: 700,
-                  lineHeight: 1.2,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
+          <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-3 bg-gradient-to-t from-black/75 to-transparent px-4 py-3 text-white">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold leading-tight">
                 {map.name}
-              </Typography>
+              </div>
               {stats.center && (
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: "rgba(255,255,255,0.75)",
-                    fontSize: "0.7rem",
-                    fontFamily: "monospace",
-                    letterSpacing: "0.02em",
-                  }}
-                >
+                <div className="font-mono text-[0.7rem] tracking-wide text-white/75">
                   {stats.center[0].toFixed(3)}°, {stats.center[1].toFixed(3)}°
-                </Typography>
+                </div>
               )}
-            </Box>
-            <Typography
-              variant="caption"
-              sx={{
-                color: "rgba(255,255,255,0.85)",
-                fontSize: "0.7rem",
-                fontWeight: 600,
-                letterSpacing: "0.08em",
-                textTransform: "uppercase",
-                flexShrink: 0,
-              }}
-            >
+            </div>
+            <div className="shrink-0 text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-white/85">
               {stats.poiCount} {stats.poiCount === 1 ? "POI" : "POIs"}
-            </Typography>
-          </Box>
-        </Box>
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: "repeat(2, 1fr)",
-            gridAutoRows: "1fr",
-          }}
-        >
-          <MetricCard
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <StatCard
             icon={<PlaceIcon fontSize="small" />}
             value={stats.poiCount}
             label="Points of interest"
           />
-          <MetricCard
+          <StatCard
             icon={<VisibilityIcon fontSize="small" />}
             value="—"
             label="Views this month"
           />
-          <MetricCard
+          <StatCard
             icon={<SearchIcon fontSize="small" />}
             value="—"
             label="Top searches"
           />
-          <MetricCard
+          <StatCard
             icon={<AccessibleIcon fontSize="small" />}
             value={`${stats.complianceScore}%`}
             label="Accessibility coverage"
           />
-        </Box>
-      </Box>
+        </div>
+      </div>
 
       {/* Enter Studio CTA */}
-      <PageCard>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 3 }}>
-          <Box sx={{ flex: 1 }}>
-            <Typography variant="h6" fontWeight={700} gutterBottom>
+      <Panel className="rounded-2xl p-6">
+        <div className="flex items-center gap-6">
+          <div className="flex-1">
+            <h3 className="text-base font-semibold text-text-primary">
               Edit your campus map
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            </h3>
+            <p className="mt-1 text-sm text-text-secondary">
               Open the Studio to add points of interest, link buildings, set the
               map location, and toggle environment layers.
-            </Typography>
-            <Button
-              variant="contained"
-              component={Link}
-              href={`/org/${orgId}/maps/${mapId}/builder`}
-              sx={{ textTransform: "none" }}
-            >
+            </p>
+            <Button className="mt-4" onClick={() => router.push(studioHref)}>
               Enter Studio
             </Button>
-          </Box>
-          <Box
-            sx={(t) => ({
-              width: 160,
-              height: 96,
-              borderRadius: 1,
-              bgcolor: alpha(t.palette.primary.main, 0.08),
-              border: "1px solid",
-              borderColor: "divider",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-            })}
-          >
-            <PlaceIcon sx={{ fontSize: 48, color: "primary.main", opacity: 0.5 }} />
-          </Box>
-        </Box>
-      </PageCard>
+          </div>
+          <div className="hidden h-24 w-40 shrink-0 items-center justify-center rounded-xl border border-line-soft bg-accent-soft sm:flex">
+            <PlaceIcon
+              sx={{ fontSize: 48 }}
+              className="text-accent opacity-50"
+            />
+          </div>
+        </div>
+      </Panel>
 
-      <PageSection title="Coverage breakdown" spacing="tight">
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
-          }}
-        >
-          <PageCard>
-            <Typography variant="overline" color="text.secondary" sx={{ fontSize: "0.7rem", letterSpacing: "0.08em" }}>
-              POIs with linked buildings
-            </Typography>
-            <Typography variant="h4" fontWeight={700} sx={{ mt: 1 }}>
-              {stats.linkedCount} / {stats.poiCount}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              Pins anchored to an actual building footprint feel more
-              authoritative on the public viewer.
-            </Typography>
-          </PageCard>
-          <PageCard>
-            <Typography variant="overline" color="text.secondary" sx={{ fontSize: "0.7rem", letterSpacing: "0.08em" }}>
-              Accessibility-tagged
-            </Typography>
-            <Typography variant="h4" fontWeight={700} sx={{ mt: 1 }}>
-              {stats.accessibleCount} / {stats.poiCount}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              The European Accessibility Act (2019/882) requires public-sector
-              sites to publish this. Fill it in.
-            </Typography>
-          </PageCard>
-          <PageCard>
-            <Typography variant="overline" color="text.secondary" sx={{ fontSize: "0.7rem", letterSpacing: "0.08em" }}>
-              Analytics
-            </Typography>
-            <Typography variant="h4" fontWeight={700} sx={{ mt: 1 }}>
-              Coming soon
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              Views, top searches, and wayfinding pain points will appear
-              here once the map is live.
-            </Typography>
-          </PageCard>
-        </Box>
-      </PageSection>
-    </Stack>
+      {/* Coverage breakdown */}
+      <section className="space-y-4">
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          Coverage breakdown
+        </h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          <CoverageCard
+            overline="POIs with linked buildings"
+            value={`${stats.linkedCount} / ${stats.poiCount}`}
+            caption="Pins anchored to an actual building footprint feel more authoritative on the public viewer."
+          />
+          <CoverageCard
+            overline="Accessibility-tagged"
+            value={`${stats.accessibleCount} / ${stats.poiCount}`}
+            caption="The European Accessibility Act (2019/882) requires public-sector sites to publish this. Fill it in."
+          />
+          <CoverageCard
+            overline="Analytics"
+            value="Coming soon"
+            caption="Views, top searches, and wayfinding pain points will appear here once the map is live."
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  value,
+  label,
+}: {
+  icon: ReactNode;
+  value: ReactNode;
+  label: string;
+}) {
+  return (
+    <Panel className="rounded-2xl p-5">
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
+        {icon}
+      </div>
+      <div className="mt-4 text-2xl font-light text-text-primary">{value}</div>
+      <div className="mt-0.5 text-sm text-text-secondary">{label}</div>
+    </Panel>
+  );
+}
+
+function CoverageCard({
+  overline,
+  value,
+  caption,
+}: {
+  overline: string;
+  value: string;
+  caption: string;
+}) {
+  return (
+    <Panel className="rounded-2xl p-5">
+      <div className="text-[0.7rem] font-medium uppercase tracking-[0.08em] text-text-tertiary">
+        {overline}
+      </div>
+      <div className="mt-1 text-3xl font-light text-text-primary">{value}</div>
+      <p className="mt-1.5 text-xs text-text-secondary">{caption}</p>
+    </Panel>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
@@ -1,20 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
+import type { ReactNode } from "react";
 import useSWR, { mutate } from "swr";
-import {
-  Button,
-  IconButton,
-  InputAdornment,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { toast } from "react-toastify";
-import { PageCard, PageSection, TextField, FormField } from "@klorad/ui";
+import { Button, Field, IconButton, Input, Panel, Textarea } from "@klorad/design-system";
 import type { Branding, SceneData } from "@klorad/api";
 
 interface Props {
@@ -53,7 +45,8 @@ export default function SettingsTab({ orgId: _orgId, mapId, map }: Props) {
   const [savingBrand, setSavingBrand] = useState(false);
 
   useEffect(() => {
-    if (serverMap?.sceneData?.branding) setBranding(serverMap.sceneData.branding);
+    if (serverMap?.sceneData?.branding)
+      setBranding(serverMap.sceneData.branding);
   }, [serverMap]);
 
   const handleSaveBranding = async () => {
@@ -79,194 +72,173 @@ export default function SettingsTab({ orgId: _orgId, mapId, map }: Props) {
   };
 
   return (
-    <Stack spacing={4} sx={{ mt: 3 }}>
-      <PageSection title="General" spacing="tight">
-        <PageCard>
-          <Stack spacing={2}>
-            <FormField label="Campus name">
-              <TextField fullWidth size="small" defaultValue={map.name} />
-            </FormField>
-            <Typography variant="caption" color="text.secondary">
-              Name changes save automatically (not yet wired — placeholder).
-            </Typography>
-          </Stack>
-        </PageCard>
-      </PageSection>
+    <div className="space-y-8 pt-6">
+      <Section title="General">
+        <Panel className="rounded-2xl p-6">
+          <Field label="Campus name">
+            <Input defaultValue={map.name} />
+          </Field>
+          <p className="mt-2 text-xs text-text-tertiary">
+            Name changes save automatically (not yet wired — placeholder).
+          </p>
+        </Panel>
+      </Section>
 
-      <PageSection title="Branding" spacing="tight">
-        <PageCard>
-          <Stack spacing={2}>
-            <FormField
-              label="Public display name"
-              helperText="Overrides the campus name in the public viewer header. Leave blank to use the campus name above."
-            >
-              <TextField
-                fullWidth
-                size="small"
-                placeholder={map.name}
-                value={branding.name ?? ""}
-                onChange={(e) => setBranding((b) => ({ ...b, name: e.target.value }))}
+      <Section title="Branding">
+        <Panel className="space-y-5 rounded-2xl p-6">
+          <Field
+            label="Public display name"
+            hint="Overrides the campus name in the public viewer header. Leave blank to use the campus name above."
+          >
+            <Input
+              placeholder={map.name}
+              value={branding.name ?? ""}
+              onChange={(e) =>
+                setBranding((b) => ({ ...b, name: e.target.value }))
+              }
+            />
+          </Field>
+          <Field
+            label="Logo URL"
+            hint="Paste a public URL to your university's logo (SVG or PNG, roughly 240×60). Shown top-left on the public viewer."
+          >
+            <Input
+              placeholder="https://…/logo.svg"
+              value={branding.logo ?? ""}
+              onChange={(e) =>
+                setBranding((b) => ({ ...b, logo: e.target.value }))
+              }
+            />
+          </Field>
+          <Field
+            label="Primary color"
+            hint="Hex code (e.g. #6B9CD8). Recolors pins, routes, buttons, and highlights on the public viewer."
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                className="max-w-[180px]"
+                placeholder="#6B9CD8"
+                value={branding.primaryColor ?? ""}
+                onChange={(e) =>
+                  setBranding((b) => ({ ...b, primaryColor: e.target.value }))
+                }
               />
-            </FormField>
-            <FormField
-              label="Logo URL"
-              helperText="Paste a public URL to your university's logo (SVG or PNG, roughly 240×60). Shown top-left on the public viewer."
-            >
-              <TextField
-                fullWidth
-                size="small"
-                placeholder="https://…/logo.svg"
-                value={branding.logo ?? ""}
-                onChange={(e) => setBranding((b) => ({ ...b, logo: e.target.value }))}
-              />
-            </FormField>
-            <FormField
-              label="Primary color"
-              helperText="Hex code (e.g. #6B9CD8). Recolors pins, routes, buttons, and highlights on the public viewer."
-            >
-              <Stack direction="row" spacing={1} alignItems="center">
-                <TextField
-                  size="small"
-                  placeholder="#6B9CD8"
-                  sx={{ maxWidth: 180 }}
-                  value={branding.primaryColor ?? ""}
-                  onChange={(e) =>
-                    setBranding((b) => ({ ...b, primaryColor: e.target.value }))
-                  }
+              {branding.primaryColor && (
+                <span
+                  className="h-9 w-9 shrink-0 rounded-md border border-line-soft"
+                  style={{ backgroundColor: branding.primaryColor }}
                 />
-                {branding.primaryColor && (
-                  <div
-                    style={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: 4,
-                      backgroundColor: branding.primaryColor,
-                      border: "1px solid rgba(255,255,255,0.12)",
-                    }}
-                  />
-                )}
-              </Stack>
-            </FormField>
-
-            {branding.logo && (
-              <div>
-                <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.75 }}>
-                  Logo preview
-                </Typography>
-                <div
-                  style={{
-                    padding: "16px 20px",
-                    borderRadius: 4,
-                    border: "1px solid rgba(255,255,255,0.12)",
-                    background: "rgba(0,0,0,0.25)",
-                    display: "flex",
-                    alignItems: "center",
-                    width: "fit-content",
-                  }}
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={branding.logo}
-                    alt="Logo preview"
-                    style={{ maxHeight: 40, maxWidth: 280, display: "block" }}
-                  />
-                </div>
-              </div>
-            )}
-
-            <div>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={handleSaveBranding}
-                disabled={savingBrand}
-                sx={{ textTransform: "none" }}
-              >
-                {savingBrand ? "Saving…" : "Save branding"}
-              </Button>
+              )}
             </div>
-          </Stack>
-        </PageCard>
-      </PageSection>
+          </Field>
 
-      <PageSection title="Sharing" spacing="tight">
-        <PageCard>
-          <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-            Public Link
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {branding.logo && (
+            <div>
+              <div className="mb-1.5 text-xs text-text-tertiary">
+                Logo preview
+              </div>
+              <div className="inline-flex items-center rounded-lg border border-line-soft bg-surface-2 px-5 py-4">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={branding.logo}
+                  alt="Logo preview"
+                  style={{ maxHeight: 40, maxWidth: 280, display: "block" }}
+                />
+              </div>
+            </div>
+          )}
+
+          <Button size="sm" onClick={handleSaveBranding} disabled={savingBrand}>
+            {savingBrand ? "Saving…" : "Save branding"}
+          </Button>
+        </Panel>
+      </Section>
+
+      <Section title="Sharing">
+        <Panel className="rounded-2xl p-6">
+          <h3 className="text-sm font-semibold text-text-primary">
+            Public link
+          </h3>
+          <p className="mt-1 text-sm text-text-secondary">
             Share this link to let anyone view the interactive campus map.
-          </Typography>
-          <TextField
-            fullWidth
-            size="small"
-            value={publicUrl}
-            slotProps={{
-              input: {
-                readOnly: true,
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip title="Copy link">
-                      <IconButton size="small" onClick={() => copy(publicUrl, "url")}>
-                        <ContentCopyIcon
-                          fontSize="small"
-                          sx={{ color: copied === "url" ? "success.main" : undefined }}
-                        />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Open in new tab">
-                      <IconButton size="small" component={Link} href={publicUrl} target="_blank">
-                        <OpenInNewIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              },
-            }}
-          />
-        </PageCard>
-      </PageSection>
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <Input readOnly value={publicUrl} className="flex-1" />
+            <IconButton
+              variant="secondary"
+              aria-label="Copy link"
+              title="Copy link"
+              onClick={() => copy(publicUrl, "url")}
+            >
+              <ContentCopyIcon
+                fontSize="small"
+                className={copied === "url" ? "text-emerald-500" : undefined}
+              />
+            </IconButton>
+            <a
+              href={publicUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open in new tab"
+              title="Open in new tab"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-line-strong text-text-primary transition-colors hover:border-accent hover:text-accent"
+            >
+              <OpenInNewIcon fontSize="small" />
+            </a>
+          </div>
+        </Panel>
+      </Section>
 
-      <PageSection title="Embed" spacing="tight">
-        <PageCard>
-          <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-            Embed Code
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+      <Section title="Embed">
+        <Panel className="rounded-2xl p-6">
+          <h3 className="text-sm font-semibold text-text-primary">
+            Embed code
+          </h3>
+          <p className="mt-1 text-sm text-text-secondary">
             Paste this snippet into any webpage to embed the campus map.
-          </Typography>
-          <TextField
-            fullWidth
-            size="small"
-            multiline
+          </p>
+          <Textarea
+            readOnly
             rows={3}
             value={embedCode}
-            slotProps={{
-              input: {
-                readOnly: true,
-                style: { fontFamily: "monospace", fontSize: "0.8125rem" },
-              },
-            }}
+            className="mt-3 font-mono text-xs"
           />
           <Button
-            size="small"
-            variant="outlined"
-            startIcon={<ContentCopyIcon />}
+            variant="secondary"
+            size="sm"
+            className="mt-3"
             onClick={() => copy(embedCode, "embed")}
-            sx={{ mt: 1.5, textTransform: "none" }}
           >
+            <ContentCopyIcon fontSize="small" />
             {copied === "embed" ? "Copied!" : "Copy embed code"}
           </Button>
-        </PageCard>
-      </PageSection>
+        </Panel>
+      </Section>
 
-      <PageSection title="Members" spacing="tight">
-        <PageCard>
-          <Typography variant="body2" color="text.secondary">
+      <Section title="Members">
+        <Panel className="rounded-2xl p-6">
+          <p className="text-sm text-text-secondary">
             Invite teammates as Admin, Editor, or Viewer. Coming next.
-          </Typography>
-        </PageCard>
-      </PageSection>
-    </Stack>
+          </p>
+        </Panel>
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+        {title}
+      </h2>
+      {children}
+    </section>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/profile/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/profile/page.tsx
@@ -1,7 +1,6 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { Page, PageCard, PageContent, PageSection } from "@klorad/ui";
-import { Avatar, Box, Stack, Typography } from "@mui/material";
+import { Panel } from "@klorad/design-system";
 
 export default async function ProfilePage() {
   const session = await auth();
@@ -11,34 +10,44 @@ export default async function ProfilePage() {
   const initial = (name?.charAt(0) || email?.charAt(0) || "U").toUpperCase();
 
   return (
-    <Page>
-      <PageContent sx={{ mt: 0 }}>
-        <PageSection title="Account" spacing="tight">
-          <PageCard>
-            <Stack direction="row" spacing={2} alignItems="center">
-              <Avatar src={image ?? undefined} sx={{ width: 64, height: 64 }}>
-                {initial}
-              </Avatar>
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography variant="h6" fontWeight={700}>
-                  {name ?? "User"}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {email}
-                </Typography>
-              </Box>
-            </Stack>
-          </PageCard>
-        </PageSection>
-        <PageSection title="Preferences" spacing="tight">
-          <PageCard>
-            <Typography variant="body2" color="text.secondary">
-              Language, default locale, and notification preferences will
-              appear here.
-            </Typography>
-          </PageCard>
-        </PageSection>
-      </PageContent>
-    </Page>
+    <div className="w-full space-y-10 px-6 py-8 md:px-10">
+      <section className="space-y-4">
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          Account
+        </h2>
+        <Panel className="flex items-center gap-4 rounded-2xl p-5">
+          {image ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={image}
+              alt=""
+              className="h-16 w-16 shrink-0 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent-soft text-xl font-semibold text-accent">
+              {initial}
+            </div>
+          )}
+          <div className="min-w-0">
+            <div className="truncate text-lg font-semibold text-text-primary">
+              {name ?? "User"}
+            </div>
+            <div className="truncate text-sm text-text-secondary">{email}</div>
+          </div>
+        </Panel>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          Preferences
+        </h2>
+        <Panel className="rounded-2xl p-5">
+          <p className="text-sm text-text-secondary">
+            Language, default locale, and notification preferences will appear
+            here.
+          </p>
+        </Panel>
+      </section>
+    </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/general/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/general/page.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams } from "next/navigation";
-import { Button, Field, Input, Panel, cn } from "@klorad/design-system";
+import { Button, Field, Input, Panel, Spinner, cn } from "@klorad/design-system";
 import { showToast } from "@klorad/ui";
 import { useOrganization } from "@/app/hooks/useOrganizations";
 
@@ -177,15 +177,6 @@ export default function SettingsGeneralPage() {
         </div>
       </Panel>
     </div>
-  );
-}
-
-function Spinner() {
-  return (
-    <div
-      className="h-6 w-6 animate-spin rounded-full border-2 border-line-strong border-t-accent"
-      aria-label="Loading"
-    />
   );
 }
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/general/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/general/page.tsx
@@ -1,22 +1,10 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import { useParams } from "next/navigation";
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Typography,
-} from "@mui/material";
-import {
-  Page,
-  PageCard,
-  PageContent,
-  PageSection,
-  TextField,
-  showToast,
-} from "@klorad/ui";
+import { Button, Field, Input, Panel, cn } from "@klorad/design-system";
+import { showToast } from "@klorad/ui";
 import { useOrganization } from "@/app/hooks/useOrganizations";
 
 export default function SettingsGeneralPage() {
@@ -37,7 +25,6 @@ export default function SettingsGeneralPage() {
     }
   }, [organization]);
 
-  const loading = loadingOrganization;
   const error = orgError ? "Failed to load organization data" : null;
 
   const handleChange =
@@ -71,156 +58,159 @@ export default function SettingsGeneralPage() {
     }
   };
 
-  if (loading) {
+  if (loadingOrganization) {
     return (
-      <Page>
-        <PageContent sx={{ mt: 0 }}>
-          <Box sx={{ display: "flex", justifyContent: "center", py: 10 }}>
-            <CircularProgress />
-          </Box>
-        </PageContent>
-      </Page>
+      <div className="flex w-full justify-center px-6 py-20">
+        <Spinner />
+      </div>
     );
   }
 
   if (!organization) {
     return (
-      <Page>
-        <PageContent sx={{ mt: 0 }}>
-          <Alert severity="error">Organization not found</Alert>
-        </PageContent>
-      </Page>
+      <div className="w-full px-6 py-8 md:px-10">
+        <Callout tone="error">Organization not found</Callout>
+      </div>
     );
   }
 
   const hasChanges =
-    formData.name !== organization.name || formData.slug !== (organization.slug ?? "");
+    formData.name !== organization.name ||
+    formData.slug !== (organization.slug ?? "");
   const canEdit =
     organization.userRole === "owner" || organization.userRole === "admin";
   const scopeLabel = organization.isPersonal ? "Workspace" : "Organization";
 
   return (
-    <Page>
-      <PageContent sx={{ mt: 0 }} maxWidth="5xl">
-        <Box
-          sx={(theme) => ({
-            display: "flex",
-            gap: 2,
-            mb: 3,
-            pb: 3,
-            alignItems: "center",
-            justifyContent: "flex-end",
-            borderBottom: `1px solid ${theme.palette.divider}`,
-          })}
-        >
-          {hasChanges && (
-            <Button
-              variant="outlined"
-              onClick={() =>
-                setFormData({
-                  name: organization.name,
-                  slug: organization.slug ?? "",
-                })
-              }
-              disabled={saving}
-              size="small"
-              sx={{ textTransform: "none", fontSize: "0.75rem", fontWeight: 500 }}
-            >
-              Cancel
-            </Button>
-          )}
+    <div className="w-full space-y-6 px-6 py-8 md:px-10">
+      <div className="flex items-center justify-end gap-2 border-b border-line-soft pb-5">
+        {hasChanges && (
           <Button
-            variant="contained"
-            onClick={handleSave}
-            disabled={!canEdit || !hasChanges || saving}
-            size="small"
-            sx={{
-              textTransform: "none",
-              fontSize: "0.75rem",
-              fontWeight: 500,
-              minWidth: 120,
-              "&:disabled": { opacity: 0.5 },
-            }}
+            variant="secondary"
+            size="sm"
+            disabled={saving}
+            onClick={() =>
+              setFormData({
+                name: organization.name,
+                slug: organization.slug ?? "",
+              })
+            }
           >
-            {saving ? <CircularProgress size={16} /> : "Save"}
+            Cancel
           </Button>
-        </Box>
+        )}
+        <Button
+          size="sm"
+          className="min-w-[96px]"
+          disabled={!canEdit || !hasChanges || saving}
+          onClick={handleSave}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
 
-        <PageCard>
-          <Typography variant="h6" sx={{ mb: 3, fontWeight: 600, fontSize: "1rem" }}>
-            {scopeLabel} Settings
-          </Typography>
+      <Panel className="rounded-2xl p-6">
+        <h2 className="text-sm font-semibold text-text-primary">
+          {scopeLabel} settings
+        </h2>
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
+        {error && (
+          <Callout tone="error" className="mt-3">
+            {error}
+          </Callout>
+        )}
+        {!canEdit && (
+          <Callout tone="info" className="mt-3">
+            You need admin or owner role to edit {scopeLabel.toLowerCase()}{" "}
+            settings.
+          </Callout>
+        )}
 
-          {!canEdit && (
-            <Alert severity="info" sx={{ mb: 2 }}>
-              You need admin or owner role to edit {scopeLabel.toLowerCase()} settings.
-            </Alert>
-          )}
+        <div className="mt-5 space-y-5">
+          <Field label={`${scopeLabel} name *`}>
+            <Input
+              value={formData.name}
+              onChange={handleChange("name")}
+              disabled={!canEdit || saving}
+              placeholder={`Enter ${scopeLabel.toLowerCase()} name`}
+            />
+          </Field>
+          <Field
+            label="Slug *"
+            hint={
+              organization.isPersonal
+                ? "Personal organization slug cannot be changed"
+                : "URL-friendly identifier — lowercase letters, numbers, hyphens, underscores"
+            }
+          >
+            <Input
+              value={formData.slug}
+              onChange={handleChange("slug")}
+              disabled={!canEdit || saving || organization.isPersonal}
+              placeholder={`Enter ${scopeLabel.toLowerCase()} slug`}
+            />
+          </Field>
+        </div>
 
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-            <Box>
-              <Typography
-                sx={{ fontSize: "0.75rem", fontWeight: 600, mb: 0.5 }}
-              >
-                {scopeLabel} Name *
-              </Typography>
-              <TextField
-                value={formData.name}
-                onChange={handleChange("name")}
-                fullWidth
-                size="small"
-                disabled={!canEdit || saving}
-                placeholder={`Enter ${scopeLabel.toLowerCase()} name`}
-              />
-            </Box>
+        <div className="mt-6 border-t border-line-soft pt-5">
+          <h3 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+            {scopeLabel} information
+          </h3>
+          <dl className="mt-3 space-y-1.5 text-sm text-text-secondary">
+            <div>
+              {scopeLabel} ID:{" "}
+              <span className="text-text-primary">{organization.id}</span>
+            </div>
+            <div>
+              Type:{" "}
+              <span className="text-text-primary">
+                {organization.isPersonal ? "Personal" : "Team"}
+              </span>
+            </div>
+            <div>
+              Your role:{" "}
+              <span className="text-text-primary">
+                {organization.userRole || "Member"}
+              </span>
+            </div>
+          </dl>
+        </div>
+      </Panel>
+    </div>
+  );
+}
 
-            <Box>
-              <Typography
-                sx={{ fontSize: "0.75rem", fontWeight: 600, mb: 0.5 }}
-              >
-                Slug *
-              </Typography>
-              <TextField
-                value={formData.slug}
-                onChange={handleChange("slug")}
-                fullWidth
-                size="small"
-                disabled={!canEdit || saving || organization.isPersonal}
-                placeholder={`Enter ${scopeLabel.toLowerCase()} slug`}
-              />
-              <Typography
-                sx={(theme) => ({
-                  fontSize: "0.75rem",
-                  color: theme.palette.text.secondary,
-                  mt: 0.5,
-                })}
-              >
-                {organization.isPersonal
-                  ? "Personal organization slug cannot be changed"
-                  : "URL-friendly identifier (lowercase letters, numbers, hyphens, underscores)"}
-              </Typography>
-            </Box>
+function Spinner() {
+  return (
+    <div
+      className="h-6 w-6 animate-spin rounded-full border-2 border-line-strong border-t-accent"
+      aria-label="Loading"
+    />
+  );
+}
 
-            <PageSection title={`${scopeLabel} Information`} spacing="tight">
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                {scopeLabel} ID: {organization.id}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                Type: {organization.isPersonal ? "Personal" : "Team"}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Your Role: {organization.userRole || "Member"}
-              </Typography>
-            </PageSection>
-          </Box>
-        </PageCard>
-      </PageContent>
-    </Page>
+function Callout({
+  tone,
+  children,
+  className,
+}: {
+  tone: "error" | "info";
+  children: ReactNode;
+  className?: string;
+}) {
+  const tones: Record<typeof tone, string> = {
+    error: "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-300",
+    info: "border-line-soft bg-accent-soft text-text-secondary",
+  };
+  return (
+    <div
+      className={cn(
+        "rounded-lg border px-3 py-2 text-sm",
+        tones[tone],
+        className,
+      )}
+    >
+      {children}
+    </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/members/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/members/page.tsx
@@ -1,41 +1,22 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import useSWR from "swr";
 import {
-  Alert,
   Avatar,
-  Box,
+  Badge,
   Button,
-  Chip,
-  CircularProgress,
-  Dialog,
+  Field,
   IconButton,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-  Typography,
-  alpha,
-} from "@mui/material";
-import {
-  MenuItem,
-  Page,
-  PageCard,
-  PageContent,
-  RightDrawer,
+  Input,
+  Modal,
+  Panel,
   Select,
-  SettingContainer,
-  SettingLabel,
-  TextField,
-  showToast,
-} from "@klorad/ui";
+  Spinner,
+} from "@klorad/design-system";
+import { showToast } from "@klorad/ui";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CancelIcon from "@mui/icons-material/Cancel";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -80,7 +61,7 @@ export default function SettingsMembersPage() {
   const { data, error, isLoading, mutate } = useSWR<MembersData>(
     orgId && organization && !isPersonalOrg
       ? `/api/organizations/${orgId}/members`
-      : null
+      : null,
   );
 
   const [inviteOpen, setInviteOpen] = useState(false);
@@ -182,7 +163,8 @@ export default function SettingsMembersPage() {
         body: JSON.stringify({ inviteId: inviteToCancel.id }),
       });
       const result = await res.json();
-      if (!res.ok) throw new Error(result.error || "Failed to cancel invitation");
+      if (!res.ok)
+        throw new Error(result.error || "Failed to cancel invitation");
       showToast("Invitation cancelled", "success");
       setCancelOpen(false);
       setInviteToCancel(null);
@@ -194,452 +176,349 @@ export default function SettingsMembersPage() {
     }
   };
 
-  const formatRole = (role: string) => role.charAt(0).toUpperCase() + role.slice(1);
+  const formatRole = (role: string) =>
+    role.charAt(0).toUpperCase() + role.slice(1);
 
   if (loadingOrganization || (!isPersonalOrg && isLoading && !data)) {
     return (
-      <Page>
-        <PageContent sx={{ mt: 0 }}>
-          <Box sx={{ display: "flex", justifyContent: "center", py: 10 }}>
-            <CircularProgress />
-          </Box>
-        </PageContent>
-      </Page>
+      <div className="flex w-full justify-center px-6 py-20">
+        <Spinner />
+      </div>
     );
   }
 
   if (!isPersonalOrg && error) {
     return (
-      <Page>
-        <PageContent sx={{ mt: 0 }}>
-          <Alert severity="error">Failed to load members</Alert>
-        </PageContent>
-      </Page>
+      <div className="w-full px-6 py-8 md:px-10">
+        <Panel className="rounded-2xl border-red-500/30 bg-red-500/10 p-4 text-sm text-red-600 dark:text-red-300">
+          Failed to load members
+        </Panel>
+      </div>
+    );
+  }
+
+  if (isPersonalOrg) {
+    return (
+      <div className="w-full px-6 py-8 md:px-10">
+        <Panel className="rounded-2xl p-6">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Personal organizations don&apos;t have members
+          </h2>
+          <p className="mt-2 max-w-prose text-sm text-text-secondary">
+            Personal organizations are for individual use only. To collaborate
+            with teammates, ask support to upgrade this workspace to an
+            organization.
+          </p>
+        </Panel>
+      </div>
     );
   }
 
   return (
-    <Page>
-      <PageContent sx={{ mt: 0 }} maxWidth="6xl">
-        {isPersonalOrg ? (
-          <PageCard>
-            <Alert severity="info">
-              <Typography variant="body1" sx={{ fontWeight: 600, mb: 1 }}>
-                Personal organizations don&apos;t have members
-              </Typography>
-              <Typography variant="body2">
-                Personal organizations are for individual use only. To
-                collaborate with teammates, ask support to upgrade this
-                workspace to an organization.
-              </Typography>
-            </Alert>
-          </PageCard>
-        ) : (
-          <>
-            <Box
-              sx={(theme) => ({
-                display: "flex",
-                gap: 2,
-                mb: 3,
-                pb: 3,
-                alignItems: "center",
-                justifyContent: "flex-end",
-                borderBottom: `1px solid ${theme.palette.divider}`,
-              })}
-            >
-              {canInvite && (
-                <Button
-                  variant="contained"
-                  startIcon={<PersonAddIcon />}
-                  onClick={() => setInviteOpen(true)}
-                  size="small"
-                  sx={{ textTransform: "none", fontSize: "0.75rem", fontWeight: 500 }}
-                >
-                  Invite Member
-                </Button>
-              )}
-            </Box>
-
-            <PageCard>
-              <Typography
-                variant="h6"
-                sx={{ mb: 3, fontWeight: 600, fontSize: "1rem" }}
-              >
-                Organization Members
-              </Typography>
-
-              {!data ? (
-                <Box sx={{ textAlign: "center", py: 6 }}>
-                  <CircularProgress />
-                </Box>
-              ) : data.members.length === 0 && data.invites.length === 0 ? (
-                <Box sx={{ textAlign: "center", py: 6, color: "text.secondary" }}>
-                  <Typography variant="body1" sx={{ mb: 1 }}>
-                    No members yet
-                  </Typography>
-                  <Typography variant="body2">
-                    {canInvite
-                      ? "Invite your first team member to get started"
-                      : "No members in this organization"}
-                  </Typography>
-                </Box>
-              ) : (
-                <TableContainer
-                  component={Box}
-                  sx={{ backgroundColor: "transparent", boxShadow: "none" }}
-                >
-                  <Table>
-                    <TableHead>
-                      <TableRow>
-                        <TableCell sx={{ fontSize: "0.75rem", fontWeight: 600 }}>
-                          Member
-                        </TableCell>
-                        <TableCell sx={{ fontSize: "0.75rem", fontWeight: 600 }}>
-                          Role
-                        </TableCell>
-                        <TableCell sx={{ fontSize: "0.75rem", fontWeight: 600 }}>
-                          Joined
-                        </TableCell>
-                        {isOwner && (
-                          <TableCell
-                            align="right"
-                            sx={{ fontSize: "0.75rem", fontWeight: 600 }}
-                          >
-                            Actions
-                          </TableCell>
-                        )}
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {data.members.map((member) => (
-                        <TableRow key={member.id} hover sx={{ "& td": { borderBottom: "none" } }}>
-                          <TableCell sx={{ fontSize: "0.75rem" }}>
-                            <Stack direction="row" spacing={1.5} alignItems="center">
-                              <Avatar
-                                src={member.user.image || undefined}
-                                sx={{ width: 32, height: 32, fontSize: "0.875rem" }}
-                              >
-                                {(member.user.name || member.user.email)
-                                  ?.charAt(0)
-                                  .toUpperCase()}
-                              </Avatar>
-                              <Box>
-                                <Typography sx={{ fontSize: "0.75rem", fontWeight: 500 }}>
-                                  {member.user.name || member.user.email}
-                                </Typography>
-                                {member.user.name && (
-                                  <Typography
-                                    sx={{ fontSize: "0.75rem", color: "text.secondary" }}
-                                  >
-                                    {member.user.email}
-                                  </Typography>
-                                )}
-                              </Box>
-                            </Stack>
-                          </TableCell>
-                          <TableCell sx={{ fontSize: "0.75rem" }}>
-                            {isOwner && member.userId !== session?.user?.id ? (
-                              <Select
-                                value={member.role}
-                                onChange={(e) =>
-                                  handleUpdateRole(member.id, e.target.value as string)
-                                }
-                                size="small"
-                                disabled={updatingRole === member.id}
-                                sx={(theme) => ({
-                                  minWidth: 100,
-                                  fontSize: "0.75rem",
-                                  backgroundColor: alpha(theme.palette.primary.main, 0.15),
-                                  color: theme.palette.primary.main,
-                                })}
-                              >
-                                <MenuItem value="member">Member</MenuItem>
-                                <MenuItem value="admin">Admin</MenuItem>
-                                <MenuItem value="owner">Owner</MenuItem>
-                              </Select>
-                            ) : (
-                              <Chip
-                                label={formatRole(member.role)}
-                                size="small"
-                                sx={(theme) => ({
-                                  fontSize: "0.75rem",
-                                  backgroundColor: alpha(theme.palette.primary.main, 0.15),
-                                  color: theme.palette.primary.main,
-                                  border: `1px solid ${alpha(theme.palette.primary.main, 0.3)}`,
-                                })}
-                              />
-                            )}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: "0.75rem", color: "text.secondary" }}>
-                            {new Date(member.createdAt).toLocaleDateString()}
-                          </TableCell>
-                          {isOwner && (
-                            <TableCell align="right">
-                              {member.userId !== session?.user?.id && (
-                                <Tooltip title="Remove member">
-                                  <IconButton
-                                    size="small"
-                                    onClick={() => {
-                                      setMemberToRemove(member);
-                                      setRemoveOpen(true);
-                                    }}
-                                    sx={{ color: "error.main" }}
-                                  >
-                                    <DeleteIcon fontSize="small" />
-                                  </IconButton>
-                                </Tooltip>
-                              )}
-                            </TableCell>
-                          )}
-                        </TableRow>
-                      ))}
-                      {data.invites.map((invite) => (
-                        <TableRow key={invite.id} hover sx={{ "& td": { borderBottom: "none" } }}>
-                          <TableCell sx={{ fontSize: "0.75rem" }}>
-                            <Stack direction="row" spacing={1.5} alignItems="center">
-                              <Avatar
-                                sx={(theme) => ({
-                                  width: 32,
-                                  height: 32,
-                                  fontSize: "0.875rem",
-                                  backgroundColor: alpha(theme.palette.primary.main, 0.15),
-                                  color: theme.palette.primary.main,
-                                })}
-                              >
-                                {invite.email.charAt(0).toUpperCase()}
-                              </Avatar>
-                              <Box>
-                                <Typography sx={{ fontSize: "0.75rem", fontWeight: 500 }}>
-                                  {invite.email}
-                                </Typography>
-                                <Typography
-                                  sx={{ fontSize: "0.75rem", color: "text.secondary" }}
-                                >
-                                  Pending invitation
-                                </Typography>
-                              </Box>
-                            </Stack>
-                          </TableCell>
-                          <TableCell sx={{ fontSize: "0.75rem" }}>
-                            <Chip
-                              label={formatRole(invite.role)}
-                              size="small"
-                              sx={(theme) => ({
-                                fontSize: "0.75rem",
-                                backgroundColor: alpha(theme.palette.primary.main, 0.15),
-                                color: theme.palette.primary.main,
-                                border: `1px solid ${alpha(theme.palette.primary.main, 0.3)}`,
-                              })}
-                            />
-                          </TableCell>
-                          <TableCell sx={{ fontSize: "0.75rem", color: "text.secondary" }}>
-                            Invited {new Date(invite.createdAt).toLocaleDateString()}
-                          </TableCell>
-                          {isOwner && (
-                            <TableCell align="right">
-                              <Stack direction="row" spacing={0.5} justifyContent="flex-end" alignItems="center">
-                                <Chip
-                                  label="Pending"
-                                  size="small"
-                                  sx={(theme) => ({
-                                    fontSize: "0.75rem",
-                                    backgroundColor: alpha(theme.palette.warning.main, 0.15),
-                                    color: theme.palette.warning.main,
-                                    border: `1px solid ${alpha(theme.palette.warning.main, 0.3)}`,
-                                  })}
-                                />
-                                <Tooltip title="Cancel invitation">
-                                  <IconButton
-                                    size="small"
-                                    onClick={() => {
-                                      setInviteToCancel(invite);
-                                      setCancelOpen(true);
-                                    }}
-                                    disabled={cancelling}
-                                    sx={{ color: "error.main" }}
-                                  >
-                                    <CancelIcon fontSize="small" />
-                                  </IconButton>
-                                </Tooltip>
-                              </Stack>
-                            </TableCell>
-                          )}
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              )}
-            </PageCard>
-          </>
+    <>
+      <div className="w-full space-y-6 px-6 py-8 md:px-10">
+        {canInvite && (
+          <div className="flex justify-end">
+            <Button size="sm" onClick={() => setInviteOpen(true)}>
+              <PersonAddIcon fontSize="small" />
+              Invite member
+            </Button>
+          </div>
         )}
-      </PageContent>
 
-      {/* Invite drawer */}
-      <RightDrawer
+        <Panel className="rounded-2xl p-6">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Organization members
+          </h2>
+
+          {!data ? (
+            <div className="flex justify-center py-10">
+              <Spinner />
+            </div>
+          ) : data.members.length === 0 && data.invites.length === 0 ? (
+            <div className="py-10 text-center">
+              <p className="text-sm font-medium text-text-primary">
+                No members yet
+              </p>
+              <p className="mt-1 text-sm text-text-secondary">
+                {canInvite
+                  ? "Invite your first team member to get started"
+                  : "No members in this organization"}
+              </p>
+            </div>
+          ) : (
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b border-line-soft text-xs uppercase tracking-[0.14em] text-text-tertiary">
+                    <th className="px-3 py-2 text-left font-medium">Member</th>
+                    <th className="px-3 py-2 text-left font-medium">Role</th>
+                    <th className="px-3 py-2 text-left font-medium">Joined</th>
+                    {isOwner && (
+                      <th className="px-3 py-2 text-right font-medium">
+                        Actions
+                      </th>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.members.map((member) => {
+                    const editable =
+                      isOwner && member.userId !== session?.user?.id;
+                    return (
+                      <tr
+                        key={member.id}
+                        className="border-b border-line-soft last:border-0"
+                      >
+                        <td className="px-3 py-3 align-middle">
+                          <div className="flex items-center gap-3">
+                            <Avatar
+                              src={member.user.image}
+                              name={member.user.name || member.user.email}
+                            />
+                            <div className="min-w-0">
+                              <div className="truncate font-medium text-text-primary">
+                                {member.user.name || member.user.email}
+                              </div>
+                              {member.user.name && (
+                                <div className="truncate text-xs text-text-secondary">
+                                  {member.user.email}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 align-middle">
+                          {editable ? (
+                            <Select
+                              className="w-32"
+                              value={member.role}
+                              disabled={updatingRole === member.id}
+                              onChange={(e) =>
+                                handleUpdateRole(member.id, e.target.value)
+                              }
+                            >
+                              <option value="member">Member</option>
+                              <option value="admin">Admin</option>
+                              <option value="owner">Owner</option>
+                            </Select>
+                          ) : (
+                            <Badge tone="accent">
+                              {formatRole(member.role)}
+                            </Badge>
+                          )}
+                        </td>
+                        <td className="px-3 py-3 align-middle text-text-secondary">
+                          {new Date(member.createdAt).toLocaleDateString()}
+                        </td>
+                        {isOwner && (
+                          <td className="px-3 py-3 text-right align-middle">
+                            {member.userId !== session?.user?.id && (
+                              <button
+                                type="button"
+                                aria-label="Remove member"
+                                onClick={() => {
+                                  setMemberToRemove(member);
+                                  setRemoveOpen(true);
+                                }}
+                                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-600"
+                              >
+                                <DeleteIcon fontSize="small" />
+                              </button>
+                            )}
+                          </td>
+                        )}
+                      </tr>
+                    );
+                  })}
+                  {data.invites.map((invite) => (
+                    <tr
+                      key={invite.id}
+                      className="border-b border-line-soft last:border-0"
+                    >
+                      <td className="px-3 py-3 align-middle">
+                        <div className="flex items-center gap-3">
+                          <Avatar name={invite.email} />
+                          <div className="min-w-0">
+                            <div className="truncate font-medium text-text-primary">
+                              {invite.email}
+                            </div>
+                            <div className="truncate text-xs text-text-secondary">
+                              Pending invitation
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-3 py-3 align-middle">
+                        <Badge tone="warning">{formatRole(invite.role)}</Badge>
+                      </td>
+                      <td className="px-3 py-3 align-middle text-text-secondary">
+                        Invited{" "}
+                        {new Date(invite.createdAt).toLocaleDateString()}
+                      </td>
+                      {isOwner && (
+                        <td className="px-3 py-3 text-right align-middle">
+                          <button
+                            type="button"
+                            aria-label="Cancel invitation"
+                            disabled={cancelling}
+                            onClick={() => {
+                              setInviteToCancel(invite);
+                              setCancelOpen(true);
+                            }}
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-600 disabled:opacity-50"
+                          >
+                            <CancelIcon fontSize="small" />
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Panel>
+      </div>
+
+      <Modal
         open={inviteOpen}
-        onClose={() => {
-          if (inviting) return;
-          setInviteOpen(false);
-        }}
-        title="Invite Member"
-        actions={
+        onClose={() => !inviting && setInviteOpen(false)}
+        title="Invite member"
+        footer={
           <>
             <Button
-              variant="outlined"
+              variant="secondary"
               onClick={() => setInviteOpen(false)}
               disabled={inviting}
-              fullWidth
-              sx={{ textTransform: "none" }}
             >
               Cancel
             </Button>
             <Button
-              variant="contained"
               onClick={handleInvite}
               disabled={!inviteEmail || inviting}
-              fullWidth
-              sx={{ textTransform: "none" }}
             >
-              {inviting ? <CircularProgress size={16} /> : "Send invitation"}
+              {inviting ? "Sending…" : "Send invitation"}
             </Button>
           </>
         }
       >
-        <SettingContainer sx={{ borderBottom: "none", padding: 0 }}>
-          <SettingLabel>Email Address *</SettingLabel>
-          <TextField
-            autoFocus
-            type="email"
-            fullWidth
-            size="small"
-            value={inviteEmail}
-            onChange={(e) => setInviteEmail(e.target.value)}
-            placeholder="name@example.com"
-          />
-        </SettingContainer>
-        <SettingContainer sx={{ borderBottom: "none", padding: 0 }}>
-          <SettingLabel>Role *</SettingLabel>
-          <Select
-            fullWidth
-            size="small"
-            value={inviteRole}
-            onChange={(e) => setInviteRole(e.target.value as string)}
-          >
-            <MenuItem value="member">Member</MenuItem>
-            <MenuItem value="admin">Admin</MenuItem>
-            {isOwner && <MenuItem value="owner">Owner</MenuItem>}
-          </Select>
-        </SettingContainer>
-      </RightDrawer>
+        <div className="space-y-4">
+          <Field label="Email address *">
+            <Input
+              autoFocus
+              type="email"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              placeholder="name@example.com"
+            />
+          </Field>
+          <Field label="Role *">
+            <Select
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value)}
+            >
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+              {isOwner && <option value="owner">Owner</option>}
+            </Select>
+          </Field>
+        </div>
+      </Modal>
 
-      {/* Invite URL share drawer */}
-      <RightDrawer
+      <Modal
         open={inviteUrlOpen}
         onClose={() => setInviteUrlOpen(false)}
         title="Share invitation link"
-        actions={
-          <Button
-            variant="contained"
-            onClick={() => setInviteUrlOpen(false)}
-            fullWidth
-            sx={{ textTransform: "none" }}
-          >
-            Done
-          </Button>
+        description="Email delivery is not yet wired on Klorad Campus. Copy this link and send it to the invitee. It expires in 7 days."
+        footer={
+          <Button onClick={() => setInviteUrlOpen(false)}>Done</Button>
         }
       >
-        <Typography variant="body2" color="text.secondary">
-          Email delivery is not yet wired on Klorad Campus. Copy this link
-          and send it to the invitee. It expires in 7 days.
-        </Typography>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <TextField
-            fullWidth
-            size="small"
-            value={lastInviteUrl ?? ""}
-            InputProps={{ readOnly: true }}
-          />
+        <div className="flex items-center gap-2">
+          <Input readOnly value={lastInviteUrl ?? ""} className="flex-1" />
           <IconButton
+            variant="secondary"
+            aria-label="Copy link"
             onClick={() => {
               if (lastInviteUrl) {
                 navigator.clipboard.writeText(lastInviteUrl).then(
                   () => showToast("Copied to clipboard", "success"),
-                  () => showToast("Copy failed", "error")
+                  () => showToast("Copy failed", "error"),
                 );
               }
             }}
-            sx={{ color: "primary.main" }}
           >
             <ContentCopyIcon fontSize="small" />
           </IconButton>
-        </Stack>
-      </RightDrawer>
+        </div>
+      </Modal>
 
-      {/* Remove confirm dialog */}
-      <Dialog open={removeOpen} onClose={() => setRemoveOpen(false)} maxWidth="sm" fullWidth>
-        <Box sx={{ p: 3 }}>
-          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-            Remove Member
-          </Typography>
-          <Typography variant="body2" sx={{ mb: 3 }}>
-            Are you sure you want to remove{" "}
-            <strong>{memberToRemove?.user.name || memberToRemove?.user.email}</strong>{" "}
-            from this organization? This action cannot be undone.
-          </Typography>
-          <Stack direction="row" spacing={2} justifyContent="flex-end">
+      <Modal
+        open={removeOpen}
+        onClose={() => !removing && setRemoveOpen(false)}
+        title="Remove member"
+        description={
+          <>
+            Remove{" "}
+            <strong className="text-text-primary">
+              {memberToRemove?.user.name || memberToRemove?.user.email}
+            </strong>{" "}
+            from this organization? This cannot be undone.
+          </>
+        }
+        footer={
+          <>
             <Button
-              variant="outlined"
+              variant="secondary"
               onClick={() => setRemoveOpen(false)}
               disabled={removing}
-              sx={{ textTransform: "none" }}
             >
               Cancel
             </Button>
             <Button
-              variant="contained"
-              color="error"
+              variant="danger"
               onClick={handleRemove}
               disabled={removing}
-              sx={{ textTransform: "none" }}
             >
-              {removing ? <CircularProgress size={16} /> : "Remove"}
+              {removing ? "Removing…" : "Remove member"}
             </Button>
-          </Stack>
-        </Box>
-      </Dialog>
+          </>
+        }
+      />
 
-      {/* Cancel invite dialog */}
-      <Dialog open={cancelOpen} onClose={() => setCancelOpen(false)} maxWidth="sm" fullWidth>
-        <Box sx={{ p: 3 }}>
-          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-            Cancel Invitation
-          </Typography>
-          <Typography variant="body2" sx={{ mb: 3 }}>
-            Are you sure you want to cancel the invitation sent to{" "}
-            <strong>{inviteToCancel?.email}</strong>? This action cannot be undone.
-          </Typography>
-          <Stack direction="row" spacing={2} justifyContent="flex-end">
+      <Modal
+        open={cancelOpen}
+        onClose={() => !cancelling && setCancelOpen(false)}
+        title="Cancel invitation"
+        description={
+          <>
+            Cancel the invitation sent to{" "}
+            <strong className="text-text-primary">
+              {inviteToCancel?.email}
+            </strong>
+            ? This cannot be undone.
+          </>
+        }
+        footer={
+          <>
             <Button
-              variant="outlined"
+              variant="secondary"
               onClick={() => setCancelOpen(false)}
               disabled={cancelling}
-              sx={{ textTransform: "none" }}
             >
               Keep invitation
             </Button>
             <Button
-              variant="contained"
-              color="error"
+              variant="danger"
               onClick={handleCancelInvite}
               disabled={cancelling}
-              sx={{ textTransform: "none" }}
             >
-              {cancelling ? <CircularProgress size={16} /> : "Cancel invitation"}
+              {cancelling ? "Cancelling…" : "Cancel invitation"}
             </Button>
-          </Stack>
-        </Box>
-      </Dialog>
-    </Page>
+          </>
+        }
+      />
+    </>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/usage/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/usage/page.tsx
@@ -1,48 +1,75 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { Box } from "@mui/material";
-import { MetricCard, Page, PageCard, PageContent, PageSection } from "@klorad/ui";
+import type { ReactNode } from "react";
 import MapIcon from "@mui/icons-material/Map";
 import PlaceIcon from "@mui/icons-material/Place";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import ApartmentIcon from "@mui/icons-material/Apartment";
-import { Typography } from "@mui/material";
+import { Panel } from "@klorad/design-system";
 
 export default async function SettingsUsagePage() {
   const session = await auth();
   if (!session) redirect("/auth/signin");
 
   return (
-    <Page>
-      <PageContent sx={{ mt: 0 }}>
-        <Box
-          sx={{
-            display: "grid",
-            gap: 2,
-            gridTemplateColumns: {
-              xs: "1fr",
-              sm: "repeat(2, 1fr)",
-              md: "repeat(4, 1fr)",
-            },
-          }}
-        >
-          <MetricCard icon={<MapIcon fontSize="small" />} value="—" label="Campus maps" />
-          <MetricCard icon={<PlaceIcon fontSize="small" />} value="—" label="Total POIs" />
-          <MetricCard icon={<ApartmentIcon fontSize="small" />} value="—" label="Floor plans" />
-          <MetricCard icon={<VisibilityIcon fontSize="small" />} value="—" label="Views (30d)" />
-        </Box>
-        <PageSection title="Plan" spacing="tight">
-          <PageCard>
-            <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-              Pro · €5k / yr
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Detailed usage, plan limits, and invoicing land here once
-              billing is wired. Contact us to adjust your plan meanwhile.
-            </Typography>
-          </PageCard>
-        </PageSection>
-      </PageContent>
-    </Page>
+    <div className="w-full space-y-10 px-6 py-8 md:px-10">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={<MapIcon fontSize="small" />}
+          value="—"
+          label="Campus maps"
+        />
+        <StatCard
+          icon={<PlaceIcon fontSize="small" />}
+          value="—"
+          label="Total POIs"
+        />
+        <StatCard
+          icon={<ApartmentIcon fontSize="small" />}
+          value="—"
+          label="Floor plans"
+        />
+        <StatCard
+          icon={<VisibilityIcon fontSize="small" />}
+          value="—"
+          label="Views (30d)"
+        />
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          Plan
+        </h2>
+        <Panel className="rounded-2xl p-5">
+          <div className="text-sm font-semibold text-text-primary">
+            Pro · €5k / yr
+          </div>
+          <p className="mt-1 max-w-prose text-sm text-text-secondary">
+            Detailed usage, plan limits, and invoicing land here once billing is
+            wired. Contact us to adjust your plan meanwhile.
+          </p>
+        </Panel>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  value,
+  label,
+}: {
+  icon: ReactNode;
+  value: string;
+  label: string;
+}) {
+  return (
+    <Panel className="rounded-2xl p-5">
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
+        {icon}
+      </div>
+      <div className="mt-4 text-2xl font-light text-text-primary">{value}</div>
+      <div className="mt-0.5 text-sm text-text-secondary">{label}</div>
+    </Panel>
   );
 }

--- a/apps/campus/app/global.css
+++ b/apps/campus/app/global.css
@@ -1,5 +1,10 @@
 @import "@klorad/ui/styles/tokens.css";
+@import "@klorad/design-system/tokens.css";
 @import "mapbox-gl/dist/mapbox-gl.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 *,
 *::before,

--- a/apps/campus/app/global.css
+++ b/apps/campus/app/global.css
@@ -14,6 +14,11 @@
   padding: 0;
 }
 
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
 html,
 body {
   height: 100%;

--- a/apps/campus/app/layout.tsx
+++ b/apps/campus/app/layout.tsx
@@ -46,7 +46,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "try{if(localStorage.getItem('klorad-theme-mode')==='dark')document.documentElement.classList.add('dark')}catch(e){}",
+              "try{if(localStorage.getItem('klorad-theme')==='dark')document.documentElement.classList.add('dark')}catch(e){}",
           }}
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/apps/campus/app/layout.tsx
+++ b/apps/campus/app/layout.tsx
@@ -40,8 +40,15 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: ReactNode }) {
   const session = await auth();
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Apply the saved theme before paint to avoid a flash. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "try{if(localStorage.getItem('klorad-theme-mode')==='dark')document.documentElement.classList.add('dark')}catch(e){}",
+          }}
+        />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         {/* eslint-disable-next-line @next/next/no-page-custom-font */}

--- a/apps/campus/app/onboarding/SignOutLink.tsx
+++ b/apps/campus/app/onboarding/SignOutLink.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { Button } from "@mui/material";
-import LogoutIcon from "@mui/icons-material/Logout";
 import { signOut } from "next-auth/react";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { Button } from "@klorad/design-system";
 
 export default function SignOutLink() {
   return (
     <Button
-      variant="outlined"
-      startIcon={<LogoutIcon />}
+      variant="secondary"
       onClick={() => signOut({ callbackUrl: "/auth/signin" })}
-      sx={{ textTransform: "none" }}
     >
+      <LogoutIcon fontSize="small" />
       Sign out
     </Button>
   );

--- a/apps/campus/app/onboarding/page.tsx
+++ b/apps/campus/app/onboarding/page.tsx
@@ -1,10 +1,7 @@
-import { Box, Stack, Typography } from "@mui/material";
-import Link from "next/link";
-import Image from "next/image";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { KloradMark, buttonClassName } from "@klorad/design-system";
 import SignOutLink from "./SignOutLink";
-import { Button } from "@mui/material";
 
 export default async function OnboardingPage() {
   const session = await auth();
@@ -19,7 +16,9 @@ export default async function OnboardingPage() {
   const hasOrgsWithoutCampus =
     memberships.length > 0 &&
     !memberships.some(
-      (m) => !m.organization.isPersonal && (m.organization.apps ?? []).includes("campus")
+      (m) =>
+        !m.organization.isPersonal &&
+        (m.organization.apps ?? []).includes("campus"),
     );
 
   const title = hasOrgsWithoutCampus
@@ -31,52 +30,26 @@ export default async function OnboardingPage() {
     : "You don't belong to any organization yet. Contact us to get started with a campus map for your institution.";
 
   return (
-    <Box
-      sx={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 3,
-        bgcolor: "#0a0d10",
-        color: "text.primary",
-        px: 3,
-        textAlign: "center",
-      }}
-    >
-      <Image
-        src="/images/logo/klorad-campus-logo-white.svg"
-        alt="Klorad Campus"
-        width={180}
-        height={40}
-        priority
-        style={{ objectFit: "contain", height: "auto" }}
-      />
-      <Stack spacing={1} sx={{ maxWidth: 460 }}>
-        <Typography variant="h6" fontWeight={700}>
-          {title}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {description}
-        </Typography>
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-bg px-6 text-center text-text-primary">
+      <KloradMark className="h-10 w-auto" />
+      <div className="max-w-md space-y-2">
+        <h1 className="text-lg font-semibold text-text-primary">{title}</h1>
+        <p className="text-sm text-text-secondary">{description}</p>
         {session?.user?.email && (
-          <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>
+          <p className="pt-2 text-xs text-text-tertiary">
             Signed in as {session.user.email}
-          </Typography>
+          </p>
         )}
-      </Stack>
-      <Stack direction="row" spacing={1.5}>
-        <Button
-          variant="contained"
-          component={Link}
+      </div>
+      <div className="flex items-center gap-3">
+        <a
           href="mailto:support@klorad.com?subject=Enable%20Klorad%20Campus"
-          sx={{ textTransform: "none" }}
+          className={buttonClassName()}
         >
           Contact us
-        </Button>
+        </a>
         {session?.user && <SignOutLink />}
-      </Stack>
-    </Box>
+      </div>
+    </div>
   );
 }

--- a/apps/campus/next.config.mjs
+++ b/apps/campus/next.config.mjs
@@ -3,6 +3,7 @@ const nextConfig = {
   transpilePackages: [
     "@klorad/api",
     "@klorad/core",
+    "@klorad/design-system",
     "@klorad/ui",
     "@klorad/engine-mapbox",
     "@klorad/engine-three",

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -19,11 +19,13 @@
     "@emotion/styled": "^11.14.0",
     "@klorad/api": "workspace:^",
     "@klorad/core": "workspace:^",
+    "@klorad/design-system": "workspace:^",
     "@klorad/engine-mapbox": "workspace:^",
     "@klorad/engine-three": "workspace:^",
     "@klorad/prisma": "workspace:*",
     "@klorad/storage": "workspace:^",
     "@klorad/ui": "workspace:^",
+    "@mapbox/mapbox-gl-draw": "^1.5.0",
     "@mui/icons-material": "^6.4.2",
     "@mui/material": "^6.4.1",
     "@prisma/client": "^5.22.0",
@@ -31,7 +33,6 @@
     "@types/node": "^20.11.30",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@mapbox/mapbox-gl-draw": "^1.5.0",
     "mapbox-gl": "^3.9.4",
     "next": "^15.1.9",
     "next-auth": "5.0.0-beta.30",
@@ -39,8 +40,8 @@
     "react-dom": "^19.2.1",
     "react-toastify": "^11.0.5",
     "swr": "^2.2.4",
-    "threebox-plugin": "2.2.7",
     "three": "^0.170.0",
+    "threebox-plugin": "2.2.7",
     "uuid": "^11.1.0",
     "zod": "^3.24.2",
     "zustand": "^5.0.3"
@@ -48,8 +49,11 @@
   "devDependencies": {
     "@types/mapbox__mapbox-gl-draw": "^1.4.9",
     "@types/uuid": "^9.0.8",
+    "autoprefixer": "10.4.20",
     "eslint": "^8.56.0",
     "eslint-config-next": "^15.1.9",
+    "postcss": "8.4.47",
+    "tailwindcss": "3.4.14",
     "typescript": "^5.9.0"
   }
 }

--- a/apps/campus/postcss.config.mjs
+++ b/apps/campus/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/campus/tailwind.config.ts
+++ b/apps/campus/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from "tailwindcss";
+import preset from "@klorad/design-system/tailwind-preset";
+
+const config: Config = {
+  presets: [preset],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    // Scan the shared design system so its component classes are generated.
+    "../../packages/design-system/src/**/*.{ts,tsx}",
+  ],
+  corePlugins: {
+    // Preflight is off while MUI and Tailwind coexist: Tailwind only adds
+    // utilities here, it does not reset element styles. Re-enable once the
+    // last MUI screen is migrated (end of Phase 2).
+    preflight: false,
+  },
+};
+
+export default config;

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@klorad/design-system",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Klorad's shared design system — tokens, Tailwind preset, theme, and components. The visual backbone for every Klorad app.",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./tailwind-preset": "./src/tailwind-preset.ts",
+    "./tokens.css": "./src/styles/tokens.css"
+  },
+  "dependencies": {
+    "next-themes": "^0.4.6"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.9.0"
+  }
+}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -11,7 +11,9 @@
     "./tokens.css": "./src/styles/tokens.css"
   },
   "dependencies": {
-    "next-themes": "^0.4.6"
+    "clsx": "^2.1.1",
+    "next-themes": "^0.4.6",
+    "tailwind-merge": "^3.6.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/design-system/src/components/app-shell.tsx
+++ b/packages/design-system/src/components/app-shell.tsx
@@ -27,6 +27,8 @@ const DefaultLink: LinkComponent = ({ href, className, children }) => (
 export type AppShellProps = {
   /** Brand block at the top of the sidebar (logo + name). */
   brand: ReactNode;
+  /** Optional node between the brand and the nav — e.g. an org/workspace switcher. */
+  sidebarHeader?: ReactNode;
   /** Primary navigation. */
   nav: NavItem[];
   /** Optional node pinned to the bottom of the sidebar (user menu, org switcher). */
@@ -47,6 +49,7 @@ export type AppShellProps = {
  */
 export function AppShell({
   brand,
+  sidebarHeader,
   nav,
   sidebarFooter,
   title,
@@ -59,6 +62,9 @@ export function AppShell({
   const sidebar = (
     <div className="flex h-full flex-col">
       <div className="flex h-16 shrink-0 items-center px-5">{brand}</div>
+      {sidebarHeader ? (
+        <div className="shrink-0 px-3 pb-2">{sidebarHeader}</div>
+      ) : null}
       <nav
         className="flex-1 space-y-1 overflow-y-auto px-3 py-2"
         onClick={() => setMobileOpen(false)}

--- a/packages/design-system/src/components/app-shell.tsx
+++ b/packages/design-system/src/components/app-shell.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import type { ComponentType, ReactNode } from "react";
+import { cn } from "../utils/cn";
+
+export type NavItem = {
+  label: string;
+  href: string;
+  icon?: ReactNode;
+  active?: boolean;
+};
+
+/** A link renderer — pass `next/link`'s `Link` so nav uses client routing. */
+type LinkComponent = ComponentType<{
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}>;
+
+const DefaultLink: LinkComponent = ({ href, className, children }) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export type AppShellProps = {
+  /** Brand block at the top of the sidebar (logo + name). */
+  brand: ReactNode;
+  /** Primary navigation. */
+  nav: NavItem[];
+  /** Optional node pinned to the bottom of the sidebar (user menu, org switcher). */
+  sidebarFooter?: ReactNode;
+  /** Optional top-bar title or breadcrumb (left side). */
+  title?: ReactNode;
+  /** Optional top-bar actions (right side) — theme toggle, etc. */
+  actions?: ReactNode;
+  /** Link component for nav items (e.g. `next/link`). Defaults to `<a>`. */
+  linkComponent?: LinkComponent;
+  children: ReactNode;
+};
+
+/**
+ * The management shell: a fixed sidebar, a top bar, and a scrolling content
+ * area. Used for account / dashboard surfaces. On small screens the sidebar
+ * collapses into a drawer.
+ */
+export function AppShell({
+  brand,
+  nav,
+  sidebarFooter,
+  title,
+  actions,
+  linkComponent: Link = DefaultLink,
+  children,
+}: AppShellProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const sidebar = (
+    <div className="flex h-full flex-col">
+      <div className="flex h-16 shrink-0 items-center px-5">{brand}</div>
+      <nav
+        className="flex-1 space-y-1 overflow-y-auto px-3 py-2"
+        onClick={() => setMobileOpen(false)}
+      >
+        {nav.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+              item.active
+                ? "bg-accent-soft text-text-primary"
+                : "text-text-secondary hover:bg-accent-soft hover:text-text-primary",
+            )}
+          >
+            {item.icon ? (
+              <span className="flex h-5 w-5 items-center justify-center">
+                {item.icon}
+              </span>
+            ) : null}
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+      {sidebarFooter ? (
+        <div className="shrink-0 border-t border-line-soft p-3">
+          {sidebarFooter}
+        </div>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className="flex h-screen bg-bg text-text-primary">
+      {/* Sidebar — desktop */}
+      <aside className="hidden w-64 shrink-0 border-r border-line-soft bg-surface-1 lg:block">
+        {sidebar}
+      </aside>
+
+      {/* Sidebar — mobile drawer */}
+      {mobileOpen ? (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden
+          />
+          <aside className="absolute left-0 top-0 h-full w-64 border-r border-line-soft bg-surface-1">
+            {sidebar}
+          </aside>
+        </div>
+      ) : null}
+
+      {/* Main column */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-16 shrink-0 items-center gap-3 border-b border-line-soft bg-surface-1 px-4 md:px-6">
+          <button
+            type="button"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Open menu"
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-line-soft text-text-secondary lg:hidden"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              aria-hidden
+            >
+              <path d="M3 6h18M3 12h18M3 18h18" />
+            </svg>
+          </button>
+          <div className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary">
+            {title}
+          </div>
+          {actions ? (
+            <div className="flex items-center gap-2">{actions}</div>
+          ) : null}
+        </header>
+        <main className="flex-1 overflow-y-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/avatar.tsx
+++ b/packages/design-system/src/components/avatar.tsx
@@ -1,0 +1,40 @@
+import { cn } from "../utils/cn";
+
+export type AvatarProps = {
+  src?: string | null;
+  /** Drives the initial fallback and the image alt text. */
+  name?: string | null;
+  /** Diameter in pixels. Default 32. */
+  size?: number;
+  className?: string;
+};
+
+/** A circular avatar — shows an image, or an initial fallback. */
+export function Avatar({ src, name, size = 32, className }: AvatarProps) {
+  const initial = (name?.trim()?.charAt(0) || "?").toUpperCase();
+
+  if (src) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={src}
+        alt={name ?? ""}
+        className={cn("shrink-0 rounded-full object-cover", className)}
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full bg-accent-soft font-semibold text-accent",
+        className,
+      )}
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}
+    >
+      {initial}
+    </span>
+  );
+}

--- a/packages/design-system/src/components/badge.tsx
+++ b/packages/design-system/src/components/badge.tsx
@@ -1,0 +1,30 @@
+import type { ComponentProps } from "react";
+import { cn } from "../utils/cn";
+
+export type BadgeTone = "neutral" | "accent" | "warning" | "danger";
+
+const toneClass: Record<BadgeTone, string> = {
+  neutral: "border-line-soft bg-surface-2 text-text-secondary",
+  accent: "border-transparent bg-accent-soft text-accent",
+  warning:
+    "border-amber-500/30 bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  danger: "border-red-500/30 bg-red-500/15 text-red-600 dark:text-red-400",
+};
+
+export type BadgeProps = ComponentProps<"span"> & {
+  tone?: BadgeTone;
+};
+
+/** A small status pill — roles, states, counts. */
+export function Badge({ tone = "neutral", className, ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+        toneClass[tone],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/design-system/src/components/badge.tsx
+++ b/packages/design-system/src/components/badge.tsx
@@ -1,11 +1,13 @@
 import type { ComponentProps } from "react";
 import { cn } from "../utils/cn";
 
-export type BadgeTone = "neutral" | "accent" | "warning" | "danger";
+export type BadgeTone = "neutral" | "accent" | "success" | "warning" | "danger";
 
 const toneClass: Record<BadgeTone, string> = {
   neutral: "border-line-soft bg-surface-2 text-text-secondary",
   accent: "border-transparent bg-accent-soft text-accent",
+  success:
+    "border-emerald-500/30 bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
   warning:
     "border-amber-500/30 bg-amber-500/15 text-amber-600 dark:text-amber-400",
   danger: "border-red-500/30 bg-red-500/15 text-red-600 dark:text-red-400",

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -23,12 +23,29 @@ const sizeClass: Record<ButtonSize, string> = {
   md: "h-10 px-4 text-sm",
 };
 
+/**
+ * The design-system button class string. Use this on anything that can't
+ * be a `<button>` — a Next.js `<Link>`, a mailto anchor, an external
+ * `<a target="_blank">`. For a real button, prefer `<Button>`.
+ */
+export function buttonClassName({
+  variant = "primary",
+  size = "md",
+  className,
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+} = {}) {
+  return cn(base, variantClass[variant], sizeClass[size], className);
+}
+
 export type ButtonProps = ComponentProps<"button"> & {
   variant?: ButtonVariant;
   size?: ButtonSize;
 };
 
-/** The standard action button. Variants: primary, secondary, ghost. */
+/** The standard action button. Variants: primary, secondary, ghost, danger. */
 export function Button({
   variant = "primary",
   size = "md",
@@ -39,9 +56,30 @@ export function Button({
   return (
     <button
       type={type}
-      className={cn(base, variantClass[variant], sizeClass[size], className)}
+      className={buttonClassName({ variant, size, className })}
       {...props}
     />
+  );
+}
+
+/**
+ * The design-system icon-button class string — same variants as
+ * `buttonClassName`, but square (h-8 w-8 for sm, h-10 w-10 for md).
+ */
+export function iconButtonClassName({
+  variant = "ghost",
+  size = "md",
+  className,
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+} = {}) {
+  return cn(
+    base,
+    variantClass[variant],
+    size === "sm" ? "h-8 w-8" : "h-10 w-10",
+    className,
   );
 }
 
@@ -61,12 +99,7 @@ export function IconButton({
   return (
     <button
       type={type}
-      className={cn(
-        base,
-        variantClass[variant],
-        size === "sm" ? "h-8 w-8" : "h-10 w-10",
-        className,
-      )}
+      className={iconButtonClassName({ variant, size, className })}
       {...props}
     />
   );

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -1,0 +1,72 @@
+import type { ComponentProps } from "react";
+import { cn } from "../utils/cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md";
+
+const base =
+  "inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent " +
+  "focus-visible:ring-offset-2 focus-visible:ring-offset-bg " +
+  "disabled:cursor-not-allowed disabled:opacity-50";
+
+const variantClass: Record<ButtonVariant, string> = {
+  primary: "bg-accent text-accent-contrast hover:bg-accent-hover",
+  secondary:
+    "border border-line-strong text-text-primary hover:border-accent hover:text-accent",
+  ghost: "text-text-secondary hover:bg-accent-soft hover:text-text-primary",
+};
+
+const sizeClass: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-xs",
+  md: "h-10 px-4 text-sm",
+};
+
+export type ButtonProps = ComponentProps<"button"> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+/** The standard action button. Variants: primary, secondary, ghost. */
+export function Button({
+  variant = "primary",
+  size = "md",
+  type = "button",
+  className,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(base, variantClass[variant], sizeClass[size], className)}
+      {...props}
+    />
+  );
+}
+
+export type IconButtonProps = ComponentProps<"button"> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+/** A square, icon-only button — same variants as Button. */
+export function IconButton({
+  variant = "ghost",
+  size = "md",
+  type = "button",
+  className,
+  ...props
+}: IconButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(
+        base,
+        variantClass[variant],
+        size === "sm" ? "h-8 w-8" : "h-10 w-10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "../utils/cn";
 
-export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 export type ButtonSize = "sm" | "md";
 
 const base =
@@ -15,6 +15,7 @@ const variantClass: Record<ButtonVariant, string> = {
   secondary:
     "border border-line-strong text-text-primary hover:border-accent hover:text-accent",
   ghost: "text-text-secondary hover:bg-accent-soft hover:text-text-primary",
+  danger: "bg-red-600 text-white hover:bg-red-700",
 };
 
 const sizeClass: Record<ButtonSize, string> = {

--- a/packages/design-system/src/components/field.tsx
+++ b/packages/design-system/src/components/field.tsx
@@ -1,0 +1,55 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "../utils/cn";
+
+const controlClass =
+  "w-full rounded-md border border-line-strong bg-surface-1 px-3 py-2 text-sm " +
+  "text-text-primary outline-none transition-colors placeholder:text-text-tertiary " +
+  "focus:border-accent disabled:cursor-not-allowed disabled:opacity-50";
+
+/** A single-line text input, styled to the design system. */
+export function Input({ className, type = "text", ...props }: ComponentProps<"input">) {
+  return <input type={type} className={cn(controlClass, className)} {...props} />;
+}
+
+/** A multi-line text input. */
+export function Textarea({ className, ...props }: ComponentProps<"textarea">) {
+  return (
+    <textarea className={cn(controlClass, "resize-y", className)} {...props} />
+  );
+}
+
+export type FieldProps = {
+  label: string;
+  htmlFor?: string;
+  hint?: string;
+  error?: string;
+  children: ReactNode;
+  className?: string;
+};
+
+/** A labelled form row — wraps any control with a label and a hint/error line. */
+export function Field({
+  label,
+  htmlFor,
+  hint,
+  error,
+  children,
+  className,
+}: FieldProps) {
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <label
+        htmlFor={htmlFor}
+        className="block text-xs font-medium uppercase tracking-[0.14em] text-text-tertiary"
+      >
+        {label}
+      </label>
+      {children}
+      {error ? (
+        <p className="text-xs text-red-500">{error}</p>
+      ) : hint ? (
+        <p className="text-xs text-text-tertiary">{hint}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/klorad-mark.tsx
+++ b/packages/design-system/src/components/klorad-mark.tsx
@@ -1,0 +1,62 @@
+export type KloradMarkProps = {
+  className?: string;
+  /** Accessible label; omit (and the mark is decorative) by passing "". */
+  title?: string;
+};
+
+/**
+ * The Klorad geometric brand mark. Fixed brand colors — it reads cleanly on
+ * both light and dark surfaces, so it does not need to theme.
+ */
+export function KloradMark({ className, title = "Klorad" }: KloradMarkProps) {
+  return (
+    <svg
+      viewBox="0 0 73 77"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      aria-label={title || undefined}
+      aria-hidden={title ? undefined : true}
+    >
+      <path d="M0 0.000232697H22L21.5 19.0002L0 0.000232697Z" fill="#0F396B" />
+      <path
+        d="M21.5 19.0002L0.00390625 38.5002L0 0.000232697L10.4834 9.26464L21.5 19.0002Z"
+        fill="#143E72"
+      />
+      <path
+        d="M72.4873 0.000465393L38 37L21.5 19.0002L40.9841 0L54.9873 0.000232697L72.4873 0.000465393Z"
+        fill="#27CEE7"
+      />
+      <path
+        d="M20.5 55.5L0.0078125 77.0002L0.00390625 38.5002L20.5 55.5Z"
+        fill="#0E3D71"
+      />
+      <path
+        d="M38 37L0.00390625 38.5002L21.5 19.0002L38 37Z"
+        fill="#14639A"
+      />
+      <path
+        d="M38 37L18.9873 37.7046L0.00390625 38.5002L20.5 55.5L38 37Z"
+        fill="#124B7E"
+      />
+      <path
+        d="M71.4873 73.0005L38 37L20.5 55.5L41.9873 73.0005H48.4873H71.4873Z"
+        fill="#27C2E2"
+      />
+      <path
+        d="M54.4798 19.0002H40.5H21.5L38 37L42 32.1678L54.4798 19.0002Z"
+        fill="#1589B6"
+      />
+      <path
+        d="M54.4798 19.0002L40.9841 0L21.5 19.0002H54.4798Z"
+        fill="#1DABD0"
+      />
+      <path d="M52.5 52.5L38 37L20.5 55.5L52.5 52.5Z" fill="#1589B6" />
+      <path
+        d="M52.5 52.5L20.5 55.5L41.9873 73.0005L52.5 52.5Z"
+        fill="#199FCA"
+      />
+    </svg>
+  );
+}

--- a/packages/design-system/src/components/menu.tsx
+++ b/packages/design-system/src/components/menu.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "../utils/cn";
+
+export type MenuProps = {
+  /** The clickable trigger element. */
+  trigger: ReactNode;
+  children: ReactNode;
+  /** Horizontal alignment of the panel against the trigger. Default `end`. */
+  align?: "start" | "end";
+  className?: string;
+};
+
+/**
+ * A dropdown menu anchored to a trigger. Manages its own open state;
+ * closes on outside click, Escape, or any click inside the panel.
+ */
+export function Menu({ trigger, children, align = "end", className }: MenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className={cn("relative inline-flex", className)}>
+      <span onClick={() => setOpen((v) => !v)}>{trigger}</span>
+      {open && (
+        <div
+          role="menu"
+          onClick={() => setOpen(false)}
+          className={cn(
+            "absolute top-full z-50 mt-1 min-w-[10rem] overflow-hidden rounded-lg",
+            "border border-line-soft bg-surface-1 py-1 shadow-glass",
+            align === "end" ? "right-0" : "left-0",
+          )}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type MenuItemProps = ComponentProps<"button"> & {
+  tone?: "default" | "danger";
+};
+
+/** A single row inside a `Menu`. */
+export function MenuItem({ tone = "default", className, ...props }: MenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      className={cn(
+        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors",
+        tone === "danger"
+          ? "text-red-600 hover:bg-red-500/10 dark:text-red-400"
+          : "text-text-secondary hover:bg-accent-soft hover:text-text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/design-system/src/components/modal.tsx
+++ b/packages/design-system/src/components/modal.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { cn } from "../utils/cn";
+
+export type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  /** Footer actions, right-aligned. */
+  footer?: ReactNode;
+  className?: string;
+};
+
+/**
+ * A centered overlay dialog. Closes on Escape or backdrop click; locks
+ * body scroll while open. Render it unconditionally — it returns null
+ * when `open` is false.
+ */
+export function Modal({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  className,
+}: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          "animate-fade-up relative w-full max-w-md rounded-2xl border border-line-soft bg-surface-1 shadow-glass",
+          className,
+        )}
+      >
+        {(title || description) && (
+          <div className="border-b border-line-soft px-5 py-4">
+            {title && (
+              <h2 className="text-sm font-semibold text-text-primary">
+                {title}
+              </h2>
+            )}
+            {description && (
+              <p className="mt-1 text-sm text-text-secondary">{description}</p>
+            )}
+          </div>
+        )}
+        {children && <div className="px-5 py-4">{children}</div>}
+        {footer && (
+          <div className="flex justify-end gap-2 border-t border-line-soft px-5 py-4">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/panel.tsx
+++ b/packages/design-system/src/components/panel.tsx
@@ -1,0 +1,25 @@
+import type { ComponentProps } from "react";
+import { cn } from "../utils/cn";
+
+export type PanelVariant = "surface" | "glass";
+
+const variantClass: Record<PanelVariant, string> = {
+  /* opaque elevated surface — the default for app content */
+  surface: "bg-surface-1 border border-line-soft",
+  /* translucent glass — for panels that float over a canvas */
+  glass: "glass-panel",
+};
+
+export type PanelProps = ComponentProps<"div"> & {
+  variant?: PanelVariant;
+};
+
+/** A surface container. Use `surface` for app content, `glass` to float over 3D. */
+export function Panel({ variant = "surface", className, ...props }: PanelProps) {
+  return (
+    <div
+      className={cn("rounded-xl", variantClass[variant], className)}
+      {...props}
+    />
+  );
+}

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -1,0 +1,35 @@
+import type { ComponentProps } from "react";
+import { cn } from "../utils/cn";
+
+export type SelectProps = ComponentProps<"select"> & {
+  /** Applied to the wrapper — use it for width (e.g. `w-40`). */
+  className?: string;
+};
+
+/** A native select, styled to match the design-system inputs. */
+export function Select({ className, ...props }: SelectProps) {
+  return (
+    <div className={cn("relative", className)}>
+      <select
+        className={cn(
+          "w-full appearance-none rounded-md border border-line-strong bg-surface-1",
+          "py-2 pl-3 pr-9 text-sm text-text-primary outline-none transition-colors",
+          "focus:border-accent disabled:cursor-not-allowed disabled:opacity-50",
+        )}
+        {...props}
+      />
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary"
+      >
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/spinner.tsx
+++ b/packages/design-system/src/components/spinner.tsx
@@ -1,0 +1,22 @@
+import { cn } from "../utils/cn";
+
+export type SpinnerProps = {
+  /** Diameter in pixels. Default 20. */
+  size?: number;
+  className?: string;
+};
+
+/** An indeterminate loading spinner. */
+export function Spinner({ size = 20, className }: SpinnerProps) {
+  return (
+    <span
+      role="status"
+      aria-label="Loading"
+      className={cn(
+        "inline-block animate-spin rounded-full border-2 border-line-strong border-t-accent",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -15,6 +15,8 @@ export { KloradMark, type KloradMarkProps } from "./components/klorad-mark";
 export {
   Button,
   IconButton,
+  buttonClassName,
+  iconButtonClassName,
   type ButtonProps,
   type IconButtonProps,
   type ButtonVariant,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -27,6 +27,17 @@ export {
   Textarea,
   type FieldProps,
 } from "./components/field";
+export { Avatar, type AvatarProps } from "./components/avatar";
+export { Badge, type BadgeProps, type BadgeTone } from "./components/badge";
+export { Spinner, type SpinnerProps } from "./components/spinner";
+export { Select, type SelectProps } from "./components/select";
+export { Modal, type ModalProps } from "./components/modal";
+export {
+  Menu,
+  MenuItem,
+  type MenuProps,
+  type MenuItemProps,
+} from "./components/menu";
 export {
   AppShell,
   type AppShellProps,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -6,5 +6,23 @@
  * - Theme + components: this entry point
  */
 
+export { cn } from "./utils/cn";
+
 export { ThemeProvider } from "./theme/theme-provider";
 export { ThemeToggle } from "./theme/theme-toggle";
+
+export {
+  Button,
+  IconButton,
+  type ButtonProps,
+  type IconButtonProps,
+  type ButtonVariant,
+  type ButtonSize,
+} from "./components/button";
+export { Panel, type PanelProps, type PanelVariant } from "./components/panel";
+export {
+  Field,
+  Input,
+  Textarea,
+  type FieldProps,
+} from "./components/field";

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @klorad/design-system — the shared visual backbone for every Klorad app.
+ *
+ * - Design tokens: `@klorad/design-system/tokens.css`
+ * - Tailwind preset: `@klorad/design-system/tailwind-preset`
+ * - Theme + components: this entry point
+ */
+
+export { ThemeProvider } from "./theme/theme-provider";
+export { ThemeToggle } from "./theme/theme-toggle";

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -11,6 +11,7 @@ export { cn } from "./utils/cn";
 export { ThemeProvider } from "./theme/theme-provider";
 export { ThemeToggle } from "./theme/theme-toggle";
 
+export { KloradMark, type KloradMarkProps } from "./components/klorad-mark";
 export {
   Button,
   IconButton,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -26,3 +26,8 @@ export {
   Textarea,
   type FieldProps,
 } from "./components/field";
+export {
+  AppShell,
+  type AppShellProps,
+  type NavItem,
+} from "./components/app-shell";

--- a/packages/design-system/src/styles/tokens.css
+++ b/packages/design-system/src/styles/tokens.css
@@ -1,0 +1,125 @@
+/* ============================================================
+   Klorad design tokens — the shared visual backbone.
+   Light is the :root default; dark applies via the `.dark` class
+   (next-themes, attribute="class"). The teal accent #158CA3 is
+   constant across themes — only neutrals and glass shift.
+
+   Apps import this once: `@import "@klorad/design-system/tokens.css";`
+   ============================================================ */
+
+:root {
+  color-scheme: light;
+
+  /* surfaces — ascending elevation */
+  --bg: #eef1f4;
+  --surface-1: #ffffff;
+  --surface-2: #e7eaee;
+  --surface-3: #ffffff;
+
+  /* glass — translucent panels for the immersive layer */
+  --glass-bg: rgba(255, 255, 255, 0.72);
+  --glass-border: rgba(15, 23, 30, 0.1);
+  --glass-highlight: rgba(255, 255, 255, 0.9);
+
+  /* text */
+  --text-primary: #0b1116;
+  --text-secondary: #48535f;
+  --text-tertiary: #8a95a1;
+
+  /* lines */
+  --line-soft: rgba(12, 17, 22, 0.08);
+  --line-strong: #d3d9df;
+
+  /* accent — Klorad teal, constant across themes */
+  --accent: #158ca3;
+  --accent-hover: #126e83;
+  --accent-soft: rgba(21, 140, 163, 0.1);
+  --accent-contrast: #ffffff;
+  --accent-glow: rgba(21, 140, 163, 0.26);
+}
+
+.dark {
+  color-scheme: dark;
+
+  --bg: #04070a;
+  --surface-1: #090d12;
+  --surface-2: #11171d;
+  --surface-3: #1a2129;
+
+  --glass-bg: rgba(17, 23, 31, 0.62);
+  --glass-border: rgba(255, 255, 255, 0.09);
+  --glass-highlight: rgba(255, 255, 255, 0.06);
+
+  --text-primary: #e6ebf0;
+  --text-secondary: #9ba7b4;
+  --text-tertiary: #5e6a76;
+
+  --line-soft: rgba(255, 255, 255, 0.06);
+  --line-strong: #2a2f32;
+
+  --accent: #158ca3;
+  --accent-hover: #126e83;
+  --accent-soft: rgba(21, 140, 163, 0.16);
+  --accent-contrast: #ffffff;
+  --accent-glow: rgba(21, 140, 163, 0.4);
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text-primary);
+  font-family: var(--font-inter), "Inter", system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+  background-color: var(--accent);
+  color: var(--accent-contrast);
+}
+
+/* ── Surface helpers ───────────────────────────────────────── */
+
+.glass-panel {
+  background-color: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  backdrop-filter: blur(20px) saturate(160%);
+}
+
+.grid-field {
+  background-image:
+    linear-gradient(var(--line-soft) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line-soft) 1px, transparent 1px);
+  background-size: 64px 64px;
+}
+
+/* ── Motion ────────────────────────────────────────────────── */
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-up {
+  animation: fade-up 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/packages/design-system/src/tailwind-preset.ts
+++ b/packages/design-system/src/tailwind-preset.ts
@@ -1,0 +1,69 @@
+import type { Config } from "tailwindcss";
+
+/**
+ * Shared Tailwind preset for every Klorad app.
+ *
+ * Each app's `tailwind.config.ts` extends this:
+ *
+ *   import preset from "@klorad/design-system/tailwind-preset";
+ *   export default {
+ *     presets: [preset],
+ *     content: [
+ *       "./app/**\/*.{ts,tsx}",
+ *       "../../packages/design-system/src/**\/*.{ts,tsx}",
+ *     ],
+ *   } satisfies Config;
+ *
+ * Colors resolve to the CSS variables defined in `tokens.css`, so they
+ * flip automatically between light and dark.
+ */
+const preset: Omit<Config, "content"> = {
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--bg)",
+        "surface-1": "var(--surface-1)",
+        "surface-2": "var(--surface-2)",
+        "surface-3": "var(--surface-3)",
+        glass: {
+          DEFAULT: "var(--glass-bg)",
+          border: "var(--glass-border)",
+          highlight: "var(--glass-highlight)",
+        },
+        "text-primary": "var(--text-primary)",
+        "text-secondary": "var(--text-secondary)",
+        "text-tertiary": "var(--text-tertiary)",
+        "line-soft": "var(--line-soft)",
+        "line-strong": "var(--line-strong)",
+        accent: {
+          DEFAULT: "var(--accent)",
+          hover: "var(--accent-hover)",
+          soft: "var(--accent-soft)",
+          contrast: "var(--accent-contrast)",
+        },
+      },
+      fontFamily: {
+        sans: ["var(--font-inter)", "Inter", "system-ui", "sans-serif"],
+      },
+      maxWidth: {
+        container: "1200px",
+      },
+      boxShadow: {
+        glass: "0 16px 50px -20px rgba(0, 0, 0, 0.45)",
+        glow: "0 0 80px -16px var(--accent-glow)",
+      },
+      keyframes: {
+        "fade-up": {
+          from: { opacity: "0", transform: "translateY(16px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      animation: {
+        "fade-up": "fade-up 0.7s cubic-bezier(0.16, 1, 0.3, 1) both",
+      },
+    },
+  },
+};
+
+export default preset;

--- a/packages/design-system/src/theme/theme-provider.tsx
+++ b/packages/design-system/src/theme/theme-provider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+/**
+ * Wraps next-themes for every Klorad app. The theme is applied via the
+ * `.dark` class on <html>, matching the Tailwind preset (darkMode: "class").
+ *
+ * New visitors get the light theme by default — the OS preference is not
+ * used. The toggle still lets visitors switch to dark, and that choice is
+ * remembered. Apps that want different behaviour can override via props.
+ */
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="light"
+      enableSystem={false}
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/packages/design-system/src/theme/theme-toggle.tsx
+++ b/packages/design-system/src/theme/theme-toggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+
+/** A light/dark toggle button. The icon renders only after mount to avoid
+ *  hydration mismatches; the label is static for the same reason. */
+export function ThemeToggle({ className = "" }: { className?: string }) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle color theme"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className={`flex h-9 w-9 items-center justify-center rounded-full border border-line-soft text-text-secondary transition-colors hover:border-accent hover:text-text-primary ${className}`}
+    >
+      {mounted ? (
+        isDark ? (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+          </svg>
+        ) : (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
+          </svg>
+        )
+      ) : (
+        <span className="block h-4 w-4" />
+      )}
+    </button>
+  );
+}

--- a/packages/design-system/src/utils/cn.ts
+++ b/packages/design-system/src/utils/cn.ts
@@ -1,0 +1,10 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merge class names, resolving conflicting Tailwind utilities so a consumer's
+ * `className` reliably overrides a component's defaults.
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.lib.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -76,7 +76,15 @@ export function OrganizationSwitcher({
     null;
 
   return (
-    <Box sx={{ width: "100%", minWidth: 0, overflow: "hidden" }}>
+    <Box
+      sx={{
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
+        borderRadius: 1,
+        border: `1px solid ${theme.palette.divider}`,
+      }}
+    >
       <Accordion
         expanded={expanded}
         onChange={(_e, v) => setExpanded(v)}
@@ -91,12 +99,15 @@ export function OrganizationSwitcher({
           expandIcon={<ExpandMoreIcon />}
           sx={{
             minHeight: 56,
-            px: 2,
+            px: 1.5,
             py: 1.5,
-            borderBottom: `1px solid ${theme.palette.divider}`,
-            "&.Mui-expanded": { minHeight: 56, borderBottom: "none" },
+            "&.Mui-expanded": {
+              minHeight: 56,
+              borderBottom: `1px solid ${theme.palette.divider}`,
+            },
             "& .MuiAccordionSummary-content": {
               margin: 0,
+              minWidth: 0,
               alignItems: "center",
               "&.Mui-expanded": { margin: 0 },
             },
@@ -151,7 +162,7 @@ export function OrganizationSwitcher({
             }}
           />
         </AccordionSummary>
-        <AccordionDetails sx={{ p: 0, borderBottom: `1px solid ${theme.palette.divider}` }}>
+        <AccordionDetails sx={{ p: 0 }}>
           <List component="div" disablePadding>
             {organizations.length === 0 && !loading && (
               <ListItem disablePadding>
@@ -166,7 +177,13 @@ export function OrganizationSwitcher({
                 <ListItem key={org.id} disablePadding>
                   <Link
                     href={buildHref(org.id)}
-                    style={{ textDecoration: "none", color: "inherit", width: "100%" }}
+                    style={{
+                      textDecoration: "none",
+                      color: "inherit",
+                      width: "100%",
+                      minWidth: 0,
+                      display: "block",
+                    }}
                     onClick={(e) => e.stopPropagation()}
                   >
                     <ListItemButton
@@ -174,6 +191,7 @@ export function OrganizationSwitcher({
                       sx={{
                         pl: 6,
                         py: 1.25,
+                        minWidth: 0,
                         color: isSelected ? theme.palette.primary.main : "inherit",
                         backgroundColor: isSelected
                           ? alpha(theme.palette.primary.main, 0.18)

--- a/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/packages/ui/src/components/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -76,7 +76,7 @@ export function OrganizationSwitcher({
     null;
 
   return (
-    <Box sx={{ width: "100%" }}>
+    <Box sx={{ width: "100%", minWidth: 0, overflow: "hidden" }}>
       <Accordion
         expanded={expanded}
         onChange={(_e, v) => setExpanded(v)}
@@ -93,7 +93,7 @@ export function OrganizationSwitcher({
             minHeight: 56,
             px: 2,
             py: 1.5,
-            borderBottom: "1px solid rgba(255,255,255,0.08)",
+            borderBottom: `1px solid ${theme.palette.divider}`,
             "&.Mui-expanded": { minHeight: 56, borderBottom: "none" },
             "& .MuiAccordionSummary-content": {
               margin: 0,
@@ -151,7 +151,7 @@ export function OrganizationSwitcher({
             }}
           />
         </AccordionSummary>
-        <AccordionDetails sx={{ p: 0, borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+        <AccordionDetails sx={{ p: 0, borderBottom: `1px solid ${theme.palette.divider}` }}>
           <List component="div" disablePadding>
             {organizations.length === 0 && !loading && (
               <ListItem disablePadding>
@@ -197,6 +197,7 @@ export function OrganizationSwitcher({
                         primaryTypographyProps={{
                           fontSize: "0.8125rem",
                           fontWeight: isSelected ? 600 : 400,
+                          noWrap: true,
                         }}
                         secondaryTypographyProps={{
                           fontSize: "0.7rem",

--- a/packages/ui/src/components/UserAccountMenu/UserAccountMenu.tsx
+++ b/packages/ui/src/components/UserAccountMenu/UserAccountMenu.tsx
@@ -13,6 +13,7 @@ import {
   ListItemIcon,
   ListItemText,
   alpha,
+  useTheme,
 } from "@mui/material";
 import { ExpandMoreIcon, LogoutIcon, PersonIcon } from "../icons/Icons";
 
@@ -39,6 +40,10 @@ export interface UserAccountMenuProps {
  * inside an accordion summary. Expanding reveals Profile and Logout
  * rows. Presentational — pass a session in, wire navigation / logout
  * handlers from the calling app.
+ *
+ * Shares its shell (rounded bordered card, transparent accordion,
+ * divider-on-expand) with `OrganizationSwitcher` so the two sidebar
+ * controls read as the same element.
  */
 export function UserAccountMenu({
   name,
@@ -50,6 +55,7 @@ export function UserAccountMenu({
   profileActive = false,
   className,
 }: UserAccountMenuProps) {
+  const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
   const userName = name || email || "User";
   const initial = useMemo(
@@ -58,84 +64,85 @@ export function UserAccountMenu({
   );
 
   return (
-    <Box className={className} sx={{ width: "100%" }}>
+    <Box
+      className={className}
+      sx={{
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
+        borderRadius: 1,
+        border: `1px solid ${theme.palette.divider}`,
+      }}
+    >
       <Accordion
         expanded={expanded}
         onChange={(_e, v) => setExpanded(v)}
         sx={{
-          marginBottom: 0,
           boxShadow: "none",
+          backgroundColor: "transparent",
           "&:before": { display: "none" },
           "&.Mui-expanded": { margin: 0 },
-          backgroundColor: "transparent",
         }}
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          sx={(theme) => ({
-            backgroundColor:
-              theme.palette.mode === "dark"
-                ? theme.palette.background.paper
-                : "rgba(248,250,252,0.6)",
-            borderRadius: 0,
-            minHeight: 48,
-            p: theme.spacing(1.5, 2),
-            "&.Mui-expanded": { minHeight: 48 },
+          sx={{
+            minHeight: 56,
+            px: 1.5,
+            py: 1.5,
+            "&.Mui-expanded": {
+              minHeight: 56,
+              borderBottom: `1px solid ${theme.palette.divider}`,
+            },
             "& .MuiAccordionSummary-content": {
               margin: 0,
+              minWidth: 0,
+              alignItems: "center",
               "&.Mui-expanded": { margin: 0 },
             },
             "&:hover": {
-              backgroundColor: alpha(theme.palette.primary.main, 0.1),
+              backgroundColor: alpha(theme.palette.primary.main, 0.08),
               color: theme.palette.primary.main,
             },
             transition: "background-color 0.15s ease, color 0.15s ease",
-          })}
+          }}
         >
-          <Box sx={{ display: "flex", alignItems: "center", width: "100%" }}>
-            <Avatar
-              src={image ?? undefined}
-              alt={userName}
-              sx={{ width: 32, height: 32, mr: 1.5 }}
+          <Avatar
+            src={image ?? undefined}
+            alt={userName}
+            sx={{ width: 32, height: 32, mr: 1.5, fontSize: "0.875rem" }}
+          >
+            {initial}
+          </Avatar>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Box
+              sx={{
+                fontSize: "0.875rem",
+                fontWeight: 600,
+                letterSpacing: "0.01em",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
             >
-              {initial}
-            </Avatar>
-            <Box sx={{ flex: 1, minWidth: 0 }}>
+              {userName}
+            </Box>
+            {email && name && (
               <Box
                 sx={{
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
+                  fontSize: "0.7rem",
+                  color: "text.secondary",
                   overflow: "hidden",
                   textOverflow: "ellipsis",
                   whiteSpace: "nowrap",
                 }}
               >
-                {userName}
+                {email}
               </Box>
-              {email && name && (
-                <Box
-                  sx={{
-                    fontSize: "0.75rem",
-                    color: "text.secondary",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {email}
-                </Box>
-              )}
-            </Box>
+            )}
           </Box>
         </AccordionSummary>
-        <AccordionDetails
-          sx={(t) => ({
-            p: 0,
-            backgroundColor: "transparent",
-            borderBottom: "1px solid",
-            borderColor: alpha(t.palette.common.white, 0.08),
-          })}
-        >
+        <AccordionDetails sx={{ p: 0 }}>
           <List component="div" disablePadding>
             <ListItem disablePadding>
               <ListItemButton
@@ -145,14 +152,14 @@ export function UserAccountMenu({
                   onProfile?.();
                 }}
                 selected={profileActive}
-                sx={(theme) => ({
-                  pl: 6,
-                  borderRadius: 0,
-                  p: theme.spacing(1.5, 2),
+                sx={{
+                  pl: 1.5,
+                  py: 1.25,
+                  minWidth: 0,
+                  color: profileActive ? theme.palette.primary.main : "inherit",
                   backgroundColor: profileActive
                     ? alpha(theme.palette.primary.main, 0.18)
-                    : theme.palette.background.paper,
-                  color: profileActive ? "primary.main" : "text.primary",
+                    : "transparent",
                   "&.Mui-selected": {
                     backgroundColor: alpha(theme.palette.primary.main, 0.18),
                     color: theme.palette.primary.main,
@@ -161,19 +168,21 @@ export function UserAccountMenu({
                     },
                   },
                   "&:hover": {
-                    backgroundColor: profileActive
-                      ? alpha(theme.palette.primary.main, 0.24)
-                      : alpha(theme.palette.primary.main, 0.1),
-                    color: "primary.main",
+                    backgroundColor: alpha(theme.palette.primary.main, 0.08),
+                    color: theme.palette.primary.main,
                   },
-                })}
+                }}
               >
-                <ListItemIcon sx={{ minWidth: 40, color: "inherit" }}>
-                  <PersonIcon />
+                <ListItemIcon sx={{ minWidth: 36, color: "inherit" }}>
+                  <PersonIcon sx={{ fontSize: "1.25rem" }} />
                 </ListItemIcon>
                 <ListItemText
                   primary="Profile"
-                  primaryTypographyProps={{ fontSize: "0.875rem", fontWeight: profileActive ? 600 : 400 }}
+                  primaryTypographyProps={{
+                    fontSize: "0.8125rem",
+                    fontWeight: profileActive ? 600 : 400,
+                    noWrap: true,
+                  }}
                 />
               </ListItemButton>
             </ListItem>
@@ -183,22 +192,24 @@ export function UserAccountMenu({
                   e.stopPropagation();
                   onLogout();
                 }}
-                sx={(theme) => ({
-                  pl: 6,
-                  borderRadius: 0,
-                  p: theme.spacing(1.5, 2),
-                  backgroundColor: theme.palette.background.paper,
-                  color: "text.primary",
+                sx={{
+                  pl: 1.5,
+                  py: 1.25,
+                  minWidth: 0,
+                  color: "inherit",
                   "&:hover": {
                     backgroundColor: alpha(theme.palette.error.main, 0.12),
                     color: theme.palette.error.main,
                   },
-                })}
+                }}
               >
-                <ListItemIcon sx={{ minWidth: 40, color: "inherit" }}>
-                  <LogoutIcon />
+                <ListItemIcon sx={{ minWidth: 36, color: "inherit" }}>
+                  <LogoutIcon sx={{ fontSize: "1.25rem" }} />
                 </ListItemIcon>
-                <ListItemText primary="Sign out" primaryTypographyProps={{ fontSize: "0.875rem" }} />
+                <ListItemText
+                  primary="Sign out"
+                  primaryTypographyProps={{ fontSize: "0.8125rem", noWrap: true }}
+                />
               </ListItemButton>
             </ListItem>
           </List>

--- a/packages/ui/src/theme/ThemeModeProvider.tsx
+++ b/packages/ui/src/theme/ThemeModeProvider.tsx
@@ -22,7 +22,12 @@ export default function ThemeModeProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [mode, setMode] = useState<ThemeMode>(() => "dark");
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    if (typeof window === "undefined") return "light";
+    return window.localStorage.getItem("klorad-theme-mode") === "dark"
+      ? "dark"
+      : "light";
+  });
 
   useEffect(() => {
     if (typeof document !== "undefined") {

--- a/packages/ui/src/theme/ThemeModeProvider.tsx
+++ b/packages/ui/src/theme/ThemeModeProvider.tsx
@@ -24,7 +24,7 @@ export default function ThemeModeProvider({
 }) {
   const [mode, setMode] = useState<ThemeMode>(() => {
     if (typeof window === "undefined") return "light";
-    return window.localStorage.getItem("klorad-theme-mode") === "dark"
+    return window.localStorage.getItem("klorad-theme") === "dark"
       ? "dark"
       : "light";
   });
@@ -36,7 +36,7 @@ export default function ThemeModeProvider({
       else root.classList.remove("dark");
     }
     if (typeof window !== "undefined") {
-      window.localStorage.setItem("klorad-theme-mode", mode);
+      window.localStorage.setItem("klorad-theme", mode);
     }
   }, [mode]);
 

--- a/packages/ui/src/theme/theme.ts
+++ b/packages/ui/src/theme/theme.ts
@@ -12,7 +12,7 @@ const PRIMARY_ACTIVE = "#126E83";
 export const createAppTheme = (mode: ThemeMode): Theme =>
   createTheme({
     shape: {
-      borderRadius: 4,
+      borderRadius: 8,
     },
     palette: {
       mode,

--- a/packages/ui/src/theme/theme.ts
+++ b/packages/ui/src/theme/theme.ts
@@ -4,8 +4,10 @@ import { alpha, createTheme, Theme } from "@mui/material/styles";
 
 export type ThemeMode = "light" | "dark";
 
-const PRIMARY_BASE = "#6B9CD8";
-const PRIMARY_ACTIVE = "#4B6FAF";
+// Klorad teal — mirrors the @klorad/design-system accent so MUI surfaces
+// stay on-brand while the app migrates off MUI.
+const PRIMARY_BASE = "#158CA3";
+const PRIMARY_ACTIVE = "#126E83";
 
 export const createAppTheme = (mode: ThemeMode): Theme =>
   createTheme({
@@ -17,20 +19,20 @@ export const createAppTheme = (mode: ThemeMode): Theme =>
       primary: {
         main: PRIMARY_BASE,
         dark: PRIMARY_ACTIVE,
-        light: "#87ADD9",
+        light: "#3FB6CC",
         contrastText: "#FFFFFF",
       },
-      secondary: { main: mode === "dark" ? "#94a3b8" : "#646464" },
+      secondary: { main: mode === "dark" ? "#9BA7B4" : "#48535F" },
       background: {
-        default: mode === "dark" ? "#0E0F10" : "#ffffff",
-        paper: mode === "dark" ? "#14171A" : "#f8fafc",
+        default: mode === "dark" ? "#04070A" : "#EEF1F4",
+        paper: mode === "dark" ? "#11171D" : "#FFFFFF",
       },
       text: {
-        primary: mode === "dark" ? "#FFFFFF" : "#0f172a",
-        secondary: mode === "dark" ? "rgba(255, 255, 255, 0.65)" : "#475569",
+        primary: mode === "dark" ? "#E6EBF0" : "#0B1116",
+        secondary: mode === "dark" ? "#9BA7B4" : "#48535F",
       },
       divider:
-        mode === "dark" ? "rgba(255,255,255,0.08)" : "rgba(15,23,42,0.12)",
+        mode === "dark" ? "rgba(255,255,255,0.06)" : "rgba(12,17,22,0.08)",
       error: { main: mode === "dark" ? "#FF5656" : "#ef4444" },
     },
     typography: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@klorad/core':
         specifier: workspace:^
         version: link:../../packages/core
+      '@klorad/design-system':
+        specifier: workspace:^
+        version: link:../../packages/design-system
       '@klorad/engine-mapbox':
         specifier: workspace:^
         version: link:../../packages/engine-mapbox
@@ -324,12 +327,21 @@ importers:
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
+      autoprefixer:
+        specifier: 10.4.20
+        version: 10.4.20(postcss@8.4.47)
       eslint:
         specifier: ^8.56.0
         version: 8.57.1
       eslint-config-next:
         specifier: ^15.1.9
         version: 15.5.7(eslint@8.57.1)(typescript@5.9.3)
+      postcss:
+        specifier: 8.4.47
+        version: 8.4.47
+      tailwindcss:
+        specifier: 3.4.14
+        version: 3.4.14
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
@@ -4277,6 +4289,13 @@ packages:
     resolution: {integrity: sha512-vEfYZPmvVOIuE567XBVCsx8SBgOYtjB2+S1iAaJ+HgH+DNjAcrHem2hmAeC9yaNGWayicv4yR+9UaJlkF3pvtw==}
     engines: {pnpm: '>=10.10.0'}
 
+  autoprefixer@10.4.20:
+    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6007,6 +6026,10 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -6596,6 +6619,18 @@ packages:
     peerDependencies:
       postcss: ^8.4.21
 
+  postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -6676,6 +6711,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.47:
+    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.4.49:
@@ -7477,6 +7516,11 @@ packages:
   syncpack@13.0.4:
     resolution: {integrity: sha512-kJ9VlRxNCsBD5pJAE29oXeBYbPLhEySQmK4HdpsLv81I6fcDDW17xeJqMwiU3H7/woAVsbgq25DJNS8BeiN5+w==}
     engines: {node: '>=18.18.0'}
+    hasBin: true
+
+  tailwindcss@3.4.14:
+    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
 
   tailwindcss@3.4.18:
@@ -11931,6 +11975,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  autoprefixer@10.4.20(postcss@8.4.47):
+    dependencies:
+      browserslist: 4.27.0
+      caniuse-lite: 1.0.30001753
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.27.0
@@ -12734,8 +12788,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -12765,7 +12819,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -12776,7 +12830,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12795,17 +12849,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -12815,35 +12858,6 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
@@ -13918,6 +13932,8 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lilconfig@2.1.0: {}
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -14499,6 +14515,13 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-import@15.1.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.11
+
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -14506,10 +14529,22 @@ snapshots:
       read-cache: 1.0.0
       resolve: 1.22.11
 
+  postcss-js@4.1.0(postcss@8.4.47):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.47
+
   postcss-js@4.1.0(postcss@8.5.6):
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.5.6
+
+  postcss-load-config@4.0.2(postcss@8.4.47):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.8.1
+    optionalDependencies:
+      postcss: 8.4.47
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -14561,6 +14596,11 @@ snapshots:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
 
+  postcss-nested@6.2.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
+
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -14586,6 +14626,12 @@ snapshots:
       quote-unquote: 1.0.0
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.4.47:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -15544,6 +15590,33 @@ snapshots:
       ts-toolbelt: 9.6.0
     transitivePeerDependencies:
       - typescript
+
+  tailwindcss@3.4.14:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 2.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.4.47
+      postcss-import: 15.1.0(postcss@8.4.47)
+      postcss-js: 4.1.0(postcss@8.4.47)
+      postcss-load-config: 4.0.2(postcss@8.4.47)
+      postcss-nested: 6.2.0(postcss@8.4.47)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.11
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
 
   tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,31 @@ importers:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@19.2.7)(react@19.2.1)
 
+  packages/design-system:
+    dependencies:
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.7)
+      tailwindcss:
+        specifier: ^3.4.14
+        version: 3.4.18(tsx@4.20.6)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+
   packages/dev-audits:
     dependencies:
       glob:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,9 @@ importers:
 
   packages/design-system:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -738,6 +741,9 @@ importers:
       react-dom:
         specifier: ^19.2.1
         version: 19.2.1(react@19.2.1)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
     devDependencies:
       '@types/react':
         specifier: ^19.0.0
@@ -7518,6 +7524,9 @@ packages:
     engines: {node: '>=18.18.0'}
     hasBin: true
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
   tailwindcss@3.4.14:
     resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
     engines: {node: '>=14.0.0'}
@@ -12789,7 +12798,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -12830,7 +12839,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12849,6 +12858,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -12858,6 +12878,35 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
@@ -15590,6 +15639,8 @@ snapshots:
       ts-toolbelt: 9.6.0
     transitivePeerDependencies:
       - typescript
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@3.4.14:
     dependencies:


### PR DESCRIPTION
## Summary

Builds out `@klorad/design-system` into a real component kit and migrates every non-builder surface of `apps/campus` onto it. Drops MUI from those screens.

## What's in the design system now

The package started this branch with just `Button`, `IconButton`, `Panel`, `Field` / `Input` / `Textarea`, and `AppShell`. It now also exports:

- **`Modal`** — centred overlay; Escape / backdrop close, scroll lock
- **`Menu` / `MenuItem`** — dropdown anchored to a trigger, outside-click close
- **`Select`** — native `<select>` styled to match the DS inputs
- **`Avatar`** — image with an initial fallback
- **`Badge`** — neutral / accent / success / warning / danger
- **`Spinner`** — indeterminate loader
- **`buttonClassName` / `iconButtonClassName`** — helpers so a `<Link>`, mailto, or external `<a target="_blank">` can wear the button look without nesting a `<button>` inside an anchor

Plus a `danger` variant on `Button` and a `success` tone on `Badge`.

## Campus screens migrated

Every dashboard / management surface is on the design system now:

- **Dashboard** — stacked Klorad / Campus wordmark, full-width container, quiet card hover
- **Campuses (`/maps`)** — DS card grid, `Menu` per card, `Modal` create + delete flows
- **Members** — DS `Panel` + table, inline role `Select`, `Avatar` / `Badge` rows, `Modal` invite / share-link / remove / cancel
- **Settings → General** — DS `Field` / `Input` / `Button`; MUI `Alert` / `CircularProgress` replaced with a token-themed callout + DS `Spinner`
- **Settings → Usage** — DS `Panel` + the shared `StatCard` layout
- **Profile** — DS `Panel` cards + a themed avatar
- **Map detail (`/maps/[mapId]`)** — underline tab bar replacing MUI `Tabs`; Overview / Settings / Integrations all on DS
- **`LocationsHeader`** — `glass-panel` pill, DS `Button`, brand-accent marker pin
- **Onboarding** — theme-aware, `KloradMark` instead of the hardcoded white logo
- **Sign-in** — drops `OAuthSignInCard` / `GoogleIcon` from `@klorad/ui`; inline DS `Panel` card with a 4-path Google "G" SVG

The org switcher and user menu were also rebuilt on a shared shell (rounded bordered card, divider-only-when-expanded, name / email truncation).

## Still on MUI (deliberately)

The Builder / Studio (`maps/[mapId]/builder/*`, ~3,600 lines). This is the **Workbench** from the architecture discussion — open view registry, dock layout, operations decoupled from views. A straight MUI → DS swap would lock in today's layout, which is the trap the Workbench redesign exists to avoid. Worth scoping before writing code.

`@mui/icons-material` glyphs are kept everywhere — they're pure SVGs, not a MUI surface.

## Worth knowing

- **`Select`** is a native `<select>` — reliable and accessible, but the *open option list* is OS-styled. A custom-listbox version can come later if needed.
- **`Modal` / `Menu`** have no focus trap yet — fine for v1, polish item.
- The app hasn't been run end-to-end — TypeScript, ESLint, and the pre-push build all pass, but the create / delete / invite flows deserve a click-through.

## Test plan

- [ ] Sign in works (Google + GitHub)
- [ ] Light is the default theme; toggle persists
- [ ] Dashboard renders, nav active states correct
- [ ] Campuses list — create a map (`Modal`), delete a map (`Modal`), per-card `Menu`
- [ ] Members — invite, copy invite URL, change role, remove member, cancel invite
- [ ] Settings → General — save works, role guards correct
- [ ] Map detail tabs — Overview / Settings / Integrations
- [ ] `LocationsHeader` — map preview, "Fit to extent", pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
