### PR TITLE
Workbench Phase 4c: HierarchyView + stacking views in one dock region

### DIFF
--- a/apps/campus/lib/workbench/views/hierarchy.tsx
+++ b/apps/campus/lib/workbench/views/hierarchy.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import type { FloorPlan, POI } from "@klorad/api";
+import type { Entity, View, ViewProps } from "@klorad/config/workbench";
+import type { Building } from "../entities/building";
+
+/**
+ * Phase 4c — HierarchyView.
+ *
+ * A collapsible tree of Building → (FloorPlans + child POIs), with
+ * a flat "Unbuilt" section underneath for POIs that don't belong to
+ * a building. Lives in the left dock, stacked under TableView.
+ *
+ * - Buildings come from `ctx.entities.byType("campus.building")`.
+ * - Child POIs are matched by `payload.parentBuildingId === building.id`.
+ * - Floor plans are matched by `payload.buildingId === building.id`.
+ * - Standalone POIs are POIs without a `parentBuildingId` that aren't
+ *   themselves Building-entities.
+ *
+ * Clicking any leaf or building name fires `ctx.setSelection(...)`.
+ * The 3D scene + table + overview all react via the shared selection.
+ *
+ * Local UI state: which buildings are expanded. Selection state
+ * lives in the shell.
+ */
+function HierarchyViewComponent({ ctx }: ViewProps) {
+  const buildings = ctx.entities.byType(
+    "campus.building",
+  ) as Entity<Building>[];
+  const allPois = ctx.entities.byType("campus.poi") as Entity<POI>[];
+  const allFloorPlans = ctx.entities.byType(
+    "campus.floor-plan",
+  ) as Entity<FloorPlan>[];
+
+  const buildingIdSet = useMemo(
+    () => new Set(buildings.map((b) => b.id)),
+    [buildings],
+  );
+
+  const childPoisByBuilding = useMemo(() => {
+    const map = new Map<string, Entity<POI>[]>();
+    for (const p of allPois) {
+      const pid = p.payload.parentBuildingId;
+      if (pid && buildingIdSet.has(pid)) {
+        const existing = map.get(pid);
+        if (existing) existing.push(p);
+        else map.set(pid, [p]);
+      }
+    }
+    return map;
+  }, [allPois, buildingIdSet]);
+
+  const floorsByBuilding = useMemo(() => {
+    const map = new Map<string, Entity<FloorPlan>[]>();
+    for (const fp of allFloorPlans) {
+      const bid = fp.payload.buildingId;
+      if (bid && buildingIdSet.has(bid)) {
+        const existing = map.get(bid);
+        if (existing) existing.push(fp);
+        else map.set(bid, [fp]);
+      }
+    }
+    // Sort floor plans by floor number where available.
+    for (const list of map.values()) {
+      list.sort((a, b) => (a.payload.floor ?? 0) - (b.payload.floor ?? 0));
+    }
+    return map;
+  }, [allFloorPlans, buildingIdSet]);
+
+  const standalonePois = useMemo(
+    () =>
+      allPois.filter(
+        (p) => !p.payload.parentBuildingId && !buildingIdSet.has(p.id),
+      ),
+    [allPois, buildingIdSet],
+  );
+
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const toggleExpanded = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const focusedId = ctx.selection.focusedId;
+  const select = (id: string) => {
+    const next = focusedId === id ? null : id;
+    ctx.setSelection({
+      ids: next ? new Set([next]) : new Set<string>(),
+      focusedId: next,
+    });
+  };
+
+  const isEmpty = buildings.length === 0 && standalonePois.length === 0;
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b border-line-soft px-4 py-3">
+        <h2 className="text-sm font-semibold text-text-primary">Hierarchy</h2>
+        <p className="mt-0.5 text-[0.7rem] text-text-tertiary">
+          {buildings.length} building{buildings.length === 1 ? "" : "s"} ·{" "}
+          {standalonePois.length} unbuilt
+        </p>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto py-1">
+        {isEmpty ? (
+          <div className="px-4 py-6 text-center text-xs text-text-tertiary">
+            Nothing in this world yet.
+          </div>
+        ) : (
+          <>
+            {buildings.map((b) => {
+              const open = expanded.has(b.id);
+              const children = childPoisByBuilding.get(b.id) ?? [];
+              const floors = floorsByBuilding.get(b.id) ?? [];
+              const isSelected = focusedId === b.id;
+              return (
+                <div key={b.id}>
+                  <div className="flex items-stretch">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(b.id)}
+                      className="flex w-7 shrink-0 items-center justify-center text-text-tertiary hover:text-text-primary"
+                      aria-label={open ? "Collapse" : "Expand"}
+                      aria-expanded={open}
+                    >
+                      <Chevron open={open} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => select(b.id)}
+                      aria-pressed={isSelected}
+                      className={
+                        "flex flex-1 items-center gap-1.5 truncate py-1.5 pr-3 text-left text-sm transition-colors " +
+                        (isSelected
+                          ? "font-medium text-accent"
+                          : "text-text-primary hover:text-accent")
+                      }
+                    >
+                      <BuildingIcon />
+                      <span className="truncate">
+                        {b.payload.name || "Unnamed building"}
+                      </span>
+                    </button>
+                  </div>
+
+                  {open ? (
+                    <div className="ml-3.5 border-l border-line-soft pl-1.5 pb-1">
+                      {floors.length === 0 && children.length === 0 ? (
+                        <Leaf>
+                          <span className="italic">
+                            No floors or child POIs
+                          </span>
+                        </Leaf>
+                      ) : null}
+                      {floors.map((f) => (
+                        <Leaf
+                          key={f.id}
+                          icon={<FloorIcon />}
+                          label={
+                            f.payload.name ??
+                            (f.payload.floor !== undefined
+                              ? `Floor ${f.payload.floor}`
+                              : "Floor")
+                          }
+                          selected={focusedId === f.id}
+                          onSelect={() => select(f.id)}
+                        />
+                      ))}
+                      {children.map((p) => (
+                        <Leaf
+                          key={p.id}
+                          icon={<PoiIcon />}
+                          label={p.payload.name || "Unnamed POI"}
+                          selected={focusedId === p.id}
+                          onSelect={() => select(p.id)}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+
+            {standalonePois.length > 0 ? (
+              <>
+                <div className="border-t border-line-soft px-4 pt-3 pb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-tertiary">
+                  Unbuilt POIs
+                </div>
+                {standalonePois.map((p) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => select(p.id)}
+                    aria-pressed={focusedId === p.id}
+                    className={
+                      "flex w-full items-center gap-1.5 truncate px-4 py-1.5 text-left text-sm transition-colors " +
+                      (focusedId === p.id
+                        ? "bg-accent-soft font-medium text-accent"
+                        : "text-text-secondary hover:text-text-primary")
+                    }
+                  >
+                    <PoiIcon />
+                    <span className="truncate">
+                      {p.payload.name || "Unnamed POI"}
+                    </span>
+                  </button>
+                ))}
+              </>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Leaf({
+  icon,
+  label,
+  selected,
+  onSelect,
+  children,
+}: {
+  icon?: ReactNode;
+  label?: string;
+  selected?: boolean;
+  onSelect?: () => void;
+  children?: ReactNode;
+}) {
+  if (!onSelect) {
+    return (
+      <div className="flex items-center gap-1.5 py-1 pl-2 pr-3 text-xs text-text-tertiary">
+        {children}
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={
+        "flex w-full items-center gap-1.5 truncate py-1 pl-2 pr-3 text-left text-[0.8125rem] transition-colors " +
+        (selected
+          ? "font-medium text-accent"
+          : "text-text-secondary hover:text-text-primary")
+      }
+    >
+      {icon}
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={"transition-transform " + (open ? "rotate-90" : "")}
+      aria-hidden
+    >
+      <path d="m9 6 6 6-6 6" />
+    </svg>
+  );
+}
+
+function BuildingIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden
+    >
+      <rect x="4" y="3" width="16" height="18" rx="1" />
+      <line x1="9" y1="7" x2="9" y2="7" />
+      <line x1="15" y1="7" x2="15" y2="7" />
+      <line x1="9" y1="12" x2="9" y2="12" />
+      <line x1="15" y1="12" x2="15" y2="12" />
+      <line x1="9" y1="17" x2="15" y2="17" />
+    </svg>
+  );
+}
+
+function FloorIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      className="shrink-0"
+      aria-hidden
+    >
+      <line x1="3" y1="8" x2="21" y2="8" />
+      <line x1="3" y1="16" x2="21" y2="16" />
+    </svg>
+  );
+}
+
+function PoiIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden
+    >
+      <path d="M12 21s-7-6.5-7-12a7 7 0 1 1 14 0c0 5.5-7 12-7 12Z" />
+      <circle cx="12" cy="9" r="2.5" />
+    </svg>
+  );
+}
+
+function HierarchyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <line x1="9" y1="6" x2="20" y2="6" />
+      <line x1="11" y1="12" x2="20" y2="12" />
+      <line x1="13" y1="18" x2="20" y2="18" />
+      <path d="M4 4v14a2 2 0 0 0 2 2h2" />
+      <path d="M6 12h4" />
+    </svg>
+  );
+}
+
+export const hierarchyView: View = {
+  id: "hierarchy",
+  label: "Hierarchy",
+  icon: HierarchyIcon,
+  entityTypes: ["campus.building", "campus.poi", "campus.floor-plan"],
+  defaultDock: "left",
+  component: HierarchyViewComponent,
+};

--- a/apps/campus/lib/workbench/views/index.ts
+++ b/apps/campus/lib/workbench/views/index.ts
@@ -1,3 +1,4 @@
 export { mapView } from "./map";
 export { overviewView } from "./overview";
 export { tableView } from "./table";
+export { hierarchyView } from "./hierarchy";

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -8,6 +8,7 @@ import {
   mapView,
   overviewView,
   tableView,
+  hierarchyView,
 } from "@/lib/workbench";
 
 /**
@@ -21,8 +22,9 @@ import {
  *                floor-plan counts, accessibility coverage)
  * - Phase 4b  — `tableView` in the left region (POI list, click to
  *                select, bridges to the map)
- * - Phase 4c+ — HierarchyView (left, stacked under the table),
- *                operations, further layout tuning
+ * - Phase 4c  — `hierarchyView` in the left region, stacked under
+ *                the table (Building → Floor + child POIs tree)
+ * - Phase 5+  — operations, further layout tuning
  *
  * Imported by `/maps/[mapId]/workbench/page.tsx` at runtime; the old
  * `/maps/[mapId]/builder` route stays untouched until Phase 6.
@@ -38,10 +40,10 @@ const workbenchConfig = defineWorkbench({
     tourStopEntity,
     eventEntity,
   ],
-  views: [mapView, overviewView, tableView],
+  views: [mapView, overviewView, tableView, hierarchyView],
   operations: [],
   defaultLayout: {
-    left: ["table"],
+    left: ["table", "hierarchy"],
     center: ["map"],
     right: ["overview"],
     bottom: [],

--- a/packages/design-system/src/components/workbench.tsx
+++ b/packages/design-system/src/components/workbench.tsx
@@ -100,6 +100,10 @@ export function Workbench({
       <div className="flex h-full flex-col">
         {ids.map((id) => {
           const view = viewById.get(id);
+          // Each view is wrapped in `flex-1 min-h-0` so multiple views
+          // stacked in the same region split the available height evenly
+          // instead of fighting over `h-full`. A divider between siblings
+          // (except the last) gives them visual separation.
           if (!view) {
             return (
               <div
@@ -111,7 +115,14 @@ export function Workbench({
             );
           }
           const Component = view.component;
-          return <Component key={id} ctx={ctx} />;
+          return (
+            <div
+              key={id}
+              className="min-h-0 flex-1 overflow-hidden border-b border-line-soft last:border-b-0"
+            >
+              <Component ctx={ctx} />
+            </div>
+          );
         })}
       </div>
     );


### PR DESCRIPTION
## Summary

Closes out the Phase 4 view triad. After this PR the `/workbench` dock mounts:

```
  left:    TableView  +  HierarchyView   (stacked, share the column)
  center:  MapView
  right:   OverviewView
```

Two coordinated changes:

1. **`@klorad/design-system` `Workbench` shell** — per-region renderer wraps each view in a `flex-1 min-h-0 overflow-hidden border-b border-line-soft last:border-b-0` div so multiple views stacked in the same region split the available height evenly. Without this, two views with `h-full` rendered on top of each other fought over the column and the second one overflowed.

2. **New `HierarchyView` in `apps/campus`** — a collapsible Building → (FloorPlans + child POIs) tree, plus a flat "Unbuilt POIs" section underneath for POIs that aren't attached to any building. Drives selection via `ctx.setSelection` like the other views; expand/collapse state lives locally.

4 files changed, +393 / −5.

## How the tree is derived

Pure projection of the entity index:

- **Buildings** — `ctx.entities.byType("campus.building")`.
- **Child POIs of building B** — POIs where `payload.parentBuildingId === B.id`.
- **Floors of building B** — `FloorPlan`s where `payload.buildingId === B.id`, sorted by `floor` number.
- **Standalone POIs** — POIs without a `parentBuildingId` that aren't themselves Building-entities.

No data fetching, no shared state with `TableView` — both views consume the same `EntityIndex`. The architectural pay-off of Phase 1 (typed entities) + Phase 2 (shared `ViewContext`) + Phase 3 (selection bridge) lives across all four views now.

## Selection bridges across four views

Click any node in the hierarchy →

- The 3D scene highlights the POI (for POI nodes).
- The row highlights in `TableView`.
- The `OverviewView`'s "Selected" line updates.
- The hierarchy itself highlights the selected node.

…and clicks from any of those other surfaces propagate back into the hierarchy node.

## On stacking in the dock

The shell change is small but important — it's the first time **multiple views in one region** has been exercised end-to-end. The fix is local to `renderRegion` and behaves identically for single-view regions (one wrapper, `flex-1` takes the whole column). The optional `border-b` between siblings is a token-themed thin divider; it disappears for the last child via `last:border-b-0`.

## Files

- **`packages/design-system/src/components/workbench.tsx`** — wraps each view in `flex-1 min-h-0` inside `renderRegion`.
- **`apps/campus/lib/workbench/views/hierarchy.tsx`** *(new)* — `hierarchyView` registration + `HierarchyViewComponent` with `Chevron`, `Leaf`, `BuildingIcon`, `FloorIcon`, `PoiIcon`, `HierarchyIcon` helpers.
- **`apps/campus/lib/workbench/views/index.ts`** — re-exports `hierarchyView`.
- **`apps/campus/workbench.config.ts`** — registers `hierarchyView`, adds to `defaultLayout.left` after `table`.

## Worth knowing

- **The left column is `w-72` (288 px) and now hosts two scrollable views.** Each takes ~50% of the column height. If the split feels too generous to one or the other, a `flex-grow` ratio on the wrappers can be added later — for now, equal-split is the simplest contract.
- **Rooms aren't in the hierarchy.** Room entities aren't registered in `@klorad/config/workbench` yet (Phase 1.2 stopped at POI / Building / FloorPlan / TourStop / Event). When they land, the hierarchy gets a fourth level: Building → Floor → Room.
- **Floor selection just stores the id.** `MapView` doesn't yet react to a floor-plan id in `ctx.selection` (it only highlights POIs). Wiring that comes when Phase 5 introduces operations and the active-floor concept gets formalised.

## Test plan

- [x] Typecheck: design-system + campus clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Open `/org/<orgId>/maps/<mapId>/workbench` on a real map
- [ ] Left dock opens with TableView on top + HierarchyView below, separated by a thin divider
- [ ] HierarchyView shows the buildings as collapsible nodes; chevron expands; floors sorted by number; child POIs listed
- [ ] Click a child POI in the hierarchy → POI highlights in the 3D scene + row highlights in the table
- [ ] Click a POI in the 3D scene → its row in the table highlights AND its parent building auto-expands in the hierarchy (if applicable) — actually this doesn't auto-expand yet; an interesting follow-up, but the leaf only highlights when the parent is already expanded
- [ ] Standalone POIs list shows under an "Unbuilt POIs" header

## Next

**Phase 5 — operations.** Now that the four views are in place and selection works end-to-end, the next step is the operations layer:

- Define typed `Operation` records (per the contracts that already exist in `@klorad/config/workbench`).
- Route writes through `ctx.runOperation` instead of through `BuilderClient`'s side paths.
- Surface operations contextually — right-click on a selection, a command palette (`mod+k`), keyboard shortcuts, view-authored buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
