### PR TITLE
Workbench Phase 4a: OverviewView in the right dock

### DIFF
--- a/apps/campus/lib/workbench/views/index.ts
+++ b/apps/campus/lib/workbench/views/index.ts
@@ -1,1 +1,2 @@
 export { mapView } from "./map";
+export { overviewView } from "./overview";

--- a/apps/campus/lib/workbench/views/overview.tsx
+++ b/apps/campus/lib/workbench/views/overview.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { View, ViewProps } from "@klorad/config/workbench";
+
+/**
+ * Phase 4a — the Overview view.
+ *
+ * A compact landing panel that summarises the current world: how
+ * many POIs / buildings / floor plans are loaded, plus simple
+ * accessibility coverage. Lives in the right dock region by default
+ * so it sits next to the map without competing for the centre.
+ *
+ * Reads everything from `ctx.entities`. No writes; no engine
+ * interaction. The simplest possible "second view" — proves the
+ * dock supports more than one View consuming the shared entity
+ * index, and sets the pattern that TableView and HierarchyView
+ * follow in Phases 4b and 4c.
+ */
+function OverviewViewComponent({ ctx }: ViewProps) {
+  const pois = ctx.entities.byType("campus.poi");
+  const buildings = ctx.entities.byType("campus.building");
+  const floorPlans = ctx.entities.byType("campus.floor-plan");
+  const events = ctx.entities.byType("campus.event");
+
+  // Accessibility coverage — pulls `wheelchairAccessible` off each
+  // POI's payload. Typed loosely here to avoid coupling the view to
+  // the @klorad/api `POI` shape directly; if accessibility becomes a
+  // first-class concept it gets its own field on `EntityType`.
+  const accessibleCount = pois.filter((p) => {
+    const payload = p.payload as { accessibility?: { wheelchairAccessible?: boolean } };
+    return payload?.accessibility?.wheelchairAccessible;
+  }).length;
+  const accessibilityPct =
+    pois.length > 0 ? Math.round((accessibleCount / pois.length) * 100) : 0;
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4">
+      <header className="space-y-1">
+        <h2 className="text-sm font-semibold text-text-primary">Overview</h2>
+        <p className="font-mono text-[0.7rem] text-text-tertiary">
+          {ctx.worldId}
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 gap-2">
+        <StatTile label="POIs" value={pois.length} />
+        <StatTile label="Buildings" value={buildings.length} />
+        <StatTile label="Floor plans" value={floorPlans.length} />
+        <StatTile label="Events" value={events.length} />
+      </div>
+
+      <div className="rounded-lg border border-line-soft bg-surface-1 p-3">
+        <div className="text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
+          Accessibility coverage
+        </div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="text-2xl font-light text-text-primary">
+            {accessibilityPct}%
+          </span>
+          <span className="text-xs text-text-secondary">
+            {accessibleCount} / {pois.length} POIs
+          </span>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-dashed border-line-soft p-3 text-xs text-text-tertiary">
+        Selected:{" "}
+        {ctx.selection.focusedId ? (
+          <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.7rem] text-text-primary">
+            {ctx.selection.focusedId}
+          </code>
+        ) : (
+          <span>nothing</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatTile({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-line-soft bg-surface-1 p-3">
+      <div className="text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-light text-text-primary">{value}</div>
+    </div>
+  );
+}
+
+function OverviewIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+    </svg>
+  );
+}
+
+export const overviewView: View = {
+  id: "overview",
+  label: "Overview",
+  icon: OverviewIcon,
+  entityTypes: "*",
+  defaultDock: "right",
+  component: OverviewViewComponent,
+};

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -6,15 +6,20 @@ import {
   tourStopEntity,
   eventEntity,
   mapView,
+  overviewView,
 } from "@/lib/workbench";
 
 /**
  * The campus vertical's Workbench configuration.
  *
  * - Phase 1.2 — five typed entities registered
- * - Phase 2   — one placeholder `mapView` in the centre region
- * - Phase 3+  — real views (Map / Table / Hierarchy / Overview),
- *                operations, populated dock layout
+ * - Phase 2   — `mapView` placeholder in the centre region
+ * - Phase 3b  — real 3D `mapView` (POIs + drawn buildings + selection
+ *                bridge)
+ * - Phase 4a  — `overviewView` in the right region (POI / building /
+ *                floor-plan counts, accessibility coverage)
+ * - Phase 4b+ — TableView (left), HierarchyView (left), operations,
+ *                further layout tuning
  *
  * Imported by `/maps/[mapId]/workbench/page.tsx` at runtime; the old
  * `/maps/[mapId]/builder` route stays untouched until Phase 6.
@@ -30,12 +35,12 @@ const workbenchConfig = defineWorkbench({
     tourStopEntity,
     eventEntity,
   ],
-  views: [mapView],
+  views: [mapView, overviewView],
   operations: [],
   defaultLayout: {
     left: [],
     center: ["map"],
-    right: [],
+    right: ["overview"],
     bottom: [],
   },
 });


### PR DESCRIPTION
## Summary

Workbench Phase 4, **first sub-PR**. Adds the second view to the dock — a compact `OverviewView` in the right region — so two views now share the same `EntityIndex` and selection state. Sets the pattern that **TableView (4b)** and **HierarchyView (4c)** will follow.

3 files changed, +132 / −5.

## The dock after this PR

```
  left:    -
  center:  MapView       (3D scene, from Phase 3b)
  right:   OverviewView   (NEW)
  bottom:  -
```

## What OverviewView shows

Reads everything from `ctx.entities`. No writes, no engine interaction — the simplest possible second view.

- **Stat tiles:** POI / Building / Floor plan / Event counts
- **Accessibility coverage:** % of POIs flagged `wheelchairAccessible`, with the raw `accessible / total` underneath
- **Selection echo:** the currently focused entity id, surfaced live (verifies the cross-view selection bridge is working — click a POI in the 3D scene, the id shows up here)

## Why it lives in the right region

`MapView` claims the centre; `OverviewView` is small, summary-y, and doesn't need height — it slots neatly next to the map without competing for visual weight. The right dock has its own collapse-expand chevron from the Phase 2 `Dock`, so users can hide it.

## Files

- **`apps/campus/lib/workbench/views/overview.tsx`** *(new)* — the `overviewView` registration + `OverviewViewComponent`. Reads `wheelchairAccessible` via a loose payload type so the view stays decoupled from `@klorad/api`'s `POI` shape. If accessibility becomes a first-class concept later it gets its own field on `EntityType` and the view tightens up.
- **`apps/campus/lib/workbench/views/index.ts`** — re-exports `overviewView`.
- **`apps/campus/workbench.config.ts`** — registers `overviewView`, pins it to `defaultLayout.right`.

## Worth knowing

- **The right dock is 288 px wide** (`w-72`) when open. The stat tile grid is 2-column inside that — comfortable but not roomy. The layout will hold for the inspector-style views that follow.
- **No data dependencies beyond what `MapView` already loads.** `WorkbenchClient` already passes a populated entity index; this view just reads more keys off it.
- **The accessibility number will read `0%` on maps with zero POIs flagged.** Not a bug — that's literally the current coverage. The view exists partly to make that gap visible.

## Test plan

- [x] Typecheck: campus + design-system + config all clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Open `/org/<orgId>/maps/<mapId>/workbench` on a real map — right dock opens with OverviewView showing real counts
- [ ] Click a POI in the 3D scene — `OverviewView`'s "Selected" line updates to that POI's id
- [ ] Toggle the right region with the dock's chevron — OverviewView hides / reveals
- [ ] `/builder` still untouched (this PR doesn't touch it)

## Next

**Phase 4b — TableView.** Generic row list over an entity type (POIs first); rows click to select, selection bridges to the map. The most interactive of the three new views; will land on the left region.

**Phase 4c — HierarchyView.** Building → Floor → POI tree, also on the left. Shares the entity index the table and overview read from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
