### PR TITLE
Workbench Phase 5b: wire ctx.toast + world.open-viewer + world.copy-link

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Workbench } from "@klorad/design-system";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast as toastify } from "react-toastify";
+import { Workbench, type WorkbenchToast } from "@klorad/design-system";
 import { createSceneAPI } from "@klorad/api";
 import type { CampusAPI, FloorPlan, POI, TourStop } from "@klorad/api";
 import { withCampusLabelDefaults } from "@/app/hooks/useCampusLabelDefaults";
@@ -77,6 +78,26 @@ export default function WorkbenchClient({ mapId }: Props) {
     [mapId, pois, plans, tourStops],
   );
 
+  // Bridge the Workbench's `ctx.toast(msg, tone)` calls — emitted from
+  // inside operation `invoke` bodies — to react-toastify, the same
+  // surface BuilderClient / SettingsTab already use elsewhere in
+  // campus. The ToastContainer is mounted at the app's providers level.
+  const toast = useCallback<WorkbenchToast>((msg, tone) => {
+    switch (tone) {
+      case "success":
+        toastify.success(msg);
+        return;
+      case "warning":
+        toastify.warning(msg);
+        return;
+      case "error":
+        toastify.error(msg);
+        return;
+      default:
+        toastify.info(msg);
+    }
+  }, []);
+
   if (!sceneReady) {
     return (
       <div className="flex h-screen w-screen items-center justify-center bg-bg text-sm text-text-secondary">
@@ -91,6 +112,7 @@ export default function WorkbenchClient({ mapId }: Props) {
         config={workbenchConfig}
         worldId={mapId}
         entities={entities}
+        toast={toast}
       />
     </div>
   );

--- a/apps/campus/lib/workbench/operations/copy-link.ts
+++ b/apps/campus/lib/workbench/operations/copy-link.ts
@@ -1,0 +1,26 @@
+import type { Operation } from "@klorad/config/workbench";
+
+/**
+ * Copy the world's public-viewer URL to the clipboard. World-level
+ * operation (no entity scope). Pairs with `world.open-viewer`.
+ */
+export const copyLinkOp: Operation = {
+  id: "world.copy-link",
+  label: "Copy public link",
+  scope: [],
+  applies: () => true,
+  async invoke(ctx) {
+    if (typeof window === "undefined") {
+      return { ok: false, reason: "Not in a browser" };
+    }
+    const url = `${window.location.origin}/campus/${ctx.worldId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      ctx.toast("Public link copied to clipboard", "success");
+      return { ok: true };
+    } catch {
+      ctx.toast("Couldn't copy the public link", "error");
+      return { ok: false, reason: "Clipboard write failed" };
+    }
+  },
+};

--- a/apps/campus/lib/workbench/operations/index.ts
+++ b/apps/campus/lib/workbench/operations/index.ts
@@ -1,1 +1,3 @@
 export { flyToPoiOp } from "./fly-to-poi";
+export { openViewerOp } from "./open-viewer";
+export { copyLinkOp } from "./copy-link";

--- a/apps/campus/lib/workbench/operations/open-viewer.ts
+++ b/apps/campus/lib/workbench/operations/open-viewer.ts
@@ -1,0 +1,29 @@
+import type { Operation } from "@klorad/config/workbench";
+
+/**
+ * Open the world's public viewer in a new tab. World-level operation
+ * (no entity scope). Applies always; the public viewer route exists
+ * for every map.
+ *
+ * Public URL convention: `${origin}/campus/${worldId}` — same
+ * pattern the SettingsTab uses for its "Public Link" copy.
+ */
+export const openViewerOp: Operation = {
+  id: "world.open-viewer",
+  label: "Open public viewer",
+  scope: [],
+  applies: () => true,
+  async invoke(ctx) {
+    if (typeof window === "undefined") {
+      return { ok: false, reason: "Not in a browser" };
+    }
+    const url = `${window.location.origin}/campus/${ctx.worldId}`;
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (!opened) {
+      ctx.toast("Pop-up blocked — couldn't open the public viewer", "warning");
+      return { ok: false, reason: "Pop-up blocked" };
+    }
+    ctx.toast("Opened public viewer in a new tab", "success");
+    return { ok: true };
+  },
+};

--- a/apps/campus/lib/workbench/views/overview.tsx
+++ b/apps/campus/lib/workbench/views/overview.tsx
@@ -65,7 +65,97 @@ function OverviewViewComponent({ ctx }: ViewProps) {
       </div>
 
       <SelectionPanel ctx={ctx} />
+      <WorldActions ctx={ctx} />
     </div>
+  );
+}
+
+/**
+ * World-level operations — `world.open-viewer`, `world.copy-link`.
+ * Apply regardless of selection so they live in their own panel.
+ */
+function WorldActions({ ctx }: { ctx: ViewProps["ctx"] }) {
+  return (
+    <div className="space-y-2">
+      <div className="text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
+        World actions
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        <ActionButton
+          onClick={() =>
+            void ctx.runOperation("world.open-viewer", undefined, [])
+          }
+        >
+          <OpenViewerIcon />
+          Open viewer
+        </ActionButton>
+        <ActionButton
+          onClick={() =>
+            void ctx.runOperation("world.copy-link", undefined, [])
+          }
+        >
+          <CopyIcon />
+          Copy link
+        </ActionButton>
+      </div>
+    </div>
+  );
+}
+
+function ActionButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex h-7 items-center gap-1 rounded-md border border-line-strong px-2 text-[0.7rem] font-medium text-text-secondary transition-colors hover:border-accent hover:text-accent"
+    >
+      {children}
+    </button>
+  );
+}
+
+function OpenViewerIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
   );
 }
 
@@ -86,17 +176,35 @@ function SelectionPanel({ ctx }: { ctx: ViewProps["ctx"] }) {
     void ctx.runOperation("poi.fly-to", undefined, [focusedId]);
   };
 
+  // Selection-clearing is a UI affordance, not an entity-level operation
+  // — `OpInvokeContext` doesn't (and shouldn't) carry `setSelection`.
+  // Calls the view context directly.
+  const handleClear = () => {
+    ctx.setSelection({ ids: new Set<string>(), focusedId: null });
+  };
+
   return (
     <div className="rounded-lg border border-dashed border-line-soft p-3 text-xs text-text-tertiary">
-      <div>
-        Selected:{" "}
+      <div className="flex items-center justify-between gap-2">
+        <span className="min-w-0 truncate">
+          Selected:{" "}
+          {focusedId ? (
+            <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.7rem] text-text-primary">
+              {focusedId}
+            </code>
+          ) : (
+            <span>nothing</span>
+          )}
+        </span>
         {focusedId ? (
-          <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.7rem] text-text-primary">
-            {focusedId}
-          </code>
-        ) : (
-          <span>nothing</span>
-        )}
+          <button
+            type="button"
+            onClick={handleClear}
+            className="shrink-0 text-[0.7rem] font-medium text-text-secondary transition-colors hover:text-accent"
+          >
+            Clear
+          </button>
+        ) : null}
       </div>
       {canFlyToPoi ? (
         <button

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -10,6 +10,8 @@ import {
   tableView,
   hierarchyView,
   flyToPoiOp,
+  openViewerOp,
+  copyLinkOp,
 } from "@/lib/workbench";
 
 /**
@@ -28,6 +30,9 @@ import {
  * - Phase 5a  — first typed `Operation` registered (`poi.fly-to`),
  *                invoked via `ctx.runOperation(...)` from a button in
  *                the OverviewView when a POI is focused
+ * - Phase 5b  — `ctx.toast` wired through to react-toastify; two
+ *                world-level ops added (`world.open-viewer`,
+ *                `world.copy-link`)
  *
  * Imported by `/maps/[mapId]/workbench/page.tsx` at runtime; the old
  * `/maps/[mapId]/builder` route stays untouched until Phase 6.
@@ -44,7 +49,7 @@ const workbenchConfig = defineWorkbench({
     eventEntity,
   ],
   views: [mapView, overviewView, tableView, hierarchyView],
-  operations: [flyToPoiOp],
+  operations: [flyToPoiOp, openViewerOp, copyLinkOp],
   defaultLayout: {
     left: ["table", "hierarchy"],
     center: ["map"],

--- a/packages/design-system/src/components/workbench.tsx
+++ b/packages/design-system/src/components/workbench.tsx
@@ -7,11 +7,14 @@ import type {
   EntityIndex,
   OpResult,
   SelectionState,
+  ToastTone,
   ViewContext,
   WorkbenchConfig,
 } from "@klorad/config/workbench";
 import { emptyEntityIndex } from "@klorad/config/workbench";
 import { Dock } from "./dock";
+
+export type WorkbenchToast = (msg: string, tone?: ToastTone) => void;
 
 export type WorkbenchProps = {
   /** The vertical's config, produced by `defineWorkbench(...)`. */
@@ -22,9 +25,19 @@ export type WorkbenchProps = {
   actor?: Actor;
   /** Custom entity backend. Defaults to an empty in-memory index. */
   entities?: EntityIndex;
+  /**
+   * Surface for operation toasts. Operations call `ctx.toast(msg, tone)`
+   * from inside `invoke`; whatever surface the app uses (react-toastify,
+   * sonner, etc.) plugs in here. Defaults to a noop — operations stay
+   * functional, but their feedback is silent.
+   */
+  toast?: WorkbenchToast;
 };
 
 const defaultActor: Actor = { kind: "user", userId: "anonymous" };
+const noopToast: WorkbenchToast = () => {
+  /* deliberate noop default */
+};
 
 /**
  * The Workbench shell — Phase 2 v1.
@@ -45,6 +58,7 @@ export function Workbench({
   worldId,
   actor = defaultActor,
   entities = emptyEntityIndex,
+  toast = noopToast,
 }: WorkbenchProps) {
   const [selection, setSelection] = useState<SelectionState>(() => ({
     ids: new Set<string>(),
@@ -73,24 +87,15 @@ export function Workbench({
           return { ok: false, reason: `Unknown operation: ${opId}` };
         }
         return op.invoke(
-          {
-            worldId,
-            actor,
-            entities,
-            // Phase 5 wires this to the app's real toast surface. For
-            // now, swallow — no operations exist yet to call it anyway.
-            toast: () => {
-              /* noop */
-            },
-          },
+          { worldId, actor, entities, toast },
           args as never,
           on,
         );
       },
-      // Computed in Phase 5 once operations exist.
+      // Computed in a later phase once we wire `applies` per selection.
       applicableOperations: [],
     }),
-    [worldId, selection, entities, actor, operationById],
+    [worldId, selection, entities, actor, operationById, toast],
   );
 
   const renderRegion = (region: DockRegion) => {

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -46,4 +46,8 @@ export {
   type NavItem,
 } from "./components/app-shell";
 export { Dock, type DockProps } from "./components/dock";
-export { Workbench, type WorkbenchProps } from "./components/workbench";
+export {
+  Workbench,
+  type WorkbenchProps,
+  type WorkbenchToast,
+} from "./components/workbench";


### PR DESCRIPTION
## Summary

Phase 5b of the Workbench migration:

1. **Operation feedback is no longer silent.** `ctx.toast(msg, tone)` calls from inside an operation's `invoke` now surface as react-toastify notifications — the same surface `BuilderClient` / `SettingsTab` already use elsewhere in campus.
2. **Two world-level operations land** alongside `poi.fly-to`: `world.open-viewer` and `world.copy-link`. Both `scope: []`, both surface in OverviewView's new "World actions" panel.
3. **Selection-clearing** lands as a UI affordance, not an operation — `OpInvokeContext` deliberately doesn't carry `setSelection`. Direct call on `ctx.setSelection` inside the view.

8 files changed, +225 / −24.

## What the shell gained

A new `toast?: WorkbenchToast` prop on `<Workbench>` in `@klorad/design-system`. The shell threads it into every `ctx.toast(...)` call inside `op.invoke`. Defaults to a noop so existing consumers (none today besides campus) keep working.

```ts
// packages/design-system/src/components/workbench.tsx
export type WorkbenchToast = (msg: string, tone?: ToastTone) => void;

<Workbench
  config={…}
  worldId={…}
  entities={…}
  toast={toast}   // ← new
/>
```

`WorkbenchToast` is re-exported from `@klorad/design-system`'s entry so consumers can type their handler.

## What `WorkbenchClient` does with it

Bridges to react-toastify with a `useCallback` switch over the four `ToastTone` cases:

```ts
const toast = useCallback<WorkbenchToast>((msg, tone) => {
  switch (tone) {
    case "success": toastify.success(msg); return;
    case "warning": toastify.warning(msg); return;
    case "error":   toastify.error(msg);   return;
    default:        toastify.info(msg);
  }
}, []);
```

The `ToastContainer` already mounts in `apps/campus/app/providers.tsx`; nothing else needed.

## Two new operations

| op id | scope | what it does |
|---|---|---|
| `world.open-viewer` | `[]` | `window.open` the public-viewer URL (`/campus/{worldId}`) in a new tab. Pop-up-blocker fallback: `{ ok: false }` + a `warning` toast. |
| `world.copy-link`  | `[]` | `navigator.clipboard.writeText` the same URL. Success / error toasts. |

Both world-level (`scope: []`, `applies: () => true`) — they don't read selection. They're the first ops that exist alongside `poi.fly-to` to demonstrate the operations registry handles more than one entry.

## Where they surface in OverviewView

New `WorldActions` panel under the existing `SelectionPanel`:

```
┌────────────────────────────────────┐
│ Overview                           │
│ <worldId hash>                     │
├────────────────────────────────────┤
│ [POIs][Buildings][Floor plans]…    │
├────────────────────────────────────┤
│ Accessibility coverage: 12%        │
├────────────────────────────────────┤
│ Selected: <id>           Clear     │ ← Clear is UI-only
│   [✈ Fly to in 3D] (when POI)      │
├────────────────────────────────────┤
│ WORLD ACTIONS                      │
│  [↗ Open viewer] [⧉ Copy link]     │ ← both go through ctx.runOperation
└────────────────────────────────────┘
```

The "Clear" button on the SelectionPanel is **not** an operation. It calls `ctx.setSelection({ ids: new Set(), focusedId: null })` directly. Selection clearing is shell state; operations mutate entities (or surface effects like fly-to / clipboard), not the shell's UI state. `OpInvokeContext` only carries `worldId / actor / entities / toast` on purpose.

## Files

- **`packages/design-system/src/components/workbench.tsx`** — `WorkbenchToast` type, `toast?` prop, thread into `op.invoke`'s context.
- **`packages/design-system/src/index.ts`** — re-export `WorkbenchToast`.
- **`apps/campus/.../workbench/WorkbenchClient.tsx`** — react-toastify bridge via `useCallback`, passed to `<Workbench toast={toast} />`.
- **`apps/campus/lib/workbench/operations/open-viewer.ts`** *(new)*.
- **`apps/campus/lib/workbench/operations/copy-link.ts`** *(new)*.
- **`apps/campus/lib/workbench/operations/index.ts`** — re-export the two new ops.
- **`apps/campus/workbench.config.ts`** — register `[flyToPoiOp, openViewerOp, copyLinkOp]`.
- **`apps/campus/lib/workbench/views/overview.tsx`** — `SelectionPanel` gets a "Clear" button; new `WorldActions` panel under it.

## Test plan

- [x] Typecheck: design-system + campus + config clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Visit `/org/<orgId>/maps/<mapId>/workbench`
- [ ] **Right dock, World actions**: click "Open viewer" → public viewer opens in a new tab + a success toast
- [ ] Click "Copy link" → URL on clipboard + a success toast; paste somewhere to confirm
- [ ] **Selection panel**: click a POI → "Selected" line + "Fly to in 3D" button + "Clear" button all appear
- [ ] Click "Fly to in 3D" → camera flies + an info toast (the existing `poi.fly-to` toast call now surfaces)
- [ ] Click "Clear" → selection clears across views (table row de-highlights, 3D pin un-selected, overview "Selected: nothing")
- [ ] Block pop-ups for the site, click "Open viewer" → warning toast + no new tab

## Next

**Phase 5c — generic operation surfacing.** Compute `applicableOperations` in the shell from `config.operations` + the current selection (each op's `applies` predicate). Views render them generically — no more per-button hardcoding inside OverviewView. With that in place, a command palette (`mod+k`) and right-click menus drop in cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
