### PR TITLE
fix(editor): exclude next/font from generic CSS rule

### DIFF
--- a/apps/editor/next.config.mjs
+++ b/apps/editor/next.config.mjs
@@ -179,13 +179,17 @@ const nextConfig = {
       ],
     });
 
-    // Handle other CSS files (fallback until packages are split)
+    // Handle other CSS files (fallback until packages are split).
+    // Must NOT match next/font's virtual target.css — Next handles that via
+    // its own next-font-loader, and intercepting it here makes the font
+    // module's default export resolve to undefined at runtime.
     config.module.rules.push({
       test: /\.css$/,
       exclude: [
         /node_modules\/cesium/,
         /node_modules\/mapbox-gl/,
         /styles\/vendor\/mapbox-gl\.css$/,
+        /next[\\/]font[\\/]/,
       ],
       use: [
         'style-loader',


### PR DESCRIPTION
## Summary
- Root-causes the `TypeError: Cannot read properties of undefined (reading 'variable')` thrown from `apps/editor/app/layout.tsx` at `inter.variable`.
- The editor's `next.config.mjs` registered a catch-all `/\.css$/` rule for everything outside `cesium`/`mapbox-gl`. That rule also matched the virtual `target.css` emitted by `next/font/google`, displacing Next's own `next-font-loader`, so the font module's default export resolved to `undefined`.
- Adds `/next[\\/]font[\\/]/` to the exclude list. No app code change required.

## Why this over the guard
There's an older `fix/editor-font-guard` branch on origin that wraps the call site with `inter?.variable ?? ""`. That hides the symptom but the font CSS never loads — pages render in the system font. This PR fixes the actual loader pipeline, so Inter renders as intended.

## Test plan
- [x] `pnpm build:editor` succeeds (pre-push hook).
- [ ] `pnpm --filter @klorad/editor dev`, hit `/`, confirm no `inter.variable` runtime error and Inter is applied (DevTools → `<html class>` contains a `__variable_*` token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)