### PR TITLE
Workbench Phase 4b: TableView in the left dock (selection bridges both ways)

### DIFF
--- a/apps/campus/lib/workbench/views/index.ts
+++ b/apps/campus/lib/workbench/views/index.ts
@@ -1,2 +1,3 @@
 export { mapView } from "./map";
 export { overviewView } from "./overview";
+export { tableView } from "./table";

--- a/apps/campus/lib/workbench/views/table.tsx
+++ b/apps/campus/lib/workbench/views/table.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { POI } from "@klorad/api";
+import type { Entity, View, ViewProps } from "@klorad/config/workbench";
+
+/**
+ * Phase 4b — TableView.
+ *
+ * A compact list of POIs in the left dock region. Click a row to
+ * select; selection bridges to the map (the 3D view highlights the
+ * same id). v1 is POI-only and renders as a single-column list
+ * because the left dock is `w-72` wide — narrow for a real table.
+ *
+ * Per-entity-type column definitions (so the same component can
+ * render Buildings, FloorPlans, etc. with their own columns) are
+ * deferred. When TableView starts surfacing more than one entity
+ * type, `EntityType` gains a `tableColumns: { key, label, render }`
+ * field and this component renders against that.
+ */
+function TableViewComponent({ ctx }: ViewProps) {
+  const pois = ctx.entities.byType("campus.poi") as Entity<POI>[];
+  const selectedId = ctx.selection.focusedId;
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b border-line-soft px-4 py-3">
+        <h2 className="text-sm font-semibold text-text-primary">POIs</h2>
+        <p className="mt-0.5 text-[0.7rem] text-text-tertiary">
+          {pois.length} entr{pois.length === 1 ? "y" : "ies"}
+        </p>
+      </header>
+
+      {pois.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center p-4 text-center text-xs text-text-tertiary">
+          No POIs in this world yet.
+        </div>
+      ) : (
+        <ul className="min-h-0 flex-1 overflow-auto">
+          {pois.map((entity) => {
+            const poi = entity.payload;
+            const isSelected = entity.id === selectedId;
+            const handleClick = () => {
+              ctx.setSelection({
+                ids: isSelected ? new Set<string>() : new Set([entity.id]),
+                focusedId: isSelected ? null : entity.id,
+              });
+            };
+            return (
+              <li key={entity.id}>
+                <button
+                  type="button"
+                  onClick={handleClick}
+                  className={
+                    "flex w-full items-center gap-2 border-b border-line-soft px-4 py-2.5 text-left transition-colors " +
+                    (isSelected
+                      ? "border-l-2 border-l-accent bg-accent-soft text-text-primary"
+                      : "border-l-2 border-l-transparent text-text-secondary hover:bg-surface-2 hover:text-text-primary")
+                  }
+                  aria-pressed={isSelected}
+                >
+                  <span className="min-w-0 flex-1 truncate text-sm">
+                    {poi.name || "Unnamed POI"}
+                  </span>
+                  {poi.category ? (
+                    <span className="shrink-0 rounded-full border border-line-soft bg-surface-1 px-1.5 py-0.5 text-[0.65rem] uppercase tracking-[0.04em] text-text-tertiary">
+                      {poi.category}
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function TableIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="3" y1="15" x2="21" y2="15" />
+      <line x1="9" y1="3" x2="9" y2="21" />
+    </svg>
+  );
+}
+
+export const tableView: View = {
+  id: "table",
+  label: "Table",
+  icon: TableIcon,
+  entityTypes: ["campus.poi"],
+  defaultDock: "left",
+  component: TableViewComponent,
+};

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -7,6 +7,7 @@ import {
   eventEntity,
   mapView,
   overviewView,
+  tableView,
 } from "@/lib/workbench";
 
 /**
@@ -18,8 +19,10 @@ import {
  *                bridge)
  * - Phase 4a  — `overviewView` in the right region (POI / building /
  *                floor-plan counts, accessibility coverage)
- * - Phase 4b+ — TableView (left), HierarchyView (left), operations,
- *                further layout tuning
+ * - Phase 4b  — `tableView` in the left region (POI list, click to
+ *                select, bridges to the map)
+ * - Phase 4c+ — HierarchyView (left, stacked under the table),
+ *                operations, further layout tuning
  *
  * Imported by `/maps/[mapId]/workbench/page.tsx` at runtime; the old
  * `/maps/[mapId]/builder` route stays untouched until Phase 6.
@@ -35,10 +38,10 @@ const workbenchConfig = defineWorkbench({
     tourStopEntity,
     eventEntity,
   ],
-  views: [mapView, overviewView],
+  views: [mapView, overviewView, tableView],
   operations: [],
   defaultLayout: {
-    left: [],
+    left: ["table"],
     center: ["map"],
     right: ["overview"],
     bottom: [],


### PR DESCRIPTION
## Summary

Workbench Phase 4, **second sub-PR**. Adds the third view to the dock — a `TableView` (POI list) in the left region. Two-direction selection now works: clicking a POI in the 3D scene highlights its row in the list, and clicking a row sends the focus back through `ctx.setSelection` → MapView.

3 files changed, +116 / −4.

## The dock after this PR

```
  left:    TableView    (NEW)
  center:  MapView
  right:   OverviewView
  bottom:  -
```

## What TableView does

- Reads POIs from `ctx.entities.byType("campus.poi")`.
- Renders a **single-column row list** — the left dock is `w-72` (288 px), narrow for a real multi-column table. Each row shows the POI name, with a small category pill on the right when one is set.
- **Click a row** → `ctx.setSelection({ ids: {id}, focusedId: id })`. The 3D scene picks up the same id via the Phase 3b selection bridge and highlights the POI on the map.
- **Re-click the same row** deselects.
- **Selected row** gets an accent left-border + soft accent background.
- **Empty state** when the world has no POIs.

## Two-direction selection is now real

After this PR, the cross-view selection bridge round-trips:

1. Click a POI in the 3D scene → `MapView` calls `ctx.setSelection`.
2. The shell stores the selection, propagates `ctx` to every view.
3. `TableView` re-renders, finds its row whose `entity.id === ctx.selection.focusedId`, highlights it.
4. `OverviewView` echoes the focused id text.

And the reverse:

1. Click a row in `TableView` → `ctx.setSelection(...)`.
2. `MapView` re-renders, `useMapboxPoiLayer` re-runs with the new `selectedPoiId`, highlights the POI in 3D.

That's the architectural payoff of the EntityIndex + selection-state design from earlier phases working end-to-end.

## Per-entity-type columns: deliberately deferred

The doc mentions "per-entity-type column definition layer" as part of Phase 4. v1 hardcodes POI columns inside `TableView`. When the view starts surfacing more than one entity type, `EntityType` gains a `tableColumns: { key, label, render }` field and `TableView` renders against that contract. Defer until needed — keeps the surface honest.

## Files

- **`apps/campus/lib/workbench/views/table.tsx`** *(new)* — `tableView` registration + `TableViewComponent`.
- **`apps/campus/lib/workbench/views/index.ts`** — re-exports `tableView`.
- **`apps/campus/workbench.config.ts`** — registers `tableView`, pins it to `defaultLayout.left`.

## Test plan

- [x] Typecheck: campus all clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Open `/org/<orgId>/maps/<mapId>/workbench` on a real map — left dock opens with the POI list, count in the header matches the OverviewView count
- [ ] Click a row → POI highlights in the 3D scene → OverviewView "Selected" line updates
- [ ] Click a POI in the 3D scene → its row highlights in the table
- [ ] Re-click the selected row → deselects in both views
- [ ] Toggle the left region with the dock's chevron → TableView hides / reveals
- [ ] On a fresh map with zero POIs, the empty state message appears

## Next

**Phase 4c — HierarchyView.** Building → Floor → POI tree, also in the left region (stacked under `TableView`). The view drills into the building-floor-POI relationship that `TableView` flattens out. After 4c lands, all three Phase 4 views are in place and the dock is at "minimum useful Workbench" — every view consumes the same entity index, selection bridges everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
