### PR TITLE
Workbench Phase 5a: first typed Operation (poi.fly-to)

### DIFF
--- a/apps/campus/lib/workbench/index.ts
+++ b/apps/campus/lib/workbench/index.ts
@@ -2,14 +2,11 @@
  * The campus Workbench module — campus's typed entities, views, and
  * operations that the shared Workbench shell consumes.
  *
- * - Phase 1.2 — entity registrations
- * - Phase 2 — a placeholder map view
- * - Phase 5 — operations (TBD)
- *
  * See `apps/campus/WORKBENCH.md` for the full migration plan.
  */
 
 export * from "./entities";
+export * from "./operations";
 export * from "./runtime";
 export * from "./views";
 export { identitySchema } from "./schema";

--- a/apps/campus/lib/workbench/operations/fly-to-poi.ts
+++ b/apps/campus/lib/workbench/operations/fly-to-poi.ts
@@ -1,0 +1,57 @@
+import type { POI } from "@klorad/api";
+import type { Operation } from "@klorad/config/workbench";
+import { useSceneStore } from "@klorad/core";
+import type { Map as MapboxMap } from "mapbox-gl";
+
+/**
+ * Fly the Mapbox camera to a POI.
+ *
+ * Phase 5a — the first operation. Demonstrates the contract
+ * end-to-end:
+ *
+ *   - declared in @klorad/config/workbench's `Operation` shape
+ *   - registered on the campus workbench config
+ *   - invoked from a view via `ctx.runOperation("poi.fly-to", …)`
+ *
+ * Reads the focused POI's `position` off the entity index and calls
+ * Mapbox's `flyTo`. The Mapbox instance comes off the global scene
+ * store (the same store both `/builder` and the Workbench MapView
+ * write into) — operations don't need a custom engine handle for
+ * v1; they reach the engine via the existing shared singleton.
+ */
+export const flyToPoiOp: Operation = {
+  id: "poi.fly-to",
+  label: "Fly to POI",
+  scope: ["campus.poi"],
+  applies: (sel, entities) => {
+    if (!sel.focusedId) return false;
+    const entity = entities.byId(sel.focusedId);
+    return entity?.typeId === "campus.poi";
+  },
+  async invoke(ctx, _args, on) {
+    const id = on[0] ?? ctx.entities.all().find((e) => e.typeId === "campus.poi")?.id;
+    if (!id) return { ok: false, reason: "No POI to fly to" };
+
+    const entity = ctx.entities.byId(id);
+    if (!entity || entity.typeId !== "campus.poi") {
+      return { ok: false, reason: `Not a POI: ${id}` };
+    }
+
+    const poi = entity.payload as POI;
+    const [lng, lat] = poi.position;
+    const map = useSceneStore.getState().mapboxMap as MapboxMap | null;
+    if (!map) return { ok: false, reason: "Map not loaded" };
+
+    map.flyTo({
+      center: [lng, lat],
+      zoom: poi.view?.zoom ?? 17,
+      pitch: poi.view?.pitch,
+      bearing: poi.view?.bearing,
+      duration: 1500,
+      essential: true,
+    });
+
+    ctx.toast(`Flying to ${poi.name || "POI"}`);
+    return { ok: true };
+  },
+};

--- a/apps/campus/lib/workbench/operations/index.ts
+++ b/apps/campus/lib/workbench/operations/index.ts
@@ -1,0 +1,1 @@
+export { flyToPoiOp } from "./fly-to-poi";

--- a/apps/campus/lib/workbench/views/overview.tsx
+++ b/apps/campus/lib/workbench/views/overview.tsx
@@ -64,17 +64,70 @@ function OverviewViewComponent({ ctx }: ViewProps) {
         </div>
       </div>
 
-      <div className="rounded-lg border border-dashed border-line-soft p-3 text-xs text-text-tertiary">
+      <SelectionPanel ctx={ctx} />
+    </div>
+  );
+}
+
+/**
+ * The right-dock's "what's selected" card. Echoes the focused id and
+ * surfaces operations that apply to the current selection. v1 wires
+ * `poi.fly-to` — registered in `workbench.config.ts` and invoked via
+ * `ctx.runOperation(...)`. Future ops light up here without further
+ * shell changes.
+ */
+function SelectionPanel({ ctx }: { ctx: ViewProps["ctx"] }) {
+  const focusedId = ctx.selection.focusedId;
+  const focusedEntity = focusedId ? ctx.entities.byId(focusedId) : null;
+  const canFlyToPoi = focusedEntity?.typeId === "campus.poi";
+
+  const handleFly = () => {
+    if (!focusedId) return;
+    void ctx.runOperation("poi.fly-to", undefined, [focusedId]);
+  };
+
+  return (
+    <div className="rounded-lg border border-dashed border-line-soft p-3 text-xs text-text-tertiary">
+      <div>
         Selected:{" "}
-        {ctx.selection.focusedId ? (
+        {focusedId ? (
           <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.7rem] text-text-primary">
-            {ctx.selection.focusedId}
+            {focusedId}
           </code>
         ) : (
           <span>nothing</span>
         )}
       </div>
+      {canFlyToPoi ? (
+        <button
+          type="button"
+          onClick={handleFly}
+          className="mt-2 inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-accent px-3 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover"
+        >
+          <FlyToIcon />
+          Fly to in 3D
+        </button>
+      ) : null}
     </div>
+  );
+}
+
+function FlyToIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M22 2 11 13" />
+      <path d="m22 2-7 20-4-9-9-4z" />
+    </svg>
   );
 }
 

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -9,6 +9,7 @@ import {
   overviewView,
   tableView,
   hierarchyView,
+  flyToPoiOp,
 } from "@/lib/workbench";
 
 /**
@@ -24,7 +25,9 @@ import {
  *                select, bridges to the map)
  * - Phase 4c  — `hierarchyView` in the left region, stacked under
  *                the table (Building → Floor + child POIs tree)
- * - Phase 5+  — operations, further layout tuning
+ * - Phase 5a  — first typed `Operation` registered (`poi.fly-to`),
+ *                invoked via `ctx.runOperation(...)` from a button in
+ *                the OverviewView when a POI is focused
  *
  * Imported by `/maps/[mapId]/workbench/page.tsx` at runtime; the old
  * `/maps/[mapId]/builder` route stays untouched until Phase 6.
@@ -41,7 +44,7 @@ const workbenchConfig = defineWorkbench({
     eventEntity,
   ],
   views: [mapView, overviewView, tableView, hierarchyView],
-  operations: [],
+  operations: [flyToPoiOp],
   defaultLayout: {
     left: ["table", "hierarchy"],
     center: ["map"],


### PR DESCRIPTION
## Summary

Phase 5 of the Workbench migration starts here. Lands the **first typed `Operation`** end-to-end on the smallest meaningful write-free op: **`poi.fly-to`**. Demonstrates the dispatch pipeline without pulling in modals, command palettes or destructive flows.

5 files changed, +120 / −10.

## The dispatch path now lives

Phase 1 shipped the `Operation` contract in `@klorad/config/workbench`. Phase 2 shipped `ctx.runOperation(opId, args, on)` on the shell. Phase 5a fills in the missing pieces:

```
view button onClick
  → ctx.runOperation("poi.fly-to", undefined, [focusedId])
  → shell looks up operationById.get("poi.fly-to")
  → op.invoke({ worldId, actor, entities, toast }, args, on)
  → operation reaches the engine via useSceneStore.getState()
  → map.flyTo(...)
```

Operations are **actor-agnostic** by construction. When the AI-as-actor slot ships later, the same `poi.fly-to` op is callable with `actor: { kind: "ai", … }` without touching `invoke`.

## Files

- **`apps/campus/lib/workbench/operations/fly-to-poi.ts`** *(new)* — `flyToPoiOp: Operation` with scope `["campus.poi"]`, an `applies` predicate, and an `invoke` that reads the focused POI's position from `ctx.entities` and calls Mapbox's `flyTo` via the shared scene store. Honours the POI's preferred camera framing (`view.zoom / pitch / bearing`) when present. Returns `OpResult` per the contract.
- **`apps/campus/lib/workbench/operations/index.ts`** *(new)* — barrel.
- **`apps/campus/lib/workbench/index.ts`** — re-exports operations.
- **`apps/campus/workbench.config.ts`** — registers `flyToPoiOp` in `operations`.
- **`apps/campus/lib/workbench/views/overview.tsx`** — selection panel surfaces a "**Fly to in 3D**" button when the focused entity is a POI. Click → `ctx.runOperation("poi.fly-to", undefined, [focusedId])`.

## Worth knowing

- **`ctx.toast` is still a noop in the shell.** The operation calls `ctx.toast("Flying to …")` correctly per the contract, but the shell's toast handler swallows it. Phase 5b wires this to `react-toastify` (campus already uses it elsewhere).
- **Operations reach the engine via the shared scene store.** Phase 1's `OpInvokeContext` only carries `entities` + `actor` + `toast` + `worldId` — no engine handle. For campus, that's fine: operations import `useSceneStore` directly. If a future operation needs richer engine access we extend the context; not pre-built.
- **`applies` is wired but unused.** The shell's `applicableOperations: []` is still hardcoded. The OverviewView opts in directly today. Phase 5b can compute `applicableOperations` for each region's selection so context menus + command palette light up automatically.
- **Selection of non-POI entities** (Building, FloorPlan from the hierarchy view) does **not** show the fly button — `canFlyToPoi` keys off `focusedEntity?.typeId === "campus.poi"`. The scope check on the op itself enforces this server-side too: invoking on a non-POI id returns `{ ok: false, reason: "Not a POI: …" }`.

## Test plan

- [x] Typecheck: campus + design-system + config clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Open `/org/<orgId>/maps/<mapId>/workbench` on a real map
- [ ] Click a POI in the 3D scene or table → OverviewView "Selected" line updates → **"Fly to in 3D" button appears**
- [ ] Click the button → 3D camera flies to the POI (1.5s `flyTo` with the POI's preferred zoom / pitch / bearing if set)
- [ ] Click a building or unbuilt-POI tree node where applicable → fly button does NOT appear (POI-only)
- [ ] No console errors

## Next

**Phase 5b — surface more ops + wire toasts.** Candidates: `entity.deselect` (universal clear), `world.publish` (placeholder route), then move into write operations. Plus pipe `ctx.toast` to the real toast UI; right now operations talk into a black hole.

**Phase 5c — generic operation surfacing.** Compute `applicableOperations` in the shell from the registered operations and current selection. Views render them generically — no more per-button hardcoding. Then a command palette (`mod+k`) and right-click menus drop in cheaply on top of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
