### PR TITLE
Workbench Phase 5c1: generic operation surfacing — applicableOperations

### DIFF
--- a/apps/campus/lib/workbench/operations/fly-to-poi.tsx
+++ b/apps/campus/lib/workbench/operations/fly-to-poi.tsx
@@ -3,6 +3,29 @@ import type { Operation } from "@klorad/config/workbench";
 import { useSceneStore } from "@klorad/core";
 import type { Map as MapboxMap } from "mapbox-gl";
 
+// Op icon — surfaces in OverviewView (5c1), command palette (5c2),
+// right-click menus (5c3). Co-located with the op so adding a new op
+// = one file with everything (label, icon, applies, invoke).
+function FlyToIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M22 2 11 13" />
+      <path d="m22 2-7 20-4-9-9-4z" />
+    </svg>
+  );
+}
+
 /**
  * Fly the Mapbox camera to a POI.
  *
@@ -21,7 +44,8 @@ import type { Map as MapboxMap } from "mapbox-gl";
  */
 export const flyToPoiOp: Operation = {
   id: "poi.fly-to",
-  label: "Fly to POI",
+  label: "Fly to in 3D",
+  icon: FlyToIcon,
   scope: ["campus.poi"],
   applies: (sel, entities) => {
     if (!sel.focusedId) return false;

--- a/apps/campus/lib/workbench/views/overview.tsx
+++ b/apps/campus/lib/workbench/views/overview.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import type { ReactNode } from "react";
-import type { View, ViewProps } from "@klorad/config/workbench";
+import type {
+  ResolvedOperation,
+  View,
+  ViewContext,
+  ViewProps,
+} from "@klorad/config/workbench";
 
 /**
  * Phase 4a — the Overview view.
@@ -161,20 +166,21 @@ function CopyIcon() {
 
 /**
  * The right-dock's "what's selected" card. Echoes the focused id and
- * surfaces operations that apply to the current selection. v1 wires
- * `poi.fly-to` — registered in `workbench.config.ts` and invoked via
- * `ctx.runOperation(...)`. Future ops light up here without further
- * shell changes.
+ * surfaces operations that apply to the current selection.
+ *
+ * Phase 5c1 — rendered generically from `ctx.applicableOperations`:
+ * any entity-scoped op whose `applies` predicate returns true light
+ * up here automatically. To add a new op, register it in
+ * `workbench.config.ts` — no edits to this view required.
+ *
+ * World-level ops (`scope: []`) are filtered out here; they belong
+ * in a separate "World actions" surface (5c2 lands that).
  */
 function SelectionPanel({ ctx }: { ctx: ViewProps["ctx"] }) {
   const focusedId = ctx.selection.focusedId;
-  const focusedEntity = focusedId ? ctx.entities.byId(focusedId) : null;
-  const canFlyToPoi = focusedEntity?.typeId === "campus.poi";
-
-  const handleFly = () => {
-    if (!focusedId) return;
-    void ctx.runOperation("poi.fly-to", undefined, [focusedId]);
-  };
+  const entityOps = ctx.applicableOperations.filter(
+    (r) => r.operation.scope.length > 0,
+  );
 
   // Selection-clearing is a UI affordance, not an entity-level operation
   // — `OpInvokeContext` doesn't (and shouldn't) carry `setSelection`.
@@ -206,36 +212,44 @@ function SelectionPanel({ ctx }: { ctx: ViewProps["ctx"] }) {
           </button>
         ) : null}
       </div>
-      {canFlyToPoi ? (
-        <button
-          type="button"
-          onClick={handleFly}
-          className="mt-2 inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-accent px-3 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover"
-        >
-          <FlyToIcon />
-          Fly to in 3D
-        </button>
+      {entityOps.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {entityOps.map((resolved) => (
+            <OperationButton
+              key={resolved.operation.id}
+              resolved={resolved}
+              ctx={ctx}
+            />
+          ))}
+        </div>
       ) : null}
     </div>
   );
 }
 
-function FlyToIcon() {
+/**
+ * Generic button for one `ResolvedOperation`. The view doesn't know
+ * what the op does — the shell handed it a bound `on` list and the
+ * op's own `label` / `icon`. Clicking fires `ctx.runOperation`.
+ */
+function OperationButton({
+  resolved,
+  ctx,
+}: {
+  resolved: ResolvedOperation;
+  ctx: ViewContext;
+}) {
+  const { operation, on } = resolved;
+  const Icon = operation.icon;
   return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
+    <button
+      type="button"
+      onClick={() => void ctx.runOperation(operation.id, undefined, on)}
+      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-accent px-3 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover"
     >
-      <path d="M22 2 11 13" />
-      <path d="m22 2-7 20-4-9-9-4z" />
-    </svg>
+      {Icon ? <Icon className="h-3 w-3" /> : null}
+      {operation.label}
+    </button>
   );
 }
 

--- a/packages/config/src/workbench/types.ts
+++ b/packages/config/src/workbench/types.ts
@@ -135,6 +135,12 @@ export interface OperationFormProps<Args = unknown> {
 export interface Operation<Args = void> {
   id: OperationId;
   label: string;
+  /**
+   * Optional icon used by generic rendering surfaces — view-authored
+   * buttons, command palette entries, right-click menu items. Falls
+   * back to label-only if absent.
+   */
+  icon?: React.ComponentType<{ className?: string }>;
   /** Entity types this operation applies to. */
   scope: EntityTypeId[];
   /** Predicate evaluated against the current selection. */

--- a/packages/design-system/src/components/workbench.tsx
+++ b/packages/design-system/src/components/workbench.tsx
@@ -6,6 +6,7 @@ import type {
   DockRegion,
   EntityIndex,
   OpResult,
+  ResolvedOperation,
   SelectionState,
   ToastTone,
   ViewContext,
@@ -75,6 +76,33 @@ export function Workbench({
     [config.operations],
   );
 
+  // Phase 5c1 — generic operation surfacing.
+  //
+  // For each registered op: ask its `applies` predicate against the
+  // current selection. If true, resolve the `on` list:
+  //   - world-level ops (`scope: []`) bind to no entities (`on = []`)
+  //   - entity-scoped ops bind to selected ids whose typeId falls in scope
+  //
+  // Views render this list generically instead of hardcoding per-op
+  // buttons. The command palette and right-click menu pull from the
+  // same list in 5c2 / 5c3.
+  const applicableOperations = useMemo<ResolvedOperation[]>(() => {
+    const selectedIds = [...selection.ids];
+    const resolved: ResolvedOperation[] = [];
+    for (const op of config.operations) {
+      if (!op.applies(selection, entities)) continue;
+      const on =
+        op.scope.length === 0
+          ? []
+          : selectedIds.filter((id) => {
+              const entity = entities.byId(id);
+              return entity ? op.scope.includes(entity.typeId) : false;
+            });
+      resolved.push({ operation: op, on });
+    }
+    return resolved;
+  }, [config.operations, selection, entities]);
+
   const ctx = useMemo<ViewContext>(
     () => ({
       worldId,
@@ -92,10 +120,17 @@ export function Workbench({
           on,
         );
       },
-      // Computed in a later phase once we wire `applies` per selection.
-      applicableOperations: [],
+      applicableOperations,
     }),
-    [worldId, selection, entities, actor, operationById, toast],
+    [
+      worldId,
+      selection,
+      entities,
+      actor,
+      operationById,
+      applicableOperations,
+      toast,
+    ],
   );
 
   const renderRegion = (region: DockRegion) => {


### PR DESCRIPTION
## Summary

Phase 5c1 of the Workbench migration — **generic operation surfacing**.

Before: each operation had a hardcoded button in OverviewView. To add an op, you'd touch the view.
After: views render `ctx.applicableOperations` as a list. To add an op, you register it in `workbench.config.ts`.

The shell now does the work the views were doing — running each op's `applies` predicate against the current selection and binding the `on` list.

4 files, +110 / −39.

## What the shell does now

```ts
const applicableOperations = useMemo<ResolvedOperation[]>(() => {
  const selectedIds = [...selection.ids];
  const resolved: ResolvedOperation[] = [];
  for (const op of config.operations) {
    if (!op.applies(selection, entities)) continue;
    const on =
      op.scope.length === 0
        ? []                                                       // world-level
        : selectedIds.filter((id) => {
            const entity = entities.byId(id);
            return entity ? op.scope.includes(entity.typeId) : false;
          });                                                      // entity-scoped
    resolved.push({ operation: op, on });
  }
  return resolved;
}, [config.operations, selection, entities]);
```

Exposed on `ViewContext` as `applicableOperations: ResolvedOperation[]`. The field was already typed in `@klorad/config/workbench` (Phase 1.3); the shell just hardcoded `[]` until now.

## What views do now

```tsx
const entityOps = ctx.applicableOperations.filter(
  (r) => r.operation.scope.length > 0,
);

{entityOps.map((resolved) => (
  <OperationButton
    key={resolved.operation.id}
    resolved={resolved}
    ctx={ctx}
  />
))}
```

`OperationButton` is a generic — it doesn't know what the op does. It pulls the label / icon off `resolved.operation` and fires `ctx.runOperation(operation.id, undefined, on)` on click.

## Type change

`Operation` gains one optional field:

```ts
icon?: React.ComponentType<{ className?: string }>;
```

Used by the generic surfaces — view buttons today, command palette in 5c2, right-click menu in 5c3. Co-located with the op so adding a new op is one file: label + icon + applies + invoke.

## Existing op updated

`flyToPoiOp` now carries `icon: FlyToIcon` directly (moved from OverviewView). Label changed `"Fly to POI"` → `"Fly to in 3D"` — clearer in every surface that renders it. File renamed `fly-to-poi.ts` → `fly-to-poi.tsx` because it holds a JSX component now.

## Out of scope (deferred to 5c2 / 5c3)

- **Command palette** (`mod+k`) — reads from `ctx.applicableOperations`.
- **Right-click menu** on entities in Map / Table / Hierarchy — same source.
- **World-level op surfacing in OverviewView** — waits for #123 to merge with two world ops (`world.open-viewer`, `world.copy-link`), then a follow-up adds a generic "World actions" panel and deletes the hardcoded one introduced in #123.

## Files

- **`packages/config/src/workbench/types.ts`** — `Operation.icon?: React.ComponentType<{ className?: string }>`.
- **`packages/design-system/src/components/workbench.tsx`** — compute `applicableOperations`, thread through `ViewContext`.
- **`apps/campus/lib/workbench/operations/fly-to-poi.tsx`** *(renamed)* — co-locates `FlyToIcon`; label "Fly to in 3D".
- **`apps/campus/lib/workbench/views/overview.tsx`** — `OperationButton` generic; `SelectionPanel` renders the entity-op list.

## Test plan

- [x] Typecheck campus + design-system + config: clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] Visit `/org/<orgId>/maps/<mapId>/workbench` (after #124 merges; otherwise the map paints over the docks)
- [ ] Click a POI on the map → SelectionPanel shows `Selected: <id>` + a `[✈ Fly to in 3D]` button
- [ ] Click the button → camera flies (same behaviour as before — proves the registry handoff works)
- [ ] Click a building (or anything non-POI) → no `Fly to` button (op's `applies` returns false)

## Merge order

Independent of #123 and #124. Suggested merge order: **#124 first** (unblocks visual usage), then #123 (toast + 2 world ops), then this (#125). #123 has a hardcoded `WorldActions` panel that becomes redundant once world-level generic rendering lands in 5c2 — that PR will delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
