### PR TITLE
Workbench style pass (campus-side): restyle views to use new DS primitives

### DIFF
--- a/apps/campus/lib/workbench/views/hierarchy.tsx
+++ b/apps/campus/lib/workbench/views/hierarchy.tsx
@@ -100,18 +100,19 @@ function HierarchyViewComponent({ ctx }: ViewProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="border-b border-line-soft px-4 py-3">
-        <h2 className="text-sm font-semibold text-text-primary">Hierarchy</h2>
-        <p className="mt-0.5 text-[0.7rem] text-text-tertiary">
+      <header className="space-y-1 px-4 pb-3">
+        <h2 className="text-base font-semibold text-text-primary">Hierarchy</h2>
+        <p className="text-[0.7rem] text-text-tertiary">
           {buildings.length} building{buildings.length === 1 ? "" : "s"} ·{" "}
           {standalonePois.length} unbuilt
         </p>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-auto py-1">
+      <div className="min-h-0 flex-1 overflow-auto pb-3">
         {isEmpty ? (
-          <div className="px-4 py-6 text-center text-xs text-text-tertiary">
-            Nothing in this world yet.
+          <div className="px-4 py-8 text-center text-xs text-text-tertiary">
+            Nothing in this world yet. Draw a building or place a POI on
+            the map to start filling the tree.
           </div>
         ) : (
           <>

--- a/apps/campus/lib/workbench/views/overview.tsx
+++ b/apps/campus/lib/workbench/views/overview.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import type { ReactNode } from "react";
-import type {
-  ResolvedOperation,
-  View,
-  ViewContext,
-  ViewProps,
-} from "@klorad/config/workbench";
+import {
+  WorkbenchOperationButton,
+  WorkbenchSection,
+  WorkbenchStatTile,
+} from "@klorad/design-system";
+import type { View, ViewProps } from "@klorad/config/workbench";
 
 /**
  * Phase 4a — the Overview view.
@@ -21,6 +20,15 @@ import type {
  * dock supports more than one View consuming the shared entity
  * index, and sets the pattern that TableView and HierarchyView
  * follow in Phases 4b and 4c.
+ *
+ * Phase 5c1 — operations render generically from
+ * `ctx.applicableOperations`. Add a new op to `workbench.config.ts`
+ * and it shows up in the SelectionPanel automatically.
+ *
+ * Style pass — built on `@klorad/design-system`'s `WorkbenchSection`,
+ * `WorkbenchStatTile`, and `WorkbenchOperationButton` so the view
+ * matches the dashboard's `rounded-2xl` / Panel aesthetic. Future
+ * verticals' OverviewViews inherit the same primitives.
  */
 function OverviewViewComponent({ ctx }: ViewProps) {
   const pois = ctx.entities.byType("campus.poi");
@@ -33,41 +41,48 @@ function OverviewViewComponent({ ctx }: ViewProps) {
   // the @klorad/api `POI` shape directly; if accessibility becomes a
   // first-class concept it gets its own field on `EntityType`.
   const accessibleCount = pois.filter((p) => {
-    const payload = p.payload as { accessibility?: { wheelchairAccessible?: boolean } };
+    const payload = p.payload as {
+      accessibility?: { wheelchairAccessible?: boolean };
+    };
     return payload?.accessibility?.wheelchairAccessible;
   }).length;
   const accessibilityPct =
     pois.length > 0 ? Math.round((accessibleCount / pois.length) * 100) : 0;
 
+  // Short worldId for the subtitle — full id is preserved on hover.
+  const shortWorldId = ctx.worldId.length > 12
+    ? `${ctx.worldId.slice(0, 6)}…${ctx.worldId.slice(-4)}`
+    : ctx.worldId;
+
   return (
-    <div className="flex h-full flex-col gap-4 p-4">
+    <div className="flex h-full flex-col gap-4 px-4 pb-4">
       <header className="space-y-1">
-        <h2 className="text-sm font-semibold text-text-primary">Overview</h2>
-        <p className="font-mono text-[0.7rem] text-text-tertiary">
-          {ctx.worldId}
+        <h2 className="text-base font-semibold text-text-primary">Overview</h2>
+        <p
+          className="font-mono text-[0.7rem] text-text-tertiary"
+          title={ctx.worldId}
+        >
+          {shortWorldId}
         </p>
       </header>
 
-      <div className="grid grid-cols-2 gap-2">
-        <StatTile label="POIs" value={pois.length} />
-        <StatTile label="Buildings" value={buildings.length} />
-        <StatTile label="Floor plans" value={floorPlans.length} />
-        <StatTile label="Events" value={events.length} />
+      <div className="grid grid-cols-2 gap-3">
+        <WorkbenchStatTile label="POIs" value={pois.length} />
+        <WorkbenchStatTile label="Buildings" value={buildings.length} />
+        <WorkbenchStatTile label="Floor plans" value={floorPlans.length} />
+        <WorkbenchStatTile label="Events" value={events.length} />
       </div>
 
-      <div className="rounded-lg border border-line-soft bg-surface-1 p-3">
-        <div className="text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
-          Accessibility coverage
-        </div>
-        <div className="mt-1 flex items-baseline gap-2">
-          <span className="text-2xl font-light text-text-primary">
+      <WorkbenchSection title="Accessibility coverage">
+        <div className="flex items-baseline gap-2">
+          <span className="text-3xl font-light tabular-nums text-text-primary">
             {accessibilityPct}%
           </span>
           <span className="text-xs text-text-secondary">
             {accessibleCount} / {pois.length} POIs
           </span>
         </div>
-      </div>
+      </WorkbenchSection>
 
       <SelectionPanel ctx={ctx} />
       <WorldActions ctx={ctx} />
@@ -76,66 +91,51 @@ function OverviewViewComponent({ ctx }: ViewProps) {
 }
 
 /**
- * World-level operations — `world.open-viewer`, `world.copy-link`.
- * Apply regardless of selection so they live in their own panel.
+ * World-level operations (`scope: []`) — `world.open-viewer`,
+ * `world.copy-link`. Apply regardless of selection so they live in
+ * their own panel. Rendered with `secondary` variant so they read
+ * as ambient actions rather than competing with the selection ops.
+ *
+ * 5c3 will generate this panel from `ctx.applicableOperations` so
+ * any future world-level op surfaces automatically.
  */
 function WorldActions({ ctx }: { ctx: ViewProps["ctx"] }) {
   return (
-    <div className="space-y-2">
-      <div className="text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
-        World actions
-      </div>
+    <WorkbenchSection tone="soft" title="World actions">
       <div className="flex flex-wrap gap-1.5">
-        <ActionButton
+        <WorkbenchOperationButton
+          label="Open viewer"
+          icon={OpenViewerIcon}
+          variant="secondary"
           onClick={() =>
             void ctx.runOperation("world.open-viewer", undefined, [])
           }
-        >
-          <OpenViewerIcon />
-          Open viewer
-        </ActionButton>
-        <ActionButton
+        />
+        <WorkbenchOperationButton
+          label="Copy link"
+          icon={CopyIcon}
+          variant="secondary"
           onClick={() =>
             void ctx.runOperation("world.copy-link", undefined, [])
           }
-        >
-          <CopyIcon />
-          Copy link
-        </ActionButton>
+        />
       </div>
-    </div>
+    </WorkbenchSection>
   );
 }
 
-function ActionButton({
-  onClick,
-  children,
-}: {
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="inline-flex h-7 items-center gap-1 rounded-md border border-line-strong px-2 text-[0.7rem] font-medium text-text-secondary transition-colors hover:border-accent hover:text-accent"
-    >
-      {children}
-    </button>
-  );
-}
-
-function OpenViewerIcon() {
+function OpenViewerIcon({ className }: { className?: string }) {
   return (
     <svg
-      width="11"
-      height="11"
+      width="12"
+      height="12"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
       strokeLinecap="round"
       strokeLinejoin="round"
+      className={className}
       aria-hidden
     >
       <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
@@ -145,17 +145,18 @@ function OpenViewerIcon() {
   );
 }
 
-function CopyIcon() {
+function CopyIcon({ className }: { className?: string }) {
   return (
     <svg
-      width="11"
-      height="11"
+      width="12"
+      height="12"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
       strokeLinecap="round"
       strokeLinejoin="round"
+      className={className}
       aria-hidden
     >
       <rect x="9" y="9" width="13" height="13" rx="2" />
@@ -165,16 +166,14 @@ function CopyIcon() {
 }
 
 /**
- * The right-dock's "what's selected" card. Echoes the focused id and
- * surfaces operations that apply to the current selection.
+ * "What's selected" — echoes the focused id and surfaces every
+ * applicable entity-scoped operation. Rendered from
+ * `ctx.applicableOperations` (Phase 5c1); world-level ops are
+ * filtered out and surface in `WorldActions` above.
  *
- * Phase 5c1 — rendered generically from `ctx.applicableOperations`:
- * any entity-scoped op whose `applies` predicate returns true light
- * up here automatically. To add a new op, register it in
- * `workbench.config.ts` — no edits to this view required.
- *
- * World-level ops (`scope: []`) are filtered out here; they belong
- * in a separate "World actions" surface (5c2 lands that).
+ * Clear button is a UI affordance, not an operation — `OpInvokeContext`
+ * deliberately doesn't carry `setSelection`. Calls `ctx.setSelection`
+ * directly.
  */
 function SelectionPanel({ ctx }: { ctx: ViewProps["ctx"] }) {
   const focusedId = ctx.selection.focusedId;
@@ -182,85 +181,56 @@ function SelectionPanel({ ctx }: { ctx: ViewProps["ctx"] }) {
     (r) => r.operation.scope.length > 0,
   );
 
-  // Selection-clearing is a UI affordance, not an entity-level operation
-  // — `OpInvokeContext` doesn't (and shouldn't) carry `setSelection`.
-  // Calls the view context directly.
+  const subtitle = focusedId ? (
+    <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.7rem] text-text-primary">
+      {focusedId}
+    </code>
+  ) : (
+    <span className="text-xs text-text-tertiary">Nothing selected</span>
+  );
+
   const handleClear = () => {
     ctx.setSelection({ ids: new Set<string>(), focusedId: null });
   };
 
   return (
-    <div className="rounded-lg border border-dashed border-line-soft p-3 text-xs text-text-tertiary">
-      <div className="flex items-center justify-between gap-2">
-        <span className="min-w-0 truncate">
-          Selected:{" "}
-          {focusedId ? (
-            <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[0.7rem] text-text-primary">
-              {focusedId}
-            </code>
-          ) : (
-            <span>nothing</span>
-          )}
-        </span>
-        {focusedId ? (
+    <WorkbenchSection
+      tone="dashed"
+      title="Selection"
+      subtitle={subtitle}
+      actions={
+        focusedId ? (
           <button
             type="button"
             onClick={handleClear}
-            className="shrink-0 text-[0.7rem] font-medium text-text-secondary transition-colors hover:text-accent"
+            className="text-[0.7rem] font-medium text-text-secondary transition-colors hover:text-accent"
           >
             Clear
           </button>
-        ) : null}
-      </div>
+        ) : null
+      }
+    >
       {entityOps.length > 0 ? (
-        <div className="mt-2 flex flex-wrap gap-1.5">
-          {entityOps.map((resolved) => (
-            <OperationButton
-              key={resolved.operation.id}
-              resolved={resolved}
-              ctx={ctx}
+        <div className="flex flex-wrap gap-1.5">
+          {entityOps.map(({ operation, on }) => (
+            <WorkbenchOperationButton
+              key={operation.id}
+              label={operation.label}
+              icon={operation.icon}
+              onClick={() =>
+                void ctx.runOperation(operation.id, undefined, on)
+              }
             />
           ))}
         </div>
-      ) : null}
-    </div>
-  );
-}
-
-/**
- * Generic button for one `ResolvedOperation`. The view doesn't know
- * what the op does — the shell handed it a bound `on` list and the
- * op's own `label` / `icon`. Clicking fires `ctx.runOperation`.
- */
-function OperationButton({
-  resolved,
-  ctx,
-}: {
-  resolved: ResolvedOperation;
-  ctx: ViewContext;
-}) {
-  const { operation, on } = resolved;
-  const Icon = operation.icon;
-  return (
-    <button
-      type="button"
-      onClick={() => void ctx.runOperation(operation.id, undefined, on)}
-      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-accent px-3 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover"
-    >
-      {Icon ? <Icon className="h-3 w-3" /> : null}
-      {operation.label}
-    </button>
-  );
-}
-
-function StatTile({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <div className="rounded-lg border border-line-soft bg-surface-1 p-3">
-      <div className="text-[0.7rem] uppercase tracking-[0.14em] text-text-tertiary">
-        {label}
-      </div>
-      <div className="mt-1 text-2xl font-light text-text-primary">{value}</div>
-    </div>
+      ) : (
+        <p className="text-xs text-text-tertiary">
+          {focusedId
+            ? "No actions available for this selection."
+            : "Click anything on the map or in the list to see what you can do with it."}
+        </p>
+      )}
+    </WorkbenchSection>
   );
 }
 

--- a/apps/campus/lib/workbench/views/table.tsx
+++ b/apps/campus/lib/workbench/views/table.tsx
@@ -2,6 +2,7 @@
 
 import type { POI } from "@klorad/api";
 import type { Entity, View, ViewProps } from "@klorad/config/workbench";
+import { cn } from "@klorad/design-system";
 
 /**
  * Phase 4b — TableView.
@@ -9,13 +10,18 @@ import type { Entity, View, ViewProps } from "@klorad/config/workbench";
  * A compact list of POIs in the left dock region. Click a row to
  * select; selection bridges to the map (the 3D view highlights the
  * same id). v1 is POI-only and renders as a single-column list
- * because the left dock is `w-72` wide — narrow for a real table.
+ * because the left dock is narrow for a real table.
  *
  * Per-entity-type column definitions (so the same component can
  * render Buildings, FloorPlans, etc. with their own columns) are
  * deferred. When TableView starts surfacing more than one entity
  * type, `EntityType` gains a `tableColumns: { key, label, render }`
  * field and this component renders against that.
+ *
+ * Style pass — typography matches OverviewView's header treatment;
+ * row hover and selected states use the brand accent for the active
+ * row, with a sharp 2px left rail so the eye locks onto it from a
+ * peripheral glance.
  */
 function TableViewComponent({ ctx }: ViewProps) {
   const pois = ctx.entities.byType("campus.poi") as Entity<POI>[];
@@ -23,19 +29,19 @@ function TableViewComponent({ ctx }: ViewProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="border-b border-line-soft px-4 py-3">
-        <h2 className="text-sm font-semibold text-text-primary">POIs</h2>
-        <p className="mt-0.5 text-[0.7rem] text-text-tertiary">
-          {pois.length} entr{pois.length === 1 ? "y" : "ies"}
+      <header className="space-y-1 px-4 pb-3">
+        <h2 className="text-base font-semibold text-text-primary">POIs</h2>
+        <p className="text-[0.7rem] text-text-tertiary">
+          {pois.length} {pois.length === 1 ? "entry" : "entries"}
         </p>
       </header>
 
       {pois.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center p-4 text-center text-xs text-text-tertiary">
-          No POIs in this world yet.
+        <div className="flex flex-1 items-center justify-center px-6 py-12 text-center text-xs text-text-tertiary">
+          No POIs in this world yet. Place one on the map to start.
         </div>
       ) : (
-        <ul className="min-h-0 flex-1 overflow-auto">
+        <ul className="min-h-0 flex-1 overflow-auto px-2 pb-3">
           {pois.map((entity) => {
             const poi = entity.payload;
             const isSelected = entity.id === selectedId;
@@ -50,19 +56,27 @@ function TableViewComponent({ ctx }: ViewProps) {
                 <button
                   type="button"
                   onClick={handleClick}
-                  className={
-                    "flex w-full items-center gap-2 border-b border-line-soft px-4 py-2.5 text-left transition-colors " +
-                    (isSelected
-                      ? "border-l-2 border-l-accent bg-accent-soft text-text-primary"
-                      : "border-l-2 border-l-transparent text-text-secondary hover:bg-surface-2 hover:text-text-primary")
-                  }
                   aria-pressed={isSelected}
+                  className={cn(
+                    "group flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left transition-colors",
+                    "border-l-2",
+                    isSelected
+                      ? "border-l-accent bg-accent-soft text-text-primary"
+                      : "border-l-transparent text-text-secondary hover:bg-surface-2 hover:text-text-primary",
+                  )}
                 >
                   <span className="min-w-0 flex-1 truncate text-sm">
                     {poi.name || "Unnamed POI"}
                   </span>
                   {poi.category ? (
-                    <span className="shrink-0 rounded-full border border-line-soft bg-surface-1 px-1.5 py-0.5 text-[0.65rem] uppercase tracking-[0.04em] text-text-tertiary">
+                    <span
+                      className={cn(
+                        "shrink-0 rounded-full border border-line-soft px-1.5 py-0.5 text-[0.65rem] uppercase tracking-[0.04em] transition-colors",
+                        isSelected
+                          ? "bg-surface-1 text-text-secondary"
+                          : "bg-surface-1 text-text-tertiary",
+                      )}
+                    >
                       {poi.category}
                     </span>
                   ) : null}


### PR DESCRIPTION
## Summary

Layer B of the Workbench style pass — restyle the three campus views (`OverviewView`, `TableView`, `HierarchyView`) to use the DS primitives shipped in #126. Same data, dashboard-grade chrome.

3 files changed, +105 / −111 — the views *shrink* because their inline card / tile / button markup got hoisted into reusable DS components.

## Before vs after — at a glance

```
   Before                          After
┌────────────────────────┐    ┌────────────────────────┐
│ OVERVIEW (caps label)  │    │ Overview               │
│ wf123_long_world_id…   │    │ wf1234…3a2f            │← truncated, full on hover
├────────────────────────┤    ├────────────────────────┤
│ ┌──┐ ┌──┐               │   │  ┌────┐  ┌────┐         │
│ │12│ │ 3│               │   │  │ 12 │  │ 3  │         │← tabular-nums
│ │PO│ │BL│               │   │  │POIs│  │BLDG│         │  bigger cards
│ └──┘ └──┘               │   │  └────┘  └────┘         │
├────────────────────────┤    ├────────────────────────┤
│ ACCESSIBILITY 12%       │   │  Accessibility coverage│
│                         │   │  12%   3 / 24 POIs     │
├────────────────────────┤    │                        │
│ Selected: nothing       │   ├────────────────────────┤
│ (dashed)                │   │  Selection (dashed)    │
│                         │   │  Nothing selected      │
│                         │   │  Click anything on the │
│                         │   │  map or in the list…   │
└────────────────────────┘    └────────────────────────┘
```

`OverviewView`:
- Stat tiles → `<WorkbenchStatTile>` — `rounded-xl`, `tabular-nums`, slight padding bump
- Accessibility card → `<WorkbenchSection title="Accessibility coverage">` — matches dashboard cards
- Selection panel → `<WorkbenchSection tone="dashed" title="Selection" subtitle={focusedId}>` — friendlier copy when nothing is selected ("Click anything on the map or in the list to see what you can do with it")
- Operation buttons → `<WorkbenchOperationButton>` (DS-grade, focus ring, consistent height)
- World id truncates in subtitle (`wf1234…3a2f`); full id stays available on `title`-attribute hover

`TableView`:
- Header treatment matches OverviewView (no underline border, `text-base`, sentence case spacing)
- Row hover uses rounded-lg pills inside a padded list area — was edge-to-edge with hard borders between rows
- Selected rows keep the accent-soft fill + 2px left rail (recognisable peripheral signal)
- Empty state copy: "No POIs in this world yet. Place one on the map to start." (was: "No POIs in this world yet.")

`HierarchyView`:
- Header treatment matches the two siblings
- Empty state copy: actionable ("Draw a building or place a POI on the map to start filling the tree.")
- Tree internals unchanged — structure was correct, just the surrounding chrome was off

## Why this matters

After this lands, the *only* difference between the Workbench and the dashboard's `OverviewTab` / `SettingsTab` is **density** — the Workbench's docks are narrower, so cards are tighter. Both pages use the same Panel-class surfaces, same accent treatments, same type rhythm. The Workbench reads as part of the product, not a developer console.

Reusability: every primitive `OverviewView` uses now lives in `@klorad/design-system`. When the next vertical ships its first `OverviewView`, it inherits the exact same surface treatment for free.

## Test plan

- [x] Typecheck campus: clean
- [x] Pre-commit + pre-push (editor build) pass
- [ ] After merge (and the upstream PRs land): `/org/<o>/maps/<m>/workbench` shows the new chrome
- [ ] Left dock: Table view at the top, Hierarchy view below; both use the new header style
- [ ] Right dock: Overview view with the 4 stat tiles in a 2×2 grid, accessibility card, selection card
- [ ] Click a POI on the map → SelectionPanel populates with id + Fly-to button; clicking again deselects → empty-state copy appears
- [ ] Theme toggle (light/dark) — every surface inherits tokens; no hardcoded colors leak

## Merge order

Stacked: `main` → #124 → #123 → #125 → #126 → **this**.

Each PR is independent in code (its diff doesn't conflict with the others) but the *visual* effect lands cleanest in this order. If GitHub complains about the base, retarget to `main` once #126 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
