### PR TITLE
Workbench Phase 2: the shell — dock + view registry + /workbench route

### DIFF
--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -79,9 +79,11 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
   const { organization: currentOrganization, loadingOrganization } =
     useOrganization(orgId);
 
-  // Builder routes have their own dedicated layout — no dashboard shell.
-  const isBuilder = pathname?.includes("/builder") ?? false;
-  if (isBuilder) {
+  // Builder + Workbench routes own the full viewport — no dashboard shell.
+  const isFullScreen =
+    (pathname?.includes("/builder") ?? false) ||
+    (pathname?.includes("/workbench") ?? false);
+  if (isFullScreen) {
     return <main className="min-h-screen">{children}</main>;
   }
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Workbench } from "@klorad/design-system";
+import workbenchConfig from "@/workbench.config";
+
+interface Props {
+  mapId: string;
+}
+
+/**
+ * Mounts the shared Workbench shell with the campus config. v1 just
+ * renders a placeholder Map view in the centre region; Phase 3 wraps
+ * the real 3D scene as that view.
+ *
+ * The `DashboardShell` deliberately bypasses its top-bar / sidebar
+ * chrome for `/workbench` routes — same as `/builder` — so the shell
+ * gets the full viewport.
+ */
+export default function WorkbenchClient({ mapId }: Props) {
+  return (
+    <div className="h-screen w-screen">
+      <Workbench config={workbenchConfig} worldId={mapId} />
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/page.tsx
@@ -1,0 +1,14 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import WorkbenchClient from "./WorkbenchClient";
+
+export default async function WorkbenchPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { mapId } = await params;
+  return <WorkbenchClient mapId={mapId} />;
+}

--- a/apps/campus/lib/workbench/index.ts
+++ b/apps/campus/lib/workbench/index.ts
@@ -1,15 +1,14 @@
 /**
- * The campus Workbench module — campus's typed entities, operations,
- * and views that the shared Workbench shell will consume.
+ * The campus Workbench module — campus's typed entities, views, and
+ * operations that the shared Workbench shell consumes.
  *
- * Phase 1.2 — entity registrations only. Views land in Phase 3 (after
- * the shell), operations in Phase 5 (after views). See
- * `apps/campus/WORKBENCH.md` for the full migration plan.
+ * - Phase 1.2 — entity registrations
+ * - Phase 2 — a placeholder map view
+ * - Phase 5 — operations (TBD)
  *
- * No runtime behaviour change yet: nothing in the builder reads these
- * registrations. They sit alongside the existing code paths, ready
- * for the shell.
+ * See `apps/campus/WORKBENCH.md` for the full migration plan.
  */
 
 export * from "./entities";
+export * from "./views";
 export { identitySchema } from "./schema";

--- a/apps/campus/lib/workbench/views/index.ts
+++ b/apps/campus/lib/workbench/views/index.ts
@@ -1,0 +1,1 @@
+export { mapView } from "./map";

--- a/apps/campus/lib/workbench/views/map.tsx
+++ b/apps/campus/lib/workbench/views/map.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { View, ViewProps } from "@klorad/config/workbench";
+
+/**
+ * Phase 2 placeholder. Phase 3 wraps the existing builder 3D scene
+ * (today: `apps/campus/maps/[mapId]/builder/BuilderClient`) as a
+ * `View` that talks to the entity index rather than its own state.
+ */
+function MapViewComponent({ ctx }: ViewProps) {
+  return (
+    <div className="flex h-full items-center justify-center bg-bg p-8 text-center">
+      <div className="max-w-md">
+        <span className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+          Map view
+        </span>
+        <h2 className="mt-3 text-lg font-medium text-text-primary">
+          The Workbench shell is mounted.
+        </h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          Editing world{" "}
+          <code className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[0.8em] text-text-primary">
+            {ctx.worldId}
+          </code>
+          . Phase 3 wraps the existing 3D scene here as a real View.
+        </p>
+        <p className="mt-4 text-xs text-text-tertiary">
+          Selection: {ctx.selection.ids.size} entit
+          {ctx.selection.ids.size === 1 ? "y" : "ies"} ·{" "}
+          {ctx.entities.all().length} loaded
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function MapIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <polygon points="1 6 8 3 16 6 23 3 23 18 16 21 8 18 1 21 1 6" />
+      <line x1="8" y1="3" x2="8" y2="18" />
+      <line x1="16" y1="6" x2="16" y2="21" />
+    </svg>
+  );
+}
+
+export const mapView: View = {
+  id: "map",
+  label: "Map",
+  icon: MapIcon,
+  entityTypes: "*",
+  defaultDock: "center",
+  component: MapViewComponent,
+};

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -5,19 +5,21 @@ import {
   floorPlanEntity,
   tourStopEntity,
   eventEntity,
+  mapView,
 } from "@/lib/workbench";
 
 /**
  * The campus vertical's Workbench configuration.
  *
- * Phase 1.2 — entities declared. Views, operations and the default
- * layout fill in as Phase 2–5 land (see `WORKBENCH.md` §10).
+ * - Phase 1.2 — five typed entities registered
+ * - Phase 2   — one placeholder `mapView` in the centre region
+ * - Phase 3+  — real views (Map / Table / Hierarchy / Overview),
+ *                operations, populated dock layout
  *
- * Today nothing imports this file at runtime: the existing
- * `maps/[mapId]/builder/*` route keeps rendering off `Map.sceneData`.
- * The config exists so the shape compiles end-to-end, so the next
- * phase can mount the shell off `import workbenchConfig from
- * "@/workbench.config"` with no plumbing surprises.
+ * Imported by `/maps/[mapId]/workbench/page.tsx` at runtime; the old
+ * `/maps/[mapId]/builder` route stays untouched until Phase 6.
+ *
+ * See `apps/campus/WORKBENCH.md` §10 for the full migration plan.
  */
 const workbenchConfig = defineWorkbench({
   vertical: "campus",
@@ -28,11 +30,11 @@ const workbenchConfig = defineWorkbench({
     tourStopEntity,
     eventEntity,
   ],
-  views: [],
+  views: [mapView],
   operations: [],
   defaultLayout: {
     left: [],
-    center: [],
+    center: ["map"],
     right: [],
     bottom: [],
   },

--- a/packages/config/src/workbench/index.ts
+++ b/packages/config/src/workbench/index.ts
@@ -17,3 +17,4 @@
 
 export * from "./types";
 export { defineWorkbench } from "./define";
+export { emptyEntityIndex } from "./runtime";

--- a/packages/config/src/workbench/runtime.ts
+++ b/packages/config/src/workbench/runtime.ts
@@ -1,0 +1,17 @@
+import type { EntityIndex } from "./types";
+
+/**
+ * An `EntityIndex` with no entities. Useful as a default when a
+ * Workbench mounts before its data backend is wired (or in tests).
+ *
+ * Subscribers are accepted but never invoked — the index never
+ * changes.
+ */
+export const emptyEntityIndex: EntityIndex = {
+  byId: () => undefined,
+  byType: () => [],
+  all: () => [],
+  subscribe: () => () => {
+    /* noop unsubscribe */
+  },
+};

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -16,6 +16,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "peerDependencies": {
+    "@klorad/config": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/design-system/src/components/dock.tsx
+++ b/packages/design-system/src/components/dock.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { cn } from "../utils/cn";
+
+export type DockProps = {
+  /** Optional left panel — collapses to a 40px chrome rail. */
+  left?: ReactNode;
+  /** Required center panel — always visible, always fills the remainder. */
+  center: ReactNode;
+  /** Optional right panel — collapses to a 40px chrome rail. */
+  right?: ReactNode;
+  /** Optional bottom panel — collapses to a 40px chrome rail. */
+  bottom?: ReactNode;
+  className?: string;
+};
+
+/**
+ * The Workbench dock layout — four named regions: `left`, `center`,
+ * `right`, `bottom`. v1 supports collapse / expand on the three
+ * optional regions only; drag-to-resize, drag-to-rearrange, and
+ * layout persistence are deliberately deferred (see WORKBENCH.md §6).
+ *
+ * The dock fills its parent's height. Mount inside a container that
+ * gives it a defined height (e.g. `h-screen` or `h-[calc(100vh-4rem)]`).
+ */
+export function Dock({ left, center, right, bottom, className }: DockProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 flex-col bg-bg text-text-primary",
+        className,
+      )}
+    >
+      <div className="flex min-h-0 flex-1">
+        {left ? <DockColumn side="left">{left}</DockColumn> : null}
+        <main className="min-w-0 flex-1 overflow-hidden">{center}</main>
+        {right ? <DockColumn side="right">{right}</DockColumn> : null}
+      </div>
+      {bottom ? <DockBottom>{bottom}</DockBottom> : null}
+    </div>
+  );
+}
+
+function DockColumn({
+  side,
+  children,
+}: {
+  side: "left" | "right";
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(true);
+  const label = side === "left" ? "Left" : "Right";
+  return (
+    <aside
+      className={cn(
+        "flex h-full flex-col bg-surface-1 transition-[width] duration-200",
+        side === "left" ? "border-r border-line-soft" : "border-l border-line-soft",
+        open ? "w-72" : "w-10",
+      )}
+    >
+      <header
+        className={cn(
+          "flex h-10 shrink-0 items-center border-b border-line-soft px-2 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary",
+          open ? "justify-between" : "justify-center",
+        )}
+      >
+        {open ? <span>{label}</span> : null}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-label={`Toggle ${side} panel`}
+          aria-expanded={open}
+          className="flex h-6 w-6 items-center justify-center rounded text-text-secondary transition-colors hover:bg-accent-soft hover:text-text-primary"
+        >
+          <Chevron direction={open === (side === "left") ? "left" : "right"} />
+        </button>
+      </header>
+      {open ? (
+        <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+      ) : null}
+    </aside>
+  );
+}
+
+function DockBottom({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <section
+      className={cn(
+        "flex shrink-0 flex-col border-t border-line-soft bg-surface-1 transition-[height] duration-200",
+        open ? "h-56" : "h-10",
+      )}
+    >
+      <header className="flex h-10 shrink-0 items-center justify-between border-b border-line-soft px-2 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
+        <span>{open ? "Bottom" : null}</span>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-label="Toggle bottom panel"
+          aria-expanded={open}
+          className="flex h-6 w-6 items-center justify-center rounded text-text-secondary transition-colors hover:bg-accent-soft hover:text-text-primary"
+        >
+          <Chevron direction={open ? "down" : "up"} />
+        </button>
+      </header>
+      {open ? (
+        <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+      ) : null}
+    </section>
+  );
+}
+
+function Chevron({ direction }: { direction: "left" | "right" | "up" | "down" }) {
+  const rotation = {
+    left: "rotate-90",
+    right: "-rotate-90",
+    up: "rotate-180",
+    down: "",
+  }[direction];
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("transition-transform", rotation)}
+      aria-hidden
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}

--- a/packages/design-system/src/components/workbench.tsx
+++ b/packages/design-system/src/components/workbench.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type {
+  Actor,
+  DockRegion,
+  EntityIndex,
+  OpResult,
+  SelectionState,
+  ViewContext,
+  WorkbenchConfig,
+} from "@klorad/config/workbench";
+import { emptyEntityIndex } from "@klorad/config/workbench";
+import { Dock } from "./dock";
+
+export type WorkbenchProps = {
+  /** The vertical's config, produced by `defineWorkbench(...)`. */
+  config: WorkbenchConfig;
+  /** The world being edited (typically the map id in campus). */
+  worldId: string;
+  /** Who's running the show. Defaults to an anonymous user. */
+  actor?: Actor;
+  /** Custom entity backend. Defaults to an empty in-memory index. */
+  entities?: EntityIndex;
+};
+
+const defaultActor: Actor = { kind: "user", userId: "anonymous" };
+
+/**
+ * The Workbench shell — Phase 2 v1.
+ *
+ * Reads a `WorkbenchConfig`, resolves views from the config's default
+ * layout, and mounts each view into its dock region with a shared
+ * `ViewContext`. Selection state lives in the shell; operation
+ * invocation looks up the op by id and dispatches.
+ *
+ * Out of scope for v1 (each is its own phase per WORKBENCH.md):
+ * - Free-rearrange layout, drag-to-resize handles, layout persistence
+ * - Pre-computed `applicableOperations` per selection
+ * - Command palette (`mod+k`), right-click menu, keyboard shortcuts
+ * - AI suggestion stream / approval gating
+ */
+export function Workbench({
+  config,
+  worldId,
+  actor = defaultActor,
+  entities = emptyEntityIndex,
+}: WorkbenchProps) {
+  const [selection, setSelection] = useState<SelectionState>(() => ({
+    ids: new Set<string>(),
+    focusedId: null,
+  }));
+
+  const viewById = useMemo(
+    () => new Map(config.views.map((v) => [v.id, v])),
+    [config.views],
+  );
+
+  const operationById = useMemo(
+    () => new Map(config.operations.map((o) => [o.id, o])),
+    [config.operations],
+  );
+
+  const ctx = useMemo<ViewContext>(
+    () => ({
+      worldId,
+      selection,
+      setSelection,
+      entities,
+      runOperation: async (opId, args, on): Promise<OpResult> => {
+        const op = operationById.get(opId);
+        if (!op) {
+          return { ok: false, reason: `Unknown operation: ${opId}` };
+        }
+        return op.invoke(
+          {
+            worldId,
+            actor,
+            entities,
+            // Phase 5 wires this to the app's real toast surface. For
+            // now, swallow — no operations exist yet to call it anyway.
+            toast: () => {
+              /* noop */
+            },
+          },
+          args as never,
+          on,
+        );
+      },
+      // Computed in Phase 5 once operations exist.
+      applicableOperations: [],
+    }),
+    [worldId, selection, entities, actor, operationById],
+  );
+
+  const renderRegion = (region: DockRegion) => {
+    const ids = config.defaultLayout[region];
+    if (ids.length === 0) return null;
+    return (
+      <div className="flex h-full flex-col">
+        {ids.map((id) => {
+          const view = viewById.get(id);
+          if (!view) {
+            return (
+              <div
+                key={id}
+                className="m-3 rounded-md border border-dashed border-line-strong p-3 text-xs text-text-tertiary"
+              >
+                Missing view: <code className="font-mono">{id}</code>
+              </div>
+            );
+          }
+          const Component = view.component;
+          return <Component key={id} ctx={ctx} />;
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <Dock
+      left={renderRegion("left")}
+      center={renderRegion("center") ?? <EmptyCenter />}
+      right={renderRegion("right")}
+      bottom={renderRegion("bottom")}
+    />
+  );
+}
+
+function EmptyCenter() {
+  return (
+    <div className="flex h-full items-center justify-center p-8 text-center text-sm text-text-tertiary">
+      No views configured for the center region.
+    </div>
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -45,3 +45,5 @@ export {
   type AppShellProps,
   type NavItem,
 } from "./components/app-shell";
+export { Dock, type DockProps } from "./components/dock";
+export { Workbench, type WorkbenchProps } from "./components/workbench";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,9 @@ importers:
 
   packages/design-system:
     dependencies:
+      '@klorad/config':
+        specifier: workspace:*
+        version: link:../config
       clsx:
         specifier: ^2.1.1
         version: 2.1.1

--- a/scripts/verify-workspace-deps.mjs
+++ b/scripts/verify-workspace-deps.mjs
@@ -68,8 +68,10 @@ for (const pkg of fs.readdirSync(packagesDir)) {
       .replace(/\/\/.*$/gm, "") // Remove single-line comments
       .replace(/\/\*[\s\S]*?\*\//g, ""); // Remove multi-line comments
     // Match both 'from "@klorad/..."' and 'from '@klorad/...'
-    for (const match of contentWithoutComments.matchAll(/from ["'](@klorad\/[^"']+)["']/g)) {
-      imports.add(match[1]);
+    // Strip subpath imports (e.g. "@klorad/config/workbench" -> "@klorad/config")
+    // so the dep check matches the package name as declared in package.json.
+    for (const match of contentWithoutComments.matchAll(/from ["']@klorad\/([^"'/]+)(?:\/[^"']*)?["']/g)) {
+      imports.add(`@klorad/${match[1]}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 2 of the Workbench migration — the first **runnable** surface. Adds a `/maps/[mapId]/workbench` route that mounts the shared shell and shows a placeholder Map view in the centre dock region. The existing `/builder` route is untouched until Phase 6.

15 files changed, +432 / −20.

## What's new

### `@klorad/design-system`

- **`Dock`** — the four-region layout primitive (`left` / `center` / `right` / `bottom`). v1 supports collapse-expand on the three optional regions; drag-to-resize, drag-to-rearrange, and layout persistence are deliberately deferred (WORKBENCH.md §6.2).
- **`Workbench`** — the shell. Reads a `WorkbenchConfig`, resolves views from `defaultLayout`, mounts each into its dock region with a shared `ViewContext`. Selection lives in the shell; operation dispatch looks up by id. Out of scope for v1 (each is its own later phase): applicable-ops filtering, command palette, right-click menus, AI suggestion stream.
- `@klorad/config: workspace:*` added to peerDependencies (the shell type-imports `WorkbenchConfig` and friends).

### `@klorad/config/workbench`

- **`emptyEntityIndex`** — a zero-entity backend used as the default when a Workbench mounts before its data layer is wired. dist rebuilt.

### `apps/campus`

- **`lib/workbench/views/map.tsx`** — Phase 2 placeholder view that prints worldId / selection count / loaded entity count. Phase 3 swaps in the wrapped 3D scene from the current `BuilderClient`.
- **`workbench.config.ts`** now registers `mapView` and pins it to `defaultLayout.center: ["map"]`.
- **`app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/page.tsx`** + **`WorkbenchClient.tsx`** — the new route. Server component checks auth and reads params; client component mounts `<Workbench config={workbenchConfig} worldId={mapId} />` inside an `h-screen w-screen` container.
- **`DashboardShell`** now bypasses its chrome for `/workbench` (same pattern as `/builder`) so the shell owns the full viewport.

### Toolchain

- **`scripts/verify-workspace-deps.mjs`** updated to strip subpath imports — `@klorad/config/workbench` now correctly checks against the declared `@klorad/config` dep. Previously the script flagged subpath imports as missing.

## Worth knowing

- **Visit `/org/<orgId>/maps/<mapId>/workbench` to see the shell.** You'll get the dock chrome (left / right / bottom collapsible) and the placeholder view in the centre showing the world id.
- **No data is loaded yet.** The default `emptyEntityIndex` makes `ctx.entities.all().length` always `0` and the selection count always `0`. Phase 3+ wires the real data backend.
- **Operations don't fire yet.** `ctx.runOperation` returns `{ ok: false, reason: "Unknown operation" }` for any id since `operations: []`. The dispatch path is there for Phase 5.
- **Toast handler is a noop.** No operations exist to call it. Phase 5 wires it to the app's real toast surface.
- **The `Dock` is not yet draggable or persistable.** v1 is fixed-width regions with collapse-only. Per WORKBENCH.md §6.2 — we extend if the constraint becomes painful; we don't pre-build.
- **Pre-push (the editor build) passed**, so this didn't break the existing builds.

## Test plan

- [x] Typecheck: config + design-system + campus + editor + admin + website all clean
- [x] Pre-commit (eslint + tsc) + pre-push (verify:deps + editor build) pass
- [ ] Open `/org/<orgId>/maps/<some-map-id>/workbench` — the shell renders, the centre shows the placeholder map view with the world id
- [ ] The three optional dock regions collapse-expand with the chevrons
- [ ] The existing `/builder` route still renders identically (this PR shouldn't touch it)

## Next

**Phase 3 — port the existing 3D map as a real view.** Per WORKBENCH.md §10: wrap today's `BuilderClient`'s 3D scene as a `MapView` that talks to the entity index instead of its own state. Same visual output; different ownership. Size: ~800 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
