### PR TITLE
Workbench Phase 3b: MapView wraps the real 3D scene

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
@@ -1,25 +1,97 @@
 "use client";
 
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Workbench } from "@klorad/design-system";
+import { createSceneAPI } from "@klorad/api";
+import type { CampusAPI, FloorPlan, POI, TourStop } from "@klorad/api";
+import { withCampusLabelDefaults } from "@/app/hooks/useCampusLabelDefaults";
 import workbenchConfig from "@/workbench.config";
+import { createCampusEntityIndex } from "@/lib/workbench";
 
 interface Props {
   mapId: string;
 }
 
 /**
- * Mounts the shared Workbench shell with the campus config. v1 just
- * renders a placeholder Map view in the centre region; Phase 3 wraps
- * the real 3D scene as that view.
+ * Mounts the shared Workbench shell with the campus config.
+ *
+ * Phase 3b: this component owns its own `CampusAPI` instance and load
+ * (mirroring `BuilderClient`'s setup) and feeds the resulting POIs and
+ * floor plans through `createCampusEntityIndex` to the shell. The
+ * `MapView` view consumes those entities and mounts the Mapbox layer
+ * hooks for rendering — same engine code path as `/builder`, but
+ * with the editing surface deferred to Phase 5.
+ *
+ * Both routes call into the same layer hooks against the same scene
+ * store; engine init runs once per route until a shared
+ * `useCampusScene` hook unifies it (WORKBENCH-PHASE-3.md §4).
  *
  * The `DashboardShell` deliberately bypasses its top-bar / sidebar
  * chrome for `/workbench` routes — same as `/builder` — so the shell
  * gets the full viewport.
  */
 export default function WorkbenchClient({ mapId }: Props) {
+  const [sceneReady, setSceneReady] = useState(false);
+  const [pois, setPois] = useState<POI[]>([]);
+  const [plans, setPlans] = useState<FloorPlan[]>([]);
+  const [tourStops] = useState<TourStop[]>([]);
+  const apiRef = useRef<CampusAPI | null>(null);
+
+  useEffect(() => {
+    const api = createSceneAPI("mapbox", "campus") as CampusAPI;
+    apiRef.current = api;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/maps/${mapId}`);
+        if (!res.ok) throw new Error("Failed to load map");
+        const data = await res.json();
+        if (cancelled) return;
+        // Same default-labels-off pass the builder applies, so a
+        // brand-new map still loads with clean basemap labels.
+        const sceneToLoad = withCampusLabelDefaults(data?.sceneData ?? {});
+        api.load(sceneToLoad);
+        setPois(api.poi.getAll());
+        setPlans(api.floorPlans.getAll());
+      } catch {
+        // New or unreachable map — fall through to empty defaults.
+      } finally {
+        if (!cancelled) setSceneReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mapId]);
+
+  const entities = useMemo(
+    () =>
+      createCampusEntityIndex({
+        worldId: mapId,
+        pois,
+        floorPlans: plans,
+        tourStops,
+      }),
+    [mapId, pois, plans, tourStops],
+  );
+
+  if (!sceneReady) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-bg text-sm text-text-secondary">
+        Loading the scene…
+      </div>
+    );
+  }
+
   return (
     <div className="h-screen w-screen">
-      <Workbench config={workbenchConfig} worldId={mapId} />
+      <Workbench
+        config={workbenchConfig}
+        worldId={mapId}
+        entities={entities}
+      />
     </div>
   );
 }

--- a/apps/campus/lib/workbench/views/map.tsx
+++ b/apps/campus/lib/workbench/views/map.tsx
@@ -1,36 +1,77 @@
 "use client";
 
-import type { View, ViewProps } from "@klorad/config/workbench";
+import dynamic from "next/dynamic";
+import type { POI } from "@klorad/api";
+import type { Entity, View, ViewProps } from "@klorad/config/workbench";
+import { useMapboxPoiLayer } from "@/app/hooks/useMapboxPoiLayer";
+import { useMapboxDrawnBuildingsLayer } from "@/app/hooks/useMapboxDrawnBuildingsLayer";
+import { useCampusLabelDefaults } from "@/app/hooks/useCampusLabelDefaults";
+
+const MapboxViewer = dynamic(
+  () =>
+    import("@klorad/engine-mapbox").then((m) => ({ default: m.MapboxViewer })),
+  { ssr: false, loading: () => <MapLoadingFallback /> },
+);
+
+function MapLoadingFallback() {
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-bg text-sm text-text-tertiary">
+      Loading 3D scene…
+    </div>
+  );
+}
 
 /**
- * Phase 2 placeholder. Phase 3 wraps the existing builder 3D scene
- * (today: `apps/campus/maps/[mapId]/builder/BuilderClient`) as a
- * `View` that talks to the entity index rather than its own state.
+ * Phase 3b — the real Map view.
+ *
+ * Reads POIs from `ctx.entities`, mounts the campus Mapbox layer
+ * hooks for rendering (POI markers + drawn-building extrusions +
+ * basemap-label defaults), bridges 3D clicks to `ctx.setSelection`.
+ *
+ * Read-only for v1. The full editing surface (drawing tools, room
+ * panels, undo/redo, the floor-plan drawer) stays on `/builder`
+ * until Phase 5 — by which time the engine setup can be unified via
+ * a `useCampusScene` hook (see WORKBENCH-PHASE-3.md §4).
  */
 function MapViewComponent({ ctx }: ViewProps) {
+  const pois = (ctx.entities.byType("campus.poi") as Entity<POI>[]).map(
+    (e) => e.payload,
+  );
+  const selectedPoiId = ctx.selection.focusedId;
+
+  useMapboxPoiLayer({
+    pois,
+    selectedPoiId,
+    onPoiClick: (id) => {
+      const next = selectedPoiId === id ? null : id;
+      ctx.setSelection({
+        ids: next ? new Set([next]) : new Set<string>(),
+        focusedId: next,
+      });
+    },
+  });
+
+  // Render building extrusions for POIs that carry a `linkedBuilding`.
+  // Plans + rooms are passed empty for v1 — full slab / room rendering
+  // ships when the editing surface migrates over.
+  useMapboxDrawnBuildingsLayer(pois, [], [], {
+    selectedPoiId,
+    activeFloor: null,
+    onSelect: (id) => {
+      ctx.setSelection({ ids: new Set([id]), focusedId: id });
+    },
+    clickEnabled: true,
+  });
+
+  // Force basemap labels off whenever the scene is mounted (Mapbox's
+  // default street labels collide with campus content). The hook
+  // internally early-returns until the map instance is registered in
+  // the scene store, so passing `true` unconditionally is safe.
+  useCampusLabelDefaults(true);
+
   return (
-    <div className="flex h-full items-center justify-center bg-bg p-8 text-center">
-      <div className="max-w-md">
-        <span className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
-          <span className="h-1.5 w-1.5 rounded-full bg-accent" />
-          Map view
-        </span>
-        <h2 className="mt-3 text-lg font-medium text-text-primary">
-          The Workbench shell is mounted.
-        </h2>
-        <p className="mt-2 text-sm text-text-secondary">
-          Editing world{" "}
-          <code className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[0.8em] text-text-primary">
-            {ctx.worldId}
-          </code>
-          . Phase 3 wraps the existing 3D scene here as a real View.
-        </p>
-        <p className="mt-4 text-xs text-text-tertiary">
-          Selection: {ctx.selection.ids.size} entit
-          {ctx.selection.ids.size === 1 ? "y" : "ies"} ·{" "}
-          {ctx.entities.all().length} loaded
-        </p>
-      </div>
+    <div className="h-full w-full">
+      <MapboxViewer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase 3b of the Workbench migration — the `/workbench` route now renders the **real 3D scene** with POIs and drawn-building extrusions, replacing the Phase 2 placeholder. `/builder` is untouched.

Implements `WORKBENCH-PHASE-3.md` §5 steps 3 (MapView) + 4 (WorkbenchClient wires the entity index). The `useCampusScene` hook extraction (step 1) stays deferred — engine state and editor UI are too tangled in `BuilderClient` to unify cleanly without a state-ownership refactor first. Both routes call into the same Mapbox layer hooks against the same scene store; engine init runs once per route until that unification ships in a follow-up.

## Branch dependencies

This PR is **stacked** on:

- **#113** — Phase 2 (the shell + `Workbench` export from `@klorad/design-system`)
- **#115** — Phase 3a (the `createCampusEntityIndex` adapter)

Both are reflected as cherry-picked commits on this branch. When #113 and #115 merge to main, rebase trims this PR to just the two new files at the top:

| File | What |
|---|---|
| `apps/campus/lib/workbench/views/map.tsx` | Replaces the Phase 2 placeholder with the real MapView |
| `apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx` | Replaces the Phase 2 placeholder with the data-loading client |

## What's in the new MapView

- Reads POIs from `ctx.entities.byType("campus.poi")`
- Mounts `useMapboxPoiLayer` + `useMapboxDrawnBuildingsLayer` + `useCampusLabelDefaults` against the same scene store `/builder` uses
- Renders `<MapboxViewer />`
- Bridges 3D clicks (both POI and building) to `ctx.setSelection` — **first cross-view selection state in the Workbench**
- Plans + rooms are passed empty for v1; full slab / room rendering ships when the editing surface migrates over

## What's in the new WorkbenchClient

- Creates its own `CampusAPI` instance (mirroring `BuilderClient`'s setup)
- Fetches `Map.sceneData` via `/api/maps/[mapId]`
- Runs the `withCampusLabelDefaults` pass so brand-new maps load with clean basemap labels
- Loads the API, extracts `pois` and `floorPlans`, surfaces them through `createCampusEntityIndex` to the shell
- Gates on `sceneReady` so the dock doesn't mount before engine data is ready (same pattern as `BuilderClient`)

## Worth knowing

- **Read-only for v1.** Writes (`poi.add`, `room.add`, `floorPlan.add`, …) keep going through `/builder`'s existing paths. Phase 5 reroutes them via `ctx.runOperation` once operations are typed.
- **Parallel engine init.** `/builder` and `/workbench` each mount their own `CampusAPI` + Mapbox scene against the same global scene store. Two tabs on the same map would race for the WebGL context — same as today on `/builder`. Acceptable tradeoff during the transition; resolved by Phase 5 when the engine setups merge.
- **No floor-plan / room rendering in `/workbench` yet.** Those need active-floor state which the v1 MapView doesn't track. They show up only on `/builder` until Phase 5.
- **Typecheck + pre-commit + pre-push (editor build) all pass.**

## Test plan

- [x] Typecheck: config + design-system + campus + editor + admin + website all clean
- [x] Pre-commit + pre-push hooks pass
- [ ] Visit `/org/<orgId>/maps/<mapId>/workbench` on a real map — full viewport, 3D Mapbox scene, POI markers visible, building extrusions for POIs with `linkedBuilding`
- [ ] Click a POI in 3D — the focused POI changes (verifiable via a temporary debug overlay reading `ctx.selection.focusedId`)
- [ ] Click a building extrusion — same
- [ ] `/builder` still renders identically — no regression

## Next

Phase 4 — Table / Hierarchy / Overview views — peer to MapView, consuming the same entity index. Phase 5 — operations land + writes reroute through `ctx.runOperation` + the `useCampusScene` unification can finally happen now that two routes are sharing the engine layer hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
