### PR TITLE
Workbench Phase 1.2: campus entity registrations

### DIFF
--- a/apps/campus/lib/workbench/entities/building.ts
+++ b/apps/campus/lib/workbench/entities/building.ts
@@ -1,0 +1,50 @@
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+/**
+ * A building as a first-class campus entity. Today the codebase stores
+ * the same shape nested inside `POI.linkedBuilding`; the Workbench
+ * promotes it to a peer of POI so:
+ *
+ * - Multiple POIs can reference the same building without duplication.
+ * - Buildings can be authored independently of any POI.
+ * - Floor plans attach to a building, not to a POI.
+ *
+ * Defined here rather than imported from `@klorad/api` because no
+ * standalone `Building` type exists there yet — the Workbench is the
+ * first place that needs one.
+ */
+export interface Building {
+  id: string;
+  /** Display label shown in panels and on hover. */
+  name: string;
+  /** Centroid as [lng, lat] — used to fly to the building. */
+  centroid: [number, number];
+  /**
+   * Closed polygon ring in [lng, lat]. When set, the renderer draws a
+   * fill-extrusion using `heightM`. When absent, the building is
+   * derived from a Mapbox basemap feature via `mapboxFeatureId`.
+   */
+  polygon?: [number, number][];
+  /** Extrusion height in metres. */
+  heightM?: number;
+  /** Mapbox feature id when the building is derived from the basemap. */
+  mapboxFeatureId?: string | number;
+  /** Raw Mapbox feature properties (name, height, …) when available. */
+  properties?: Record<string, unknown>;
+}
+
+const defaults: Building = {
+  id: "",
+  name: "",
+  centroid: [0, 0],
+};
+
+export const buildingEntity: EntityType<Building> = {
+  id: "campus.building",
+  label: "Building",
+  schema: identitySchema<Building>(),
+  defaults,
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/entities/event.ts
+++ b/apps/campus/lib/workbench/entities/event.ts
@@ -1,0 +1,27 @@
+import type { POIEvent } from "@klorad/api";
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+const defaults: POIEvent = {
+  id: "",
+  title: "",
+  startsAt: "",
+  endsAt: "",
+};
+
+/**
+ * Event — a scheduled occurrence at a POI (lecture, workshop, tour,
+ * exhibition). Today stored as a nested array on POI; the Workbench
+ * promotes it to a first-class entity so events can be authored,
+ * filtered, and shown on a Timeline view independently of POIs.
+ *
+ * The runtime payload mirrors `@klorad/api`'s `POIEvent` interface.
+ */
+export const eventEntity: EntityType<POIEvent> = {
+  id: "campus.event",
+  label: "Event",
+  schema: identitySchema<POIEvent>(),
+  defaults,
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/entities/floor-plan.ts
+++ b/apps/campus/lib/workbench/entities/floor-plan.ts
@@ -1,0 +1,22 @@
+import type { FloorPlan } from "@klorad/api";
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+const defaults: FloorPlan = {
+  id: "",
+};
+
+/**
+ * Floor plan — an image (or placeholder) tied to a building floor.
+ * Rooms can be drawn on top of it. The runtime shape today is
+ * `@klorad/api`'s `FloorPlan` interface; the Workbench reads it via
+ * this typed registration.
+ */
+export const floorPlanEntity: EntityType<FloorPlan> = {
+  id: "campus.floor-plan",
+  label: "Floor plan",
+  schema: identitySchema<FloorPlan>(),
+  defaults,
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/entities/index.ts
+++ b/apps/campus/lib/workbench/entities/index.ts
@@ -1,0 +1,5 @@
+export { poiEntity } from "./poi";
+export { buildingEntity, type Building } from "./building";
+export { floorPlanEntity } from "./floor-plan";
+export { tourStopEntity } from "./tour-stop";
+export { eventEntity } from "./event";

--- a/apps/campus/lib/workbench/entities/poi.ts
+++ b/apps/campus/lib/workbench/entities/poi.ts
@@ -1,0 +1,30 @@
+import type { POI } from "@klorad/api";
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+/** Sensible empty defaults for a fresh POI. */
+const defaults: POI = {
+  id: "",
+  name: "",
+  objectId: "",
+  position: [0, 0, 0],
+};
+
+/**
+ * Point of interest — the meaningful unit of a campus map. A POI carries
+ * a position, an optional category, optional media, accessibility info,
+ * and an optional link to a Building.
+ *
+ * The runtime shape today is `@klorad/api`'s `POI` interface; the
+ * Workbench reads the same shape via this typed registration.
+ */
+export const poiEntity: EntityType<POI> = {
+  id: "campus.poi",
+  label: "POI",
+  schema: identitySchema<POI>(),
+  defaults,
+  // Filled in as the Workbench shell + views and operations come online
+  // in Phase 2 and Phase 4–5.
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/entities/tour-stop.ts
+++ b/apps/campus/lib/workbench/entities/tour-stop.ts
@@ -1,0 +1,26 @@
+import type { TourStop } from "@klorad/api";
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+const defaults: TourStop = {
+  id: 0,
+  title: "",
+  description: "",
+  cameraPosition: null,
+  cameraTarget: null,
+};
+
+/**
+ * Tour stop — a guided camera waypoint with a title, description, and
+ * camera framing. Multiple stops form a tour the public viewer can play
+ * back. The runtime shape today is `@klorad/api`'s `TourStop`; the
+ * Workbench reads it via this typed registration.
+ */
+export const tourStopEntity: EntityType<TourStop> = {
+  id: "campus.tour-stop",
+  label: "Tour stop",
+  schema: identitySchema<TourStop>(),
+  defaults,
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/index.ts
+++ b/apps/campus/lib/workbench/index.ts
@@ -1,0 +1,15 @@
+/**
+ * The campus Workbench module — campus's typed entities, operations,
+ * and views that the shared Workbench shell will consume.
+ *
+ * Phase 1.2 — entity registrations only. Views land in Phase 3 (after
+ * the shell), operations in Phase 5 (after views). See
+ * `apps/campus/WORKBENCH.md` for the full migration plan.
+ *
+ * No runtime behaviour change yet: nothing in the builder reads these
+ * registrations. They sit alongside the existing code paths, ready
+ * for the shell.
+ */
+
+export * from "./entities";
+export { identitySchema } from "./schema";

--- a/apps/campus/lib/workbench/schema.ts
+++ b/apps/campus/lib/workbench/schema.ts
@@ -1,0 +1,15 @@
+import type { EntitySchema } from "@klorad/config/workbench";
+
+/**
+ * A no-op `EntitySchema` — `parse` is identity, `safeParse` always
+ * succeeds. The Phase 1 entity registrations declare the typed surface
+ * without yet running runtime validation; when the Workbench shell
+ * starts loading entities from the server (Phase 2+) these get swapped
+ * for real zod schemas (or equivalent).
+ */
+export function identitySchema<T>(): EntitySchema<T> {
+  return {
+    parse: (value) => value as T,
+    safeParse: (value) => ({ success: true, data: value as T }),
+  };
+}

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@klorad/api": "workspace:^",
+    "@klorad/config": "workspace:^",
     "@klorad/core": "workspace:^",
     "@klorad/design-system": "workspace:^",
     "@klorad/engine-mapbox": "workspace:^",

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -1,0 +1,41 @@
+import { defineWorkbench } from "@klorad/config/workbench";
+import {
+  poiEntity,
+  buildingEntity,
+  floorPlanEntity,
+  tourStopEntity,
+  eventEntity,
+} from "@/lib/workbench";
+
+/**
+ * The campus vertical's Workbench configuration.
+ *
+ * Phase 1.2 — entities declared. Views, operations and the default
+ * layout fill in as Phase 2–5 land (see `WORKBENCH.md` §10).
+ *
+ * Today nothing imports this file at runtime: the existing
+ * `maps/[mapId]/builder/*` route keeps rendering off `Map.sceneData`.
+ * The config exists so the shape compiles end-to-end, so the next
+ * phase can mount the shell off `import workbenchConfig from
+ * "@/workbench.config"` with no plumbing surprises.
+ */
+const workbenchConfig = defineWorkbench({
+  vertical: "campus",
+  entities: [
+    poiEntity,
+    buildingEntity,
+    floorPlanEntity,
+    tourStopEntity,
+    eventEntity,
+  ],
+  views: [],
+  operations: [],
+  defaultLayout: {
+    left: [],
+    center: [],
+    right: [],
+    bottom: [],
+  },
+});
+
+export default workbenchConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@klorad/api':
         specifier: workspace:^
         version: link:../../packages/api
+      '@klorad/config':
+        specifier: workspace:^
+        version: link:../../packages/config
       '@klorad/core':
         specifier: workspace:^
         version: link:../../packages/core


### PR DESCRIPTION
## Summary

Phase 1.2 of the Workbench migration. Layers typed campus entities on top of the contracts from PR #111. **No behaviour change** — the existing builder under `apps/campus/maps/[mapId]/builder/*` keeps reading `Map.sceneData`; these typed registrations sit alongside it, ready for the Workbench shell that lands in Phase 2.

11 files added, +235 lines, all in `apps/campus/`.

## What's added

Under `apps/campus/lib/workbench/`:

| File | Entity id | Payload type |
|---|---|---|
| `entities/poi.ts` | `campus.poi` | `POI` from `@klorad/api` |
| `entities/building.ts` | `campus.building` | New `Building` type (see below) |
| `entities/floor-plan.ts` | `campus.floor-plan` | `FloorPlan` from `@klorad/api` |
| `entities/tour-stop.ts` | `campus.tour-stop` | `TourStop` from `@klorad/api` |
| `entities/event.ts` | `campus.event` | `POIEvent` from `@klorad/api` |
| `schema.ts` | — | `identitySchema<T>()` helper |
| `entities/index.ts`, `index.ts` | — | Barrels |

And at the app root:

- `apps/campus/workbench.config.ts` — wires the five entities into a `defineWorkbench({ vertical: "campus", … })` call. Views, operations and the default layout stay empty for now; they fill in as Phase 2–5 land.

## Two design decisions worth flagging

### `Building` is a new type

Today the same shape lives nested inside `POI.linkedBuilding`. The Workbench promotes it to a peer of POI so:

- Multiple POIs can reference the same building without duplication
- Buildings can be authored independently of any POI
- Floor plans attach to a building, not to a POI

The new shape (`apps/campus/lib/workbench/entities/building.ts`):

```ts
export interface Building {
  id: string;
  name: string;
  centroid: [number, number];
  polygon?: [number, number][];
  heightM?: number;
  mapboxFeatureId?: string | number;
  properties?: Record<string, unknown>;
}
```

No data migration in this PR — instances still live in `POI.linkedBuilding`. The shape is what the Workbench will consume going forward, with the reconciliation happening when the Workbench actually starts loading entities (Phase 2+).

### `identitySchema` instead of zod schemas

Every `EntityType<T>` needs a `schema: EntitySchema<T>`. For Phase 1.2 the schemas are no-ops:

```ts
export function identitySchema<T>(): EntitySchema<T> {
  return {
    parse: (value) => value as T,
    safeParse: (value) => ({ success: true, data: value as T }),
  };
}
```

Phase 1.2 declares the typed surface without yet running runtime validation; nothing is loading entities from the server. The campus app already depends on zod 3.x (for forms) — when the Workbench shell starts loading entities, these get swapped for real zod schemas with no peer-dep cost.

## Dependency added

Campus now declares `@klorad/config: workspace:^` directly. It was a transitive dep through other workspace packages but never declared explicitly — and TypeScript needs the explicit dependency for the `@klorad/config/workbench` subpath to resolve.

## Worth knowing

- **Nothing imports `workbench.config.ts` at runtime yet.** It exists so the shape compiles end-to-end and so Phase 2 can mount the shell off `import workbenchConfig from "@/workbench.config"` with no plumbing surprises.
- **`@klorad/config` is a built package**, not source-consumed. The Phase 1.1 PR's dist (`packages/config/dist/workbench/`) is what consumers see. CI's `build:packages` step rebuilds it on deploy.
- **Lint-staged ran eslint --fix on 9 files** without complaints — no manual cleanups needed.

## Test plan

- [x] `@klorad/config` builds (Phase 1.1 dist is intact)
- [x] Typecheck: `@klorad/config`, campus, editor, admin, website all clean
- [x] Pre-commit + pre-push hooks pass
- [ ] Confirm the existing `/maps/[mapId]/builder` still renders identically (it shouldn't move — nothing imports the new registrations yet)
- [ ] Spot-check `workbench.config.ts` opens in an editor with type-aware autocomplete on `defineWorkbench`'s argument

## Next

**Phase 2 — build the Workbench shell.** Per `apps/campus/WORKBENCH.md` §10:

- Dock primitive in `@klorad/design-system` (four named regions: left / center / right / bottom)
- View registry + `EntityIndex` implementation in `@klorad/config`
- A new `/maps/[mapId]/workbench` route that mounts the shell with a single placeholder view, off `import workbenchConfig from "@/workbench.config"`
- The old `/builder` route stays untouched until Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
