### PR TITLE
fix(workbench): MapView needs position:relative or the map paints over the docks

### DIFF
--- a/apps/campus/lib/workbench/views/map.tsx
+++ b/apps/campus/lib/workbench/views/map.tsx
@@ -69,8 +69,13 @@ function MapViewComponent({ ctx }: ViewProps) {
   // the scene store, so passing `true` unconditionally is safe.
   useCampusLabelDefaults(true);
 
+  // `relative` is load-bearing: MapboxViewer's container is
+  // `position: absolute; inset: 0`, so without a positioned ancestor
+  // it escapes the dock's flex layout and renders against the viewport
+  // — painting over the left and right dock columns. `/builder` wraps
+  // the viewer in `<Box position="relative">` for the same reason.
   return (
-    <div className="h-full w-full">
+    <div className="relative h-full w-full">
       <MapboxViewer />
     </div>
   );


### PR DESCRIPTION
## Summary

**Symptom:** Visiting `/org/<orgId>/maps/<mapId>/workbench` showed the 3D map at full viewport width with no dock columns visible. Looked like Phase 4 / 5 never landed.

**Diagnosis:** The dock columns *are* in the DOM. They're just covered.

`MapboxViewer`'s internal container is:

```tsx
<div
  ref={containerRef}
  style={{
    width: "100%",
    height: "100%",
    position: "absolute",
    top: 0, left: 0, right: 0, bottom: 0,
  }}
/>
```

`position: absolute` walks up the DOM looking for a `relative` / `absolute` / `fixed` ancestor. The Workbench's `MapView` wraps it in `<div className="h-full w-full">` — **no `position`**. None of the dock's flex containers have `position` either. So the absolutely-positioned element falls back to the initial containing block (the viewport) and renders full-screen, painting over the left and right dock asides.

`/builder` doesn't have this bug because it wraps the viewer in `<Box sx={{ flex: 1, position: "relative" }}>`.

## Fix

One word in `apps/campus/lib/workbench/views/map.tsx`:

```diff
- <div className="h-full w-full">
+ <div className="relative h-full w-full">
    <MapboxViewer />
  </div>
```

Plus a comment block above the return explaining why `relative` is load-bearing, so the next person doesn't strip it as cosmetic.

1 file changed, +6 / −1.

## Test plan

- [x] Typecheck campus: clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Visit `/org/<orgId>/maps/<mapId>/workbench`
- [ ] **Left dock** visible with Table view at top + Hierarchy view below
- [ ] **Center** map renders only in the center column (not covering panels)
- [ ] **Right dock** visible with Overview view
- [ ] Click "L" / "R" chevron headers → asides collapse to 40 px rail, map expands; expand again → restores
- [ ] `/builder` still works untouched (separate code path; this fix is local to the workbench's MapView)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
