### PR TITLE
Workbench Phase 3a: campus EntityIndex adapter (read-through)

### DIFF
--- a/apps/campus/lib/workbench/index.ts
+++ b/apps/campus/lib/workbench/index.ts
@@ -10,5 +10,6 @@
  */
 
 export * from "./entities";
+export * from "./runtime";
 export * from "./views";
 export { identitySchema } from "./schema";

--- a/apps/campus/lib/workbench/runtime/campus-entity-index.ts
+++ b/apps/campus/lib/workbench/runtime/campus-entity-index.ts
@@ -1,0 +1,148 @@
+import type {
+  Entity,
+  EntityId,
+  EntityIndex,
+  EntityTypeId,
+} from "@klorad/config/workbench";
+import type { FloorPlan, POI, POIEvent, TourStop } from "@klorad/api";
+import type { Building } from "../entities/building";
+
+/**
+ * Inputs the adapter needs to project campus data into typed entities.
+ * Today these come from a `CampusAPI` instance loaded against a world:
+ *
+ * ```ts
+ * const api = createSceneAPI("mapbox", "campus") as CampusAPI;
+ * api.load(map.sceneData);
+ * const index = createCampusEntityIndex({
+ *   worldId: map.id,
+ *   pois: api.poi.getAll(),
+ *   floorPlans: api.floorPlans.getAll(),
+ *   tourStops: [],   // TBD — surface via api in Phase 5
+ * });
+ * ```
+ */
+export interface CampusEntitySources {
+  worldId: string;
+  pois: POI[];
+  floorPlans: FloorPlan[];
+  tourStops: TourStop[];
+}
+
+/**
+ * Build an `EntityIndex` over campus data — the read-through bridge
+ * between today's `Map.sceneData` storage and the Workbench shell's
+ * typed view of the world.
+ *
+ * Read-through, **not write-through**. Writes keep going through the
+ * existing `api.poi.add(...)` paths; this adapter never mutates the
+ * source. Phase 5 reroutes writes via `ctx.runOperation`.
+ *
+ * `subscribe` is a noop because the index is immutable for its
+ * lifetime — when source data changes, consumers recreate the index
+ * with `useMemo`, and the Workbench shell sees a new reference and
+ * re-renders naturally.
+ *
+ * Two derivations to note:
+ *
+ * - **Buildings** are today carried as `POI.linkedBuilding` (one
+ *   polygon nested on a POI). The adapter promotes them to first-class
+ *   `Entity<Building>` instances so the Workbench can talk about them
+ *   independently. For now they share the POI's id; Phase 5+ migrates
+ *   to separate ids.
+ * - **Events** are today nested on POIs (`POI.events`). The adapter
+ *   flattens them across POIs so a future Timeline view can filter
+ *   without walking through the POI graph.
+ */
+export function createCampusEntityIndex({
+  worldId,
+  pois,
+  floorPlans,
+  tourStops,
+}: CampusEntitySources): EntityIndex {
+  const poiEntities: Entity<POI>[] = pois.map((poi) => ({
+    id: poi.id,
+    typeId: "campus.poi",
+    worldId,
+    payload: poi,
+    createdAt: "",
+    updatedAt: "",
+  }));
+
+  const buildingEntities: Entity<Building>[] = pois
+    .filter((p): p is POI & { linkedBuilding: NonNullable<POI["linkedBuilding"]> } =>
+      Boolean(p.linkedBuilding),
+    )
+    .map((p) => ({
+      id: p.id,
+      typeId: "campus.building",
+      worldId,
+      payload: {
+        id: p.id,
+        name: p.linkedBuilding.label ?? p.name,
+        centroid: [p.linkedBuilding.lng, p.linkedBuilding.lat] as [number, number],
+        polygon: p.linkedBuilding.polygon,
+        heightM: p.linkedBuilding.heightM,
+        mapboxFeatureId: p.linkedBuilding.featureId,
+        properties: p.linkedBuilding.properties,
+      },
+      createdAt: "",
+      updatedAt: "",
+    }));
+
+  const floorPlanEntities: Entity<FloorPlan>[] = floorPlans.map((plan) => ({
+    id: plan.id,
+    typeId: "campus.floor-plan",
+    worldId,
+    payload: plan,
+    createdAt: "",
+    updatedAt: "",
+  }));
+
+  const tourStopEntities: Entity<TourStop>[] = tourStops.map((stop) => ({
+    id: String(stop.id),
+    typeId: "campus.tour-stop",
+    worldId,
+    payload: stop,
+    createdAt: "",
+    updatedAt: "",
+  }));
+
+  const eventEntities: Entity<POIEvent>[] = pois.flatMap((poi) =>
+    (poi.events ?? []).map((event) => ({
+      id: event.id,
+      typeId: "campus.event",
+      worldId,
+      payload: event,
+      createdAt: "",
+      updatedAt: "",
+    })),
+  );
+
+  const all: Entity[] = [
+    ...poiEntities,
+    ...buildingEntities,
+    ...floorPlanEntities,
+    ...tourStopEntities,
+    ...eventEntities,
+  ];
+
+  const byIdMap = new Map<EntityId, Entity>(all.map((e) => [e.id, e]));
+
+  const byTypeMap = new Map<EntityTypeId, Entity[]>([
+    ["campus.poi", poiEntities],
+    ["campus.building", buildingEntities],
+    ["campus.floor-plan", floorPlanEntities],
+    ["campus.tour-stop", tourStopEntities],
+    ["campus.event", eventEntities],
+  ]);
+
+  return {
+    byId: (id) => byIdMap.get(id),
+    byType: (typeId) => byTypeMap.get(typeId) ?? [],
+    all: () => all,
+    subscribe: () => () => {
+      /* immutable for this index's lifetime — recreate on change */
+    },
+  };
+}

