### PR TITLE
Campus builder: brand mark + full viewport height

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/builder/BuilderClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/builder/BuilderClient.tsx
@@ -777,7 +777,7 @@ export default function BuilderClient({ mapId }: Props) {
   });
 
   return (
-    <Box sx={{ display: "flex", height: "calc(100vh - 64px)", overflow: "hidden" }}>
+    <Box sx={{ display: "flex", height: "100vh", overflow: "hidden" }}>
       <BuilderLeftPanel pois={pois} />
 
       {/* Map */}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/builder/BuilderLeftPanel.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/builder/BuilderLeftPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import {
@@ -16,6 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
+import { KloradMark } from "@klorad/design-system";
 import { LeftPanelContainer } from "@klorad/ui";
 import { useSceneStore } from "@klorad/core";
 import type { POI } from "@klorad/api";
@@ -124,7 +124,8 @@ export default function BuilderLeftPanel({ mapName, pois }: Props) {
         flexDirection: "column",
       }}
     >
-      {/* Logo */}
+      {/* Logo — matches the campus dashboard brand block:
+          KloradMark + stacked "Klorad / Campus" wordmark. */}
       <Box
         sx={{
           display: "flex",
@@ -135,18 +136,20 @@ export default function BuilderLeftPanel({ mapName, pois }: Props) {
           flexShrink: 0,
         }}
       >
-        <Link href={profileHref} aria-label="Back to Campus Profile" style={{ textDecoration: "none", display: "flex" }}>
-          <Image
-            src="/images/logo/klorad-campus-logo-white.svg"
-            alt="Klorad Campus"
-            width={140}
-            height={32}
-            priority
-            style={{
-              objectFit: "contain",
-              height: "auto",
-            }}
-          />
+        <Link
+          href={profileHref}
+          aria-label="Back to Campus Profile"
+          className="flex items-center gap-2.5 no-underline"
+        >
+          <KloradMark className="h-8 w-auto" />
+          <span className="flex flex-col leading-none">
+            <span className="text-sm font-semibold uppercase tracking-[0.18em] text-text-primary">
+              Klorad
+            </span>
+            <span className="mt-1 text-[10px] font-medium uppercase tracking-[0.26em] text-text-tertiary">
+              Campus
+            </span>
+          </span>
         </Link>
       </Box>
 


### PR DESCRIPTION
## Summary

Two follow-ups on the campus builder route surfaced during user testing:

1. **Logo** — `BuilderLeftPanel` was still rendering the old `klorad-campus-logo-white.svg` asset. Replaced with the design-system `KloradMark` + stacked "Klorad / Campus" wordmark — same brand block the dashboard, sign-in and onboarding already use.
2. **Height** — the outer container sized to `calc(100vh - 64px)`, reserving room for the AppShell top bar. But `DashboardShell` bypasses its chrome for `/builder` routes (since the campus DS migration), so the `-64px` left a ~64-pixel gap at the bottom and the Mapbox scene fell short of filling the viewport. Set to `100vh`.

2 files changed, +18 / −15.

## What changed

**`apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/builder/BuilderLeftPanel.tsx`**
- Drops `import Image from "next/image"`.
- Adds `import { KloradMark } from "@klorad/design-system"`.
- Logo block swaps the `<Image>` with `<KloradMark className="h-8 w-auto" />` + the stacked uppercase-tracked wordmark.
- The outer `Box` (64 px header, border-bottom) is unchanged — same hit target, same positioning.

**`apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/builder/BuilderClient.tsx`**
- Outer `Box` height: `calc(100vh - 64px)` → `100vh`. Single character change in spirit, but the Mapbox scene finally fills the viewport.

## Worth knowing

- **No data flow changes.** This is purely visual / layout.
- **The left panel's own positioning** (`top: 16, height: calc(100vh - 32px)`) is unchanged and still correct — the `-32px` is for the 16 px inset top + 16 px inset bottom of the floating panel, not chrome compensation.
- **The old `klorad-campus-logo-white.svg`** asset stays in place. Removable in a follow-up sweep once we're confident nothing else references it.

## Test plan

- [x] Typecheck: campus clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Open `/org/<orgId>/maps/<mapId>/builder` on a real map
- [ ] Left panel header shows the `KloradMark` icon + "Klorad / Campus" stacked text (same as dashboard / sign-in)
- [ ] Mapbox scene fills the viewport edge-to-edge — no gap at the bottom
- [ ] Click the logo block — navigates back to the campus profile (`/maps/[mapId]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
