### PR TITLE
Workbench style pass (DS-side): shell polish + reusable primitives

### DIFF
--- a/packages/design-system/src/components/dock.tsx
+++ b/packages/design-system/src/components/dock.tsx
@@ -51,32 +51,38 @@ function DockColumn({
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(true);
-  const label = side === "left" ? "Left" : "Right";
+  const ariaLabel = side === "left" ? "Left panel" : "Right panel";
   return (
     <aside
       className={cn(
-        "flex h-full flex-col bg-surface-1 transition-[width] duration-200",
-        side === "left" ? "border-r border-line-soft" : "border-l border-line-soft",
-        open ? "w-72" : "w-10",
+        "flex h-full flex-col bg-surface-1 transition-[width] duration-300 ease-out",
+        side === "left"
+          ? "border-r border-line-soft"
+          : "border-l border-line-soft",
+        open ? "w-80" : "w-10",
       )}
     >
-      <header
+      {/*
+        Chrome is intentionally minimal — just the collapse affordance.
+        Views provide their own headers; doubling up looked utilitarian.
+        Strip is 32px tall to feel lighter than the legacy 40px caps row.
+      */}
+      <div
         className={cn(
-          "flex h-10 shrink-0 items-center border-b border-line-soft px-2 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary",
-          open ? "justify-between" : "justify-center",
+          "flex h-8 shrink-0 items-center px-1.5",
+          open ? "justify-end" : "justify-center",
         )}
       >
-        {open ? <span>{label}</span> : null}
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          aria-label={`Toggle ${side} panel`}
+          aria-label={open ? `Collapse ${ariaLabel}` : `Expand ${ariaLabel}`}
           aria-expanded={open}
-          className="flex h-6 w-6 items-center justify-center rounded text-text-secondary transition-colors hover:bg-accent-soft hover:text-text-primary"
+          className="flex h-6 w-6 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-accent-soft hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           <Chevron direction={open === (side === "left") ? "left" : "right"} />
         </button>
-      </header>
+      </div>
       {open ? (
         <div className="min-h-0 flex-1 overflow-auto">{children}</div>
       ) : null}
@@ -89,22 +95,21 @@ function DockBottom({ children }: { children: ReactNode }) {
   return (
     <section
       className={cn(
-        "flex shrink-0 flex-col border-t border-line-soft bg-surface-1 transition-[height] duration-200",
-        open ? "h-56" : "h-10",
+        "flex shrink-0 flex-col border-t border-line-soft bg-surface-1 transition-[height] duration-300 ease-out",
+        open ? "h-64" : "h-8",
       )}
     >
-      <header className="flex h-10 shrink-0 items-center justify-between border-b border-line-soft px-2 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
-        <span>{open ? "Bottom" : null}</span>
+      <div className="flex h-8 shrink-0 items-center justify-end px-1.5">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          aria-label="Toggle bottom panel"
+          aria-label={open ? "Collapse bottom panel" : "Expand bottom panel"}
           aria-expanded={open}
-          className="flex h-6 w-6 items-center justify-center rounded text-text-secondary transition-colors hover:bg-accent-soft hover:text-text-primary"
+          className="flex h-6 w-6 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-accent-soft hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           <Chevron direction={open ? "down" : "up"} />
         </button>
-      </header>
+      </div>
       {open ? (
         <div className="min-h-0 flex-1 overflow-auto">{children}</div>
       ) : null}
@@ -112,7 +117,11 @@ function DockBottom({ children }: { children: ReactNode }) {
   );
 }
 
-function Chevron({ direction }: { direction: "left" | "right" | "up" | "down" }) {
+function Chevron({
+  direction,
+}: {
+  direction: "left" | "right" | "up" | "down";
+}) {
   const rotation = {
     left: "rotate-90",
     right: "-rotate-90",

--- a/packages/design-system/src/components/workbench-primitives.tsx
+++ b/packages/design-system/src/components/workbench-primitives.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "../utils/cn";
+import { Button, type ButtonProps } from "./button";
+
+/* ─── WorkbenchSection ─────────────────────────────────────────────────
+ *
+ * One titled section inside a Workbench view. Replaces the ad-hoc
+ * `<div className="rounded-lg border border-line-soft p-3">…</div>`
+ * patterns the views were inlining.
+ *
+ * Visual contract matches the dashboard cards (`rounded-2xl`, soft
+ * border, generous padding) so the Workbench reads as the same
+ * product, not a separate utility. Use `tone="dashed"` for placeholder
+ * surfaces (selection cards, "drop here", etc.).
+ * ──────────────────────────────────────────────────────────────────── */
+
+export type WorkbenchSectionTone = "solid" | "soft" | "dashed";
+
+const toneClass: Record<WorkbenchSectionTone, string> = {
+  /* The default — an elevated card on top of the dock surface. */
+  solid: "border border-line-soft bg-surface-1",
+  /* A muted card — the dock is already surface-1, so we tint with bg. */
+  soft: "border border-line-soft bg-bg",
+  /* A placeholder card — selection panels, empty states. */
+  dashed: "border border-dashed border-line-soft bg-transparent",
+};
+
+export interface WorkbenchSectionProps
+  extends Omit<ComponentProps<"section">, "title"> {
+  /** Section heading — small caps label or sentence-case title. */
+  title?: ReactNode;
+  /** Secondary line under the title (count, id, hint). */
+  subtitle?: ReactNode;
+  /** Right-aligned actions in the header (button, link, badge). */
+  actions?: ReactNode;
+  /** Surface tone. Default `solid`. */
+  tone?: WorkbenchSectionTone;
+}
+
+export function WorkbenchSection({
+  title,
+  subtitle,
+  actions,
+  tone = "solid",
+  className,
+  children,
+  ...props
+}: WorkbenchSectionProps) {
+  const hasHeader = title || subtitle || actions;
+  return (
+    <section
+      className={cn(
+        "rounded-2xl p-5",
+        toneClass[tone],
+        className,
+      )}
+      {...props}
+    >
+      {hasHeader ? (
+        <header className="mb-3 flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-0.5">
+            {title ? (
+              <h3 className="text-sm font-semibold text-text-primary">
+                {title}
+              </h3>
+            ) : null}
+            {subtitle ? (
+              <p className="truncate text-xs text-text-tertiary">{subtitle}</p>
+            ) : null}
+          </div>
+          {actions ? (
+            <div className="flex shrink-0 items-center gap-1.5">{actions}</div>
+          ) : null}
+        </header>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+/* ─── WorkbenchStatTile ────────────────────────────────────────────────
+ *
+ * A label + value tile. Used in OverviewView for entity counts; future
+ * verticals will use it for whatever single-number snapshots they want
+ * to surface (active vehicles, restored fragments, etc.).
+ *
+ * Mirrors the dashboard's stat cards but sized for a dock column —
+ * `rounded-xl` + `p-4` instead of the dashboard's `rounded-2xl + p-6`.
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface WorkbenchStatTileProps
+  extends Omit<ComponentProps<"div">, "title"> {
+  /** Short uppercase label above the value. */
+  label: ReactNode;
+  /** The headline number / value. */
+  value: ReactNode;
+  /** Optional hint line below (e.g. `12 / 248`). */
+  hint?: ReactNode;
+  /** Optional icon shown to the left of the label. */
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+export function WorkbenchStatTile({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  className,
+  ...props
+}: WorkbenchStatTileProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-line-soft bg-surface-1 p-4",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex items-center gap-1.5 text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
+        {Icon ? <Icon className="h-3 w-3" /> : null}
+        {label}
+      </div>
+      <div className="mt-1.5 text-2xl font-light tabular-nums text-text-primary">
+        {value}
+      </div>
+      {hint ? (
+        <div className="mt-0.5 text-xs text-text-tertiary">{hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ─── WorkbenchOperationButton ─────────────────────────────────────────
+ *
+ * One button that fires a Workbench operation. Decoupled from
+ * `ResolvedOperation` so non-Workbench callers can use it too — pass
+ * the label, optional icon, and an `onClick`.
+ *
+ * Defaults to `primary` for surfaced actions in selection / world
+ * panels; pass `variant="secondary"` for less hot actions.
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface WorkbenchOperationButtonProps
+  extends Omit<ButtonProps, "children"> {
+  /** Button label (e.g., the operation's `label` field). */
+  label: ReactNode;
+  /** Optional icon — the operation's `icon` field. */
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+export function WorkbenchOperationButton({
+  label,
+  icon: Icon,
+  size = "sm",
+  variant = "primary",
+  className,
+  ...props
+}: WorkbenchOperationButtonProps) {
+  return (
+    <Button size={size} variant={variant} className={className} {...props}>
+      {Icon ? <Icon className="h-3.5 w-3.5" /> : null}
+      {label}
+    </Button>
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -51,3 +51,12 @@ export {
   type WorkbenchProps,
   type WorkbenchToast,
 } from "./components/workbench";
+export {
+  WorkbenchSection,
+  WorkbenchStatTile,
+  WorkbenchOperationButton,
+  type WorkbenchSectionProps,
+  type WorkbenchSectionTone,
+  type WorkbenchStatTileProps,
+  type WorkbenchOperationButtonProps,
+} from "./components/workbench-primitives";


### PR DESCRIPTION
## Summary

Two pieces of the broader Workbench style pass, both in `@klorad/design-system`:

1. **Shell polish (Layer A)** — Dock chrome becomes minimal: a 32px strip with just the collapse chevron, no all-caps "LEFT" / "RIGHT" labels. Wider columns (`w-80`), smoother transitions, focus rings.
2. **Reusable primitives (Layer C)** — `WorkbenchSection`, `WorkbenchStatTile`, `WorkbenchOperationButton` ship in the design system so the campus views (and future verticals' views) can drop the inline patterns they've been carrying.

Layer B — actually using these primitives in `OverviewView` / `TableView` / `HierarchyView` — is a campus-side follow-up.

3 files changed, +204 / −19.

## Shell polish — before vs after

| | Before | After |
|---|---|---|
| Header height | 40px | 32px |
| Header content | `LEFT` / `RIGHT` caps label + chevron | Chevron alone |
| Open width | `w-72` (288px) | `w-80` (320px) |
| Transition | 200ms linear | 300ms ease-out |
| Focus ring | None | `focus-visible:ring-2 ring-accent` |
| Bottom region | Same caps treatment | Same minimal chrome |

The reasoning: views render their own headers (e.g. "Overview", "Floors"). Doubling up with a generic "Left" / "Right" caps label above looked utilitarian, like a developer-tool. Dropping it lets the view's own header own the visual hierarchy. The chevron is the only affordance the chrome needs.

## New primitives

### `WorkbenchSection`

Replaces the inline `<div className="rounded-lg border border-line-soft p-3">…</div>` patterns the views were carrying. Matches the dashboard's Panel aesthetic — `rounded-2xl` + `p-5` + soft border.

```tsx
<WorkbenchSection
  title="Selection"
  subtitle={focusedId ?? "Nothing focused"}
  actions={<Button size="sm" variant="ghost" onClick={clear}>Clear</Button>}
>
  …
</WorkbenchSection>
```

Three tones:
- `solid` (default) — elevated card on top of the dock
- `soft` — tinted-down card for secondary content
- `dashed` — placeholder / selection / empty-state surfaces

### `WorkbenchStatTile`

The label-+-value tile pattern from OverviewView, promoted. `tabular-nums` so column alignment stays crisp.

```tsx
<WorkbenchStatTile label="POIs" value={pois.length} hint="12 accessible" />
```

### `WorkbenchOperationButton`

Generic op surface, decoupled from `ResolvedOperation` so non-Workbench callers (command palette in 5c2, right-click in 5c3) can reuse it.

```tsx
<WorkbenchOperationButton
  label={operation.label}
  icon={operation.icon}
  onClick={() => void ctx.runOperation(operation.id, undefined, on)}
/>
```

## Reusability

Everything in this PR is in `@klorad/design-system`, so every consumer of `<Workbench>` benefits automatically. When the next vertical ships its first `View`, it gets the polished shell and the three primitives without code changes.

## Test plan

- [x] Typecheck design-system: clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] After merge: `/org/<o>/maps/<m>/workbench` chrome is the new 32px strip with the chevron only
- [ ] Collapsing / expanding a column animates smoothly (300ms)
- [ ] No visual regression elsewhere — the only consumer of `Dock` / `Workbench` today is campus, and views haven't switched to the new primitives yet (that's the follow-up)

## Merge order

Stacked on `feature/workbench-phase-5c1-generic-ops` (PR #125). Merge order:

1. **#124** — map-paints-over-docks fix (urgent, unblocks visual usage)
2. **#123** — Phase 5b: toast + 2 world ops
3. **#125** — Phase 5c1: generic op surfacing
4. **This PR** — style pass DS-side
5. Follow-up — style pass campus-side (uses these primitives in views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