--- a/apps/campus/lib/workbench/runtime/index.ts
+++ b/apps/campus/lib/workbench/runtime/index.ts
@@ -1,0 +1,4 @@
+export {
+  createCampusEntityIndex,
+  type CampusEntitySources,
+} from "./campus-entity-index";


### PR DESCRIPTION
## Summary

The **read-through bridge** between today's `Map.sceneData` storage and the Workbench shell's typed view of the world. Implements `WORKBENCH-PHASE-3.md` §3 — Step 2 of the original Phase 3a plan.

3 files added, +153 / 0. Nothing reads it yet; Phase 3b's `WorkbenchClient` will consume it.

## What's in `createCampusEntityIndex`

Takes already-extracted campus arrays (POIs, floor plans, tour stops) from a `CampusAPI` instance and surfaces them as typed `Entity<T>` instances against the Phase 1.2 registrations:

```ts
const index = createCampusEntityIndex({
  worldId: map.id,
  pois: api.poi.getAll(),
  floorPlans: api.floorPlans.getAll(),
  tourStops: [],   // TBD — Phase 5 surfaces via api
});

index.byType("campus.poi");        // Entity<POI>[]
index.byType("campus.building");   // Entity<Building>[]
index.byType("campus.floor-plan"); // Entity<FloorPlan>[]
index.byType("campus.event");      // Entity<POIEvent>[]
```

Two derivations worth flagging:

- **Buildings** are today carried as `POI.linkedBuilding` (one polygon nested on a POI). The adapter promotes them to first-class `Entity<Building>` instances so the Workbench can talk about them independently. For now they share the POI's id; Phase 5+ migrates to separate ids.
- **Events** are today nested on POIs (`POI.events`). The adapter flattens them across POIs so a future Timeline view can filter without walking the POI graph.

**Read-through, not write-through.** Writes keep going through the existing `api.poi.add(...)` paths; this adapter never mutates the source. Phase 5 reroutes writes via `ctx.runOperation`.

`subscribe` is a noop — the index is immutable for its lifetime. Consumers recreate it via `useMemo` on data change, the Workbench shell sees a new reference, views re-render.

## Why this PR doesn't include the `useCampusScene` hook extraction

I read `BuilderClient.tsx` end-to-end before writing this. The `WORKBENCH-PHASE-3.md` doc's estimate that Step 5 would "shrink BuilderClient by ~800 lines" was **optimistic**:

- Engine state and editor-UI state are deeply tangled. The eight `useMapbox*Layer` hook calls depend on local state (`activeTool`, `selectedPoiId`, `pendingRoomFloor`, `roomsForSelection` derivation, …) that drives panel UI, not just rendering.
- The action handlers (`commitNewRoom`, `commitNewBuilding`, `quickAddFloor`, etc.) interleave `apiRef.current.x.add()` calls with `setPois`/`setRooms`/`setPlans` local-state setters and `toast` calls.
- The hook can't own all of that without effectively becoming the whole BuilderClient.

A clean `useCampusScene` extraction needs a **state-ownership refactor first**: move POI/room/plan state ownership into the scene store (so the engine is the single source of truth) and have BuilderClient subscribe to it. Without that, the hook is either a 14-parameter passthrough (no real win) or a leaky abstraction that breaks `/builder` in ways that are easy to miss.

So this PR delivers only **Step 2** from the doc. Steps 1 (hook) and 5 (BuilderClient switchover) need a deeper design pass before they can land safely.

## Worth knowing

- **Zero risk to `/builder`**. Nothing imports the adapter yet.
- **Phase 3b can still proceed without the hook.** The MapView can mount its own engine setup independently of BuilderClient for v1, then unify with a hook later when the design pass is done. The trade-off is two parallel engine init paths during the transition — not ideal but not blocking.
- **Phase 1.2's `Building` type** — the adapter is the first runtime consumer. The shape held up under real data: `linkedBuilding`'s fields map cleanly into `Building.centroid` / `polygon` / `heightM` / `mapboxFeatureId` / `properties`.

## Test plan

- [x] Typecheck: config + design-system + campus + editor + admin + website all clean
- [x] Pre-commit + pre-push hooks pass
- [ ] When Phase 3b lands, confirm `index.byType("campus.poi").length` matches `api.poi.getAll().length` on a real map

## Next

Three honest options for getting Phase 3 the rest of the way:

1. **Phase 3b with parallel engine init** — `MapView` mounts the Mapbox + layer hooks directly (mirroring BuilderClient), uses this adapter for reads. `/workbench` becomes a real 3D scene. `/builder` keeps its own copy. Two paths through the engine during the transition; defer unification until Phase 3a's design pass.

2. **State-ownership refactor first** — restructure BuilderClient so engine state lives in the scene store (POIs / rooms / plans subscribed, not local state). Then `useCampusScene` extraction becomes straightforward. Bigger change; touches `/builder` directly with regression risk; cleaner end state.

3. **Stop Phase 3 here, do something else** — the design system, marketing follow-ups, or other priorities. Workbench picks up later with more context.

My take: **option 1**. It unblocks `/workbench` quickly, keeps `/builder` byte-stable, and the parallel-init debt is paid down by Phase 5 anyway (when writes finally route through operations and the engine instances start to look the same).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
