### PR TITLE
Phase 1 — Indoor 3D immersion (X-ray rooms + FloorSwitcher)

### DIFF
--- a/apps/campus/app/hooks/useMapboxRoomsLayer.ts
+++ b/apps/campus/app/hooks/useMapboxRoomsLayer.ts
@@ -1,87 +1,29 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import type {
-  Map as MapboxMap,
-  GeoJSONSource,
-  MapMouseEvent,
-} from "mapbox-gl";
-import { useSceneStore } from "@klorad/core";
+import { useMemo } from "react";
+import {
+  useMapboxIndoorExtrusion,
+  type IndoorExtrusionFeature,
+} from "@klorad/engine-mapbox";
 import type { Room } from "@klorad/api";
 import { roomColor, roomHeightM } from "@/app/lib/roomTemplates";
 import { FLOOR_HEIGHT_M } from "./useMapboxFloorSlabsLayer";
 
-const SOURCE_ID = "campus-rooms";
-const LAYER_ID = "campus-rooms-extrusion";
-const LAYER_OUTLINE_ID = "campus-rooms-outline";
-const LAYER_HIGHLIGHT_ID = "campus-rooms-highlight";
-const LAYER_LABEL_ID = "campus-rooms-label";
-
-function buildFeatureCollection(rooms: Room[]): GeoJSON.FeatureCollection {
-  return {
-    type: "FeatureCollection",
-    features: rooms
-      .filter((r) => r.visible !== false)
-      .filter((r) => r.polygon.length >= 3)
-      .map((r) => {
-        const ring = [...r.polygon];
-        const first = ring[0];
-        const last = ring[ring.length - 1];
-        if (first[0] !== last[0] || first[1] !== last[1]) ring.push(first);
-        const h = roomHeightM(r);
-        // Stack rooms on consistent floor slabs so a tall amphitheatre
-        // on floor 1 still sits at FLOOR_HEIGHT_M m, not at 1×6 m.
-        // 0.65 sits just above the slab's top face (0.6 thick).
-        const base = r.floor * FLOOR_HEIGHT_M + 0.65;
-        const height = base + h;
-        return {
-          type: "Feature",
-          id: r.id,
-          geometry: { type: "Polygon", coordinates: [ring] },
-          properties: {
-            id: r.id,
-            name: r.name,
-            type: r.type,
-            floor: r.floor,
-            base,
-            height,
-            color: roomColor(r),
-          },
-        } satisfies GeoJSON.Feature;
-      }),
-  };
-}
-
-const NO_FLOOR_FILTER: unknown[] = [
-  "==",
-  ["get", "floor"],
-  Number.NEGATIVE_INFINITY,
-];
-
-function floorFilterFor(activeFloor: number | null | undefined): unknown[] {
-  if (activeFloor === null || activeFloor === undefined) return NO_FLOOR_FILTER;
-  return ["==", ["get", "floor"], activeFloor];
-}
-
-function highlightFilterFor(highlightRoomId: string | null | undefined): unknown[] {
-  return [
-    "==",
-    ["get", "id"],
-    highlightRoomId ?? "",
-  ];
-}
-
 /**
- * Render the given rooms as extruded polygons. All rooms across all floors
- * are drawn, but the layer hides any that don't match `activeFloor` (when
- * set) so the selected floor reads cleanly without stacking noise.
+ * Campus-side adapter over the generic `useMapboxIndoorExtrusion`
+ * hook in `@klorad/engine-mapbox`.
  *
- * Clicking a room fires `onSelect(roomId)` so the parent can open the
- * room card in the right panel.
+ * Translates campus `Room` records into the engine's
+ * `IndoorExtrusionFeature` shape — computes per-room base/height
+ * elevations from the building's floor-height constant and the
+ * room's template-driven height; resolves the fill color from
+ * `roomColor`; stamps the room type onto `extra` so any expression
+ * downstream can read it.
  *
- * The hook is split into three effects so callbacks (which change ref
- * every parent render) don't cause a teardown — that was the cause of
- * label flicker on every studio interaction.
+ * Every other vertical that maps interior space (Heritage's
+ * stratigraphy layers, Mobility's transit-floor view) ships its own
+ * thin adapter in this shape — the engine package owns the rendering,
+ * the consumer owns the domain.
  */
 export function useMapboxRoomsLayer(
   rooms: Room[],
@@ -91,205 +33,37 @@ export function useMapboxRoomsLayer(
     highlightRoomId?: string | null;
     /** When false, click + hover ignored (e.g. during polygon draw). */
     clickEnabled?: boolean;
-  } = {}
+  } = {},
 ) {
-  const map = useSceneStore((s) => s.mapboxMap as MapboxMap | null);
-  const { activeFloor, onSelect, highlightRoomId, clickEnabled = true } = opts;
+  const features = useMemo<IndoorExtrusionFeature[]>(() => {
+    return rooms
+      .filter((r) => r.visible !== false)
+      .filter((r) => r.polygon.length >= 3)
+      .map((r) => {
+        const h = roomHeightM(r);
+        // Stack rooms on consistent floor slabs so a tall amphitheatre
+        // on floor 1 still sits at FLOOR_HEIGHT_M m, not at 1×6 m.
+        // 0.65 sits just above the slab's top face (0.6 thick).
+        const base = r.floor * FLOOR_HEIGHT_M + 0.65;
+        return {
+          id: r.id,
+          polygon: r.polygon,
+          level: r.floor,
+          base,
+          height: base + h,
+          color: roomColor(r),
+          name: r.name,
+          extra: { type: r.type, floor: r.floor },
+        } satisfies IndoorExtrusionFeature;
+      });
+  }, [rooms]);
 
-  // Refs so the install effect can read the latest callback / flag
-  // without depending on them (which would tear the layer down on
-  // every parent render).
-  const onSelectRef = useRef(onSelect);
-  const clickEnabledRef = useRef(clickEnabled);
-  useEffect(() => {
-    onSelectRef.current = onSelect;
-  }, [onSelect]);
-  useEffect(() => {
-    clickEnabledRef.current = clickEnabled;
-  }, [clickEnabled]);
-
-  // ─── 1. install ──────────────────────────────────────────────────────────
-  // Runs once per map. Idempotent: re-installs gracefully on style.load /
-  // styledata (basemap import reload wipes our custom layers).
-  useEffect(() => {
-    if (!map) return;
-
-    const install = () => {
-      try {
-        if (!map.getSource(SOURCE_ID)) {
-          map.addSource(SOURCE_ID, {
-            type: "geojson",
-            data: { type: "FeatureCollection", features: [] },
-          });
-        }
-      } catch {
-        return;
-      }
-
-      const initialFloorFilter = NO_FLOOR_FILTER;
-      const initialHighlightFilter = highlightFilterFor(null);
-
-      if (!map.getLayer(LAYER_ID)) {
-        map.addLayer({
-          id: LAYER_ID,
-          type: "fill-extrusion",
-          source: SOURCE_ID,
-          filter: initialFloorFilter as never,
-          paint: {
-            "fill-extrusion-color": ["get", "color"],
-            "fill-extrusion-base": ["get", "base"],
-            "fill-extrusion-height": ["get", "height"],
-            "fill-extrusion-opacity": 0.85,
-          },
-        });
-      }
-      if (!map.getLayer(LAYER_OUTLINE_ID)) {
-        map.addLayer({
-          id: LAYER_OUTLINE_ID,
-          type: "line",
-          source: SOURCE_ID,
-          filter: initialFloorFilter as never,
-          paint: {
-            "line-color": "#ffffff",
-            "line-opacity": 0.5,
-            "line-width": 1,
-          },
-        });
-      }
-      if (!map.getLayer(LAYER_HIGHLIGHT_ID)) {
-        map.addLayer({
-          id: LAYER_HIGHLIGHT_ID,
-          type: "line",
-          source: SOURCE_ID,
-          filter: initialHighlightFilter as never,
-          paint: {
-            "line-color": "#ffffff",
-            "line-width": 3,
-          },
-        });
-      }
-      if (!map.getLayer(LAYER_LABEL_ID)) {
-        map.addLayer({
-          id: LAYER_LABEL_ID,
-          type: "symbol",
-          source: SOURCE_ID,
-          filter: initialFloorFilter as never,
-          layout: {
-            "text-field": ["get", "name"] as never,
-            "text-size": 12,
-            "text-anchor": "center",
-            "text-allow-overlap": false,
-            "text-ignore-placement": false,
-            "text-padding": 2,
-          },
-          paint: {
-            "text-color": "#f5f7fa",
-            "text-halo-color": "rgba(15,23,42,0.78)",
-            "text-halo-width": 1.3,
-            "text-halo-blur": 0.6,
-            "text-occlusion-opacity": 0,
-          },
-        });
-      }
-    };
-
-    install();
-    const onStyleLoad = () => install();
-    const onStyleData = () => install();
-    const onIdle = () => install();
-    map.on("style.load", onStyleLoad);
-    map.on("styledata", onStyleData);
-    map.on("idle", onIdle);
-
-    // Click + hover handlers. Use refs so changing onSelect / clickEnabled
-    // in the parent doesn't re-run this effect.
-    const clickHandler = (e: MapMouseEvent) => {
-      if (!clickEnabledRef.current) return;
-      const feature = map.queryRenderedFeatures(e.point, {
-        layers: [LAYER_ID],
-      })[0];
-      if (!feature) return;
-      const id = (feature.properties?.id ?? feature.id) as string | undefined;
-      if (id && onSelectRef.current) onSelectRef.current(id);
-    };
-    const hoverEnter = () => {
-      if (!clickEnabledRef.current) return;
-      map.getCanvas().style.cursor = "pointer";
-    };
-    const hoverLeave = () => {
-      map.getCanvas().style.cursor = "";
-    };
-    map.on("click", LAYER_ID, clickHandler);
-    map.on("mouseenter", LAYER_ID, hoverEnter);
-    map.on("mouseleave", LAYER_ID, hoverLeave);
-
-    return () => {
-      map.off("style.load", onStyleLoad);
-      map.off("styledata", onStyleData);
-      map.off("idle", onIdle);
-      map.off("click", LAYER_ID, clickHandler);
-      map.off("mouseenter", LAYER_ID, hoverEnter);
-      map.off("mouseleave", LAYER_ID, hoverLeave);
-      try {
-        if (map.getLayer(LAYER_LABEL_ID)) map.removeLayer(LAYER_LABEL_ID);
-        if (map.getLayer(LAYER_HIGHLIGHT_ID)) map.removeLayer(LAYER_HIGHLIGHT_ID);
-        if (map.getLayer(LAYER_OUTLINE_ID)) map.removeLayer(LAYER_OUTLINE_ID);
-        if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
-        if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
-      } catch {
-        /* ignore */
-      }
-    };
-  }, [map]);
-
-  // ─── 2. data + floor filter ──────────────────────────────────────────────
-  // Refresh the source features when rooms change; refresh the floor
-  // filter on the three filtered layers when activeFloor changes.
-  useEffect(() => {
-    if (!map) return;
-    const data = buildFeatureCollection(rooms);
-    const apply = () => {
-      const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
-      if (src) src.setData(data);
-      const filter = floorFilterFor(activeFloor);
-      try {
-        if (map.getLayer(LAYER_ID)) map.setFilter(LAYER_ID, filter as never);
-        if (map.getLayer(LAYER_OUTLINE_ID)) map.setFilter(LAYER_OUTLINE_ID, filter as never);
-        if (map.getLayer(LAYER_LABEL_ID)) map.setFilter(LAYER_LABEL_ID, filter as never);
-      } catch {
-        /* layer may be detached during a style swap */
-      }
-    };
-    apply();
-    // The install effect may re-run on styledata before the data effect
-    // does — make sure the next idle tick reapplies our filters.
-    const onStyleData = () => apply();
-    map.on("styledata", onStyleData);
-    return () => {
-      map.off("styledata", onStyleData);
-    };
-  }, [map, rooms, activeFloor]);
-
-  // ─── 3. highlight filter ─────────────────────────────────────────────────
-  useEffect(() => {
-    if (!map) return;
-    const apply = () => {
-      try {
-        if (map.getLayer(LAYER_HIGHLIGHT_ID)) {
-          map.setFilter(
-            LAYER_HIGHLIGHT_ID,
-            highlightFilterFor(highlightRoomId) as never
-          );
-        }
-      } catch {
-        /* ignore */
-      }
-    };
-    apply();
-    const onStyleData = () => apply();
-    map.on("styledata", onStyleData);
-    return () => {
-      map.off("styledata", onStyleData);
-    };
-  }, [map, highlightRoomId]);
+  useMapboxIndoorExtrusion({
+    namespace: "campus-rooms",
+    features,
+    activeLevel: opts.activeFloor ?? null,
+    highlightId: opts.highlightRoomId ?? null,
+    onSelect: opts.onSelect,
+    clickEnabled: opts.clickEnabled,
+  });
 }

--- a/apps/campus/lib/workbench/views/map.tsx
+++ b/apps/campus/lib/workbench/views/map.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import dynamic from "next/dynamic";
-import type { POI } from "@klorad/api";
+import type { FloorPlan, POI, Room } from "@klorad/api";
 import { useSceneStore } from "@klorad/core";
 import type { Entity, View, ViewProps } from "@klorad/config/workbench";
 import type { Map as MapboxMap } from "mapbox-gl";
 import { useMapboxPoiLayer } from "@/app/hooks/useMapboxPoiLayer";
 import { useMapboxDrawnBuildingsLayer } from "@/app/hooks/useMapboxDrawnBuildingsLayer";
+import { useMapboxFloorSlabsLayer } from "@/app/hooks/useMapboxFloorSlabsLayer";
+import { useMapboxRoomsLayer } from "@/app/hooks/useMapboxRoomsLayer";
 import { useCampusLabelDefaults } from "@/app/hooks/useCampusLabelDefaults";
 import { placementKind, usePlacementStore } from "../placement-store";
 
@@ -42,13 +44,60 @@ function MapViewComponent({ ctx }: ViewProps) {
   const pois = (ctx.entities.byType("campus.poi") as Entity<POI>[]).map(
     (e) => e.payload,
   );
-  const selectedPoiId = ctx.selection.focusedId;
+  const allFloorPlans = (
+    ctx.entities.byType("campus.floor-plan") as Entity<FloorPlan>[]
+  ).map((e) => e.payload);
+  const allRooms = (ctx.entities.byType("campus.room") as Entity<Room>[]).map(
+    (e) => e.payload,
+  );
+  const selectedId = ctx.selection.focusedId;
+
+  // Resolve the focused selection into the things the indoor layers
+  // care about — which building POI is in focus, and which floor (if
+  // a floor plan is selected). Phase 1 — drives the X-ray reveal.
+  const { selectedBuildingId, activeFloor } = useMemo(() => {
+    if (!selectedId) {
+      return { selectedBuildingId: null, activeFloor: null as number | null };
+    }
+    // Selected entity is a POI with a linkedBuilding payload → it's the
+    // building itself.
+    const poi = pois.find((p) => p.id === selectedId);
+    if (poi?.linkedBuilding) {
+      return { selectedBuildingId: selectedId, activeFloor: null };
+    }
+    // Selected entity is a floor plan → infer the building + active floor.
+    const plan = allFloorPlans.find((p) => p.id === selectedId);
+    if (plan) {
+      return {
+        selectedBuildingId: plan.buildingId ?? null,
+        activeFloor: plan.floor ?? null,
+      };
+    }
+    // Selected entity is a room → infer the building + active floor.
+    const room = allRooms.find((r) => r.id === selectedId);
+    if (room) {
+      return {
+        selectedBuildingId: room.buildingId,
+        activeFloor: room.floor,
+      };
+    }
+    return { selectedBuildingId: null, activeFloor: null as number | null };
+  }, [selectedId, pois, allFloorPlans, allRooms]);
+
+  // Rooms visible at any time = only the selected building's rooms.
+  // Phase 1 caps it here for performance; once we have a sample campus
+  // with hundreds of rooms the trade-off is worth revisiting (a
+  // viewport-based filter, or LOD culling).
+  const roomsForSelection = useMemo<Room[]>(() => {
+    if (!selectedBuildingId) return [];
+    return allRooms.filter((r) => r.buildingId === selectedBuildingId);
+  }, [allRooms, selectedBuildingId]);
 
   useMapboxPoiLayer({
     pois,
-    selectedPoiId,
+    selectedPoiId: selectedId,
     onPoiClick: (id) => {
-      const next = selectedPoiId === id ? null : id;
+      const next = selectedId === id ? null : id;
       ctx.setSelection({
         ids: next ? new Set([next]) : new Set<string>(),
         focusedId: next,
@@ -56,16 +105,42 @@ function MapViewComponent({ ctx }: ViewProps) {
     },
   });
 
-  // Render building extrusions for POIs that carry a `linkedBuilding`.
-  // Plans + rooms are passed empty for v1 — full slab / room rendering
-  // ships when the editing surface migrates over.
-  useMapboxDrawnBuildingsLayer(pois, [], [], {
-    selectedPoiId,
-    activeFloor: null,
+  // Building shells — when a building is selected and an `activeFloor`
+  // is in focus, the shell renders an X-ray cap that lets the eye see
+  // the rooms inside. Plans + rooms are now real (Phase 1) rather than
+  // the empty stubs the workbench shipped with on day one.
+  useMapboxDrawnBuildingsLayer(pois, allFloorPlans, allRooms, {
+    selectedPoiId: selectedId,
+    activeFloor,
     onSelect: (id) => {
       ctx.setSelection({ ids: new Set([id]), focusedId: id });
     },
     clickEnabled: true,
+  });
+
+  // Floor slabs — the horizontal plates between floors. Clicking one
+  // selects the matching floor plan, which becomes the new focused
+  // entity and drives `activeFloor` above.
+  useMapboxFloorSlabsLayer(pois, allFloorPlans, allRooms, {
+    activePlanId: activeFloor != null ? selectedId : null,
+    selectedBuildingPoiId: selectedBuildingId,
+    onSelect: (_buildingId, _floor, planId) => {
+      if (planId) ctx.setSelection({ ids: new Set([planId]), focusedId: planId });
+    },
+  });
+
+  // Rooms — the 3D extruded volumes inside the building, rendered with
+  // the X-ray-friendly opacity. Scoped to the selected building so we
+  // don't paint every room in every building all at once.
+  useMapboxRoomsLayer(roomsForSelection, {
+    activeFloor,
+    onSelect: (id) => {
+      ctx.setSelection({ ids: new Set([id]), focusedId: id });
+    },
+    highlightRoomId:
+      selectedId && allRooms.some((r) => r.id === selectedId)
+        ? selectedId
+        : null,
   });
 
   // Force basemap labels off whenever the scene is mounted (Mapbox's

--- a/apps/campus/lib/workbench/views/map.tsx
+++ b/apps/campus/lib/workbench/views/map.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import type { FloorPlan, POI, Room } from "@klorad/api";
 import { useSceneStore } from "@klorad/core";
 import type { Entity, View, ViewProps } from "@klorad/config/workbench";
+import { FloorSwitcher } from "@klorad/design-system";
 import type { Map as MapboxMap } from "mapbox-gl";
 import { useMapboxPoiLayer } from "@/app/hooks/useMapboxPoiLayer";
 import { useMapboxDrawnBuildingsLayer } from "@/app/hooks/useMapboxDrawnBuildingsLayer";
@@ -92,6 +93,43 @@ function MapViewComponent({ ctx }: ViewProps) {
     if (!selectedBuildingId) return [];
     return allRooms.filter((r) => r.buildingId === selectedBuildingId);
   }, [allRooms, selectedBuildingId]);
+
+  // Floor list for the FloorSwitcher overlay — every floor for which
+  // the building has a plan, ordered top-down (highest first) to
+  // match the visual stacking of the building.
+  const plansForBuilding = useMemo<FloorPlan[]>(() => {
+    if (!selectedBuildingId) return [];
+    return allFloorPlans.filter((p) => p.buildingId === selectedBuildingId);
+  }, [allFloorPlans, selectedBuildingId]);
+  const buildingFloors = useMemo<number[]>(() => {
+    const floors = plansForBuilding
+      .map((p) => p.floor)
+      .filter((f): f is number => typeof f === "number");
+    return Array.from(new Set(floors)).sort((a, b) => b - a);
+  }, [plansForBuilding]);
+
+  // Translate a floor pick into a selection of the matching floor
+  // plan entity — that keeps the workbench's single-source-of-truth
+  // model (everything is a selection) and means the rest of the
+  // wiring above ("if focused entity is a plan, derive activeFloor")
+  // works unchanged.
+  const onFloorChange = (floor: number | null) => {
+    if (floor === null) {
+      if (selectedBuildingId) {
+        ctx.setSelection({
+          ids: new Set([selectedBuildingId]),
+          focusedId: selectedBuildingId,
+        });
+      } else {
+        ctx.setSelection({ ids: new Set<string>(), focusedId: null });
+      }
+      return;
+    }
+    const plan = plansForBuilding.find((p) => p.floor === floor);
+    if (plan) {
+      ctx.setSelection({ ids: new Set([plan.id]), focusedId: plan.id });
+    }
+  };
 
   useMapboxPoiLayer({
     pois,
@@ -235,6 +273,14 @@ function MapViewComponent({ ctx }: ViewProps) {
     <div className="relative h-full w-full">
       <MapboxViewer />
       {placementMode ? <PlacementBanner mode={placementMode} /> : null}
+      {buildingFloors.length > 0 ? (
+        <FloorSwitcher
+          floors={buildingFloors}
+          activeFloor={activeFloor}
+          onChange={onFloorChange}
+          className="absolute right-4 top-1/2 z-10 -translate-y-1/2"
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/design-system/src/components/floor-switcher.tsx
+++ b/packages/design-system/src/components/floor-switcher.tsx
@@ -1,0 +1,120 @@
+import type { ComponentProps } from "react";
+import { cn } from "../utils/cn";
+
+/**
+ * Format an integer floor as a short pill label.
+ *
+ *   0   → "G"   (ground floor)
+ *   n>0 → "{n}" (above ground)
+ *   n<0 → "B{|n|}" (basement)
+ *
+ * Verticals that don't use the conventional building-floor numbering
+ * (route levels for Mobility, archaeology layers for Heritage, zoning
+ * tiers for Urban) pass their own `formatLabel`.
+ */
+export function defaultFloorLabel(n: number): string {
+  if (n === 0) return "G";
+  if (n > 0) return String(n);
+  return `B${Math.abs(n)}`;
+}
+
+export type FloorSwitcherProps = Omit<ComponentProps<"div">, "onChange"> & {
+  /**
+   * The set of selectable floors, as integers. The component does not
+   * sort them — pass them in the order you want them stacked. The
+   * canonical order on a building is "highest at top, basement at
+   * bottom", which means descending.
+   */
+  floors: number[];
+  /** The currently focused floor. `null` means "show all floors stacked". */
+  activeFloor: number | null;
+  /**
+   * Fires when the user picks a different floor. `null` is fired by
+   * the "All" pill and means "clear the focus".
+   */
+  onChange: (floor: number | null) => void;
+  /** Optional label formatter — defaults to {@link defaultFloorLabel}. */
+  formatLabel?: (floor: number) => string;
+  /** Optional label for the "show all floors" pill. Defaults to "All". */
+  allLabel?: string;
+  /**
+   * When true, the "All" pill is hidden — useful for surfaces where
+   * the parent always wants a single floor in focus (e.g. a tightly
+   * scoped drill-down view).
+   */
+  hideAllPill?: boolean;
+};
+
+/**
+ * A vertical stack of pills for switching between floors of a
+ * building — the standard "floor selector" pattern on Apple Maps /
+ * Google Maps / Mappedin. Position-agnostic: the caller decides
+ * whether to anchor it top-right of a map, dock it inside a panel,
+ * or render it inline.
+ *
+ * Reusable across every Klorad vertical because nothing here is
+ * building-specific — the same primitive renders Mobility's route
+ * levels and Heritage's archaeology layers with a different
+ * `formatLabel`.
+ */
+export function FloorSwitcher({
+  floors,
+  activeFloor,
+  onChange,
+  formatLabel = defaultFloorLabel,
+  allLabel = "All",
+  hideAllPill = false,
+  className,
+  ...props
+}: FloorSwitcherProps) {
+  if (floors.length === 0) return null;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Floor selector"
+      className={cn(
+        "flex flex-col gap-1 rounded-full border border-line-soft bg-surface-1/95 p-1 shadow-glass backdrop-blur",
+        className,
+      )}
+      {...props}
+    >
+      {floors.map((floor) => {
+        const active = activeFloor === floor;
+        return (
+          <button
+            key={floor}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(floor)}
+            className={cn(
+              "h-8 w-8 rounded-full text-xs font-medium tabular-nums transition-colors",
+              active
+                ? "bg-accent text-accent-contrast"
+                : "text-text-secondary hover:bg-surface-2 hover:text-text-primary",
+            )}
+          >
+            {formatLabel(floor)}
+          </button>
+        );
+      })}
+      {hideAllPill ? null : (
+        <button
+          type="button"
+          role="radio"
+          aria-checked={activeFloor === null}
+          onClick={() => onChange(null)}
+          className={cn(
+            "h-8 w-8 rounded-full text-[0.65rem] font-semibold uppercase tracking-wider transition-colors",
+            activeFloor === null
+              ? "bg-accent text-accent-contrast"
+              : "text-text-tertiary hover:bg-surface-2 hover:text-text-primary",
+          )}
+        >
+          {allLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -33,6 +33,11 @@ export { Avatar, type AvatarProps } from "./components/avatar";
 export { Badge, type BadgeProps, type BadgeTone } from "./components/badge";
 export { Spinner, type SpinnerProps } from "./components/spinner";
 export { EmptyState, type EmptyStateProps } from "./components/empty-state";
+export {
+  FloorSwitcher,
+  defaultFloorLabel,
+  type FloorSwitcherProps,
+} from "./components/floor-switcher";
 export { Select, type SelectProps } from "./components/select";
 export { Modal, type ModalProps } from "./components/modal";
 export {

--- a/packages/engine-mapbox/src/hooks/index.ts
+++ b/packages/engine-mapbox/src/hooks/index.ts
@@ -2,3 +2,9 @@ export { useMapboxInitialization } from "./useMapboxInitialization";
 export { useMapboxSceneSync } from "./useMapboxSceneSync";
 export { useMapboxThreeboxModels } from "./useMapboxThreeboxModels";
 export { useMapboxPreviewInteractionLock } from "./useMapboxPreviewInteractionLock";
+export {
+  useMapboxIndoorExtrusion,
+  type IndoorExtrusionFeature,
+  type IndoorExtrusionPaint,
+  type UseMapboxIndoorExtrusionOptions,
+} from "./useMapboxIndoorExtrusion";

--- a/packages/engine-mapbox/src/hooks/useMapboxIndoorExtrusion.ts
+++ b/packages/engine-mapbox/src/hooks/useMapboxIndoorExtrusion.ts
@@ -1,0 +1,412 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type {
+  Map as MapboxMap,
+  GeoJSONSource,
+  MapMouseEvent,
+} from "mapbox-gl";
+import { useSceneStore } from "@klorad/core";
+
+/**
+ * One polygon to render as an extruded indoor volume.
+ *
+ * Carries everything the generic hook needs:
+ *   - stable `id` for click + highlight routing
+ *   - `polygon` outer ring as `[lng, lat]` pairs (open or closed — the
+ *     hook closes it if needed)
+ *   - `level` (floor/layer/tier) for the active-level filter
+ *   - `base` + `height` in metres (absolute, not deltas)
+ *   - `color` — fill color
+ *   - optional `name` for the centered label
+ *
+ * Verticals tag whatever else they want under `extra` — it ends up on
+ * the GeoJSON feature properties so layer expressions or click
+ * handlers can read it.
+ */
+export interface IndoorExtrusionFeature {
+  id: string;
+  polygon: [number, number][];
+  level: number;
+  base: number;
+  height: number;
+  color: string;
+  name?: string;
+  extra?: Record<string, unknown>;
+}
+
+export interface IndoorExtrusionPaint {
+  /** Fill opacity for the volume. Default 0.85. */
+  fillOpacity?: number;
+  /** Color of the polygon outline lines. Default `#ffffff`. */
+  outlineColor?: string;
+  /** Outline opacity. Default 0.5. */
+  outlineOpacity?: number;
+  /** Outline width in pixels. Default 1. */
+  outlineWidth?: number;
+  /** Color of the highlight outline (drawn on top of the regular outline). */
+  highlightColor?: string;
+  /** Highlight outline width in pixels. Default 3. */
+  highlightWidth?: number;
+  /** Label text color. Default `#f5f7fa`. */
+  labelColor?: string;
+  /** Label halo color (for legibility on any background). */
+  labelHaloColor?: string;
+  /** Label text size in pixels. Default 12. */
+  labelSize?: number;
+}
+
+export interface UseMapboxIndoorExtrusionOptions {
+  /**
+   * Layer/source namespace — used to derive the four layer ids
+   * (`-source`, `-extrusion`, `-outline`, `-highlight`, `-label`).
+   * Pass a vertical-specific prefix like `"campus-rooms"` so two
+   * different consumers (rooms + slabs, rooms + heritage layers) can
+   * coexist on the same map without clashing.
+   */
+  namespace: string;
+  /** The polygons to render. Order is not significant. */
+  features: IndoorExtrusionFeature[];
+  /**
+   * The active level filter. `null` or `undefined` means "hide all"
+   * (parity with the original campus hook — callers that want
+   * everything visible should pass an explicit filter via
+   * `filterAll`).
+   */
+  activeLevel?: number | null;
+  /**
+   * When true, ignore `activeLevel` and show every feature
+   * regardless of its `level`. Use for surfaces that want a
+   * permanent X-ray of all floors at once.
+   */
+  showAllLevels?: boolean;
+  /** Optional id of a feature to outline with the highlight style. */
+  highlightId?: string | null;
+  /** Click handler — receives the feature `id`. */
+  onSelect?: (id: string) => void;
+  /** Disable click + hover (e.g. while a placement is active). */
+  clickEnabled?: boolean;
+  /** Render the centred name label? Default true. */
+  showLabels?: boolean;
+  /** Paint overrides — every key has a sensible default. */
+  paint?: IndoorExtrusionPaint;
+}
+
+function buildFeatureCollection(
+  features: IndoorExtrusionFeature[],
+): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: features
+      .filter((f) => f.polygon.length >= 3)
+      .map((f) => {
+        const ring = [...f.polygon];
+        const first = ring[0];
+        const last = ring[ring.length - 1];
+        if (first[0] !== last[0] || first[1] !== last[1]) ring.push(first);
+        return {
+          type: "Feature",
+          id: f.id,
+          geometry: { type: "Polygon", coordinates: [ring] },
+          properties: {
+            ...(f.extra ?? {}),
+            id: f.id,
+            name: f.name ?? "",
+            level: f.level,
+            base: f.base,
+            height: f.height,
+            color: f.color,
+          },
+        } satisfies GeoJSON.Feature;
+      }),
+  };
+}
+
+const HIDE_ALL_FILTER: unknown[] = [
+  "==",
+  ["get", "level"],
+  Number.NEGATIVE_INFINITY,
+];
+
+function levelFilter(
+  activeLevel: number | null | undefined,
+  showAllLevels: boolean | undefined,
+): unknown[] {
+  if (showAllLevels) return ["literal", true];
+  if (activeLevel === null || activeLevel === undefined) return HIDE_ALL_FILTER;
+  return ["==", ["get", "level"], activeLevel];
+}
+
+function highlightFilter(highlightId: string | null | undefined): unknown[] {
+  return ["==", ["get", "id"], highlightId ?? ""];
+}
+
+/**
+ * Render a set of indoor polygons as semi-transparent extruded
+ * volumes — the "X-ray" indoor view used in every Klorad vertical
+ * that maps interior space (campus rooms, heritage stratigraphy,
+ * mobility transit layers).
+ *
+ * What's installed (under `namespace`):
+ *   - one GeoJSON source
+ *   - one fill-extrusion layer (the volume)
+ *   - one line layer (the outline)
+ *   - one line layer (the highlight outline, filtered to highlightId)
+ *   - one symbol layer (the centered name label, if `showLabels`)
+ *
+ * The hook is split into three effects so callbacks (which change
+ * ref every parent render) don't cause a teardown — that fixed
+ * label flicker on the campus side and the same trade-off applies
+ * here. Idempotent across style swaps: re-installs on `style.load`,
+ * `styledata`, and `idle` because Mapbox occasionally drops custom
+ * layers when the basemap reloads its imports.
+ */
+export function useMapboxIndoorExtrusion(opts: UseMapboxIndoorExtrusionOptions) {
+  const map = useSceneStore((s) => s.mapboxMap as MapboxMap | null);
+  const {
+    namespace,
+    features,
+    activeLevel,
+    showAllLevels,
+    highlightId,
+    onSelect,
+    clickEnabled = true,
+    showLabels = true,
+    paint,
+  } = opts;
+
+  const sourceId = `${namespace}-source`;
+  const extrusionId = `${namespace}-extrusion`;
+  const outlineId = `${namespace}-outline`;
+  const highlightLayerId = `${namespace}-highlight`;
+  const labelId = `${namespace}-label`;
+
+  const fillOpacity = paint?.fillOpacity ?? 0.85;
+  const outlineColor = paint?.outlineColor ?? "#ffffff";
+  const outlineOpacity = paint?.outlineOpacity ?? 0.5;
+  const outlineWidth = paint?.outlineWidth ?? 1;
+  const highlightColor = paint?.highlightColor ?? "#ffffff";
+  const highlightWidth = paint?.highlightWidth ?? 3;
+  const labelColor = paint?.labelColor ?? "#f5f7fa";
+  const labelHaloColor = paint?.labelHaloColor ?? "rgba(15,23,42,0.78)";
+  const labelSize = paint?.labelSize ?? 12;
+
+  // Refs so the install effect can read the latest callback / flag
+  // without depending on them.
+  const onSelectRef = useRef(onSelect);
+  const clickEnabledRef = useRef(clickEnabled);
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
+  useEffect(() => {
+    clickEnabledRef.current = clickEnabled;
+  }, [clickEnabled]);
+
+  // ─── 1. install ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!map) return;
+
+    const install = () => {
+      try {
+        if (!map.getSource(sourceId)) {
+          map.addSource(sourceId, {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          });
+        }
+      } catch {
+        return;
+      }
+
+      const initialFilter = HIDE_ALL_FILTER;
+      const initialHighlight = highlightFilter(null);
+
+      if (!map.getLayer(extrusionId)) {
+        map.addLayer({
+          id: extrusionId,
+          type: "fill-extrusion",
+          source: sourceId,
+          filter: initialFilter as never,
+          paint: {
+            "fill-extrusion-color": ["get", "color"],
+            "fill-extrusion-base": ["get", "base"],
+            "fill-extrusion-height": ["get", "height"],
+            "fill-extrusion-opacity": fillOpacity,
+          },
+        });
+      }
+      if (!map.getLayer(outlineId)) {
+        map.addLayer({
+          id: outlineId,
+          type: "line",
+          source: sourceId,
+          filter: initialFilter as never,
+          paint: {
+            "line-color": outlineColor,
+            "line-opacity": outlineOpacity,
+            "line-width": outlineWidth,
+          },
+        });
+      }
+      if (!map.getLayer(highlightLayerId)) {
+        map.addLayer({
+          id: highlightLayerId,
+          type: "line",
+          source: sourceId,
+          filter: initialHighlight as never,
+          paint: {
+            "line-color": highlightColor,
+            "line-width": highlightWidth,
+          },
+        });
+      }
+      if (showLabels && !map.getLayer(labelId)) {
+        map.addLayer({
+          id: labelId,
+          type: "symbol",
+          source: sourceId,
+          filter: initialFilter as never,
+          layout: {
+            "text-field": ["get", "name"] as never,
+            "text-size": labelSize,
+            "text-anchor": "center",
+            "text-allow-overlap": false,
+            "text-ignore-placement": false,
+            "text-padding": 2,
+          },
+          paint: {
+            "text-color": labelColor,
+            "text-halo-color": labelHaloColor,
+            "text-halo-width": 1.3,
+            "text-halo-blur": 0.6,
+            "text-occlusion-opacity": 0,
+          },
+        });
+      }
+    };
+
+    install();
+    const onStyleLoad = () => install();
+    const onStyleData = () => install();
+    const onIdle = () => install();
+    map.on("style.load", onStyleLoad);
+    map.on("styledata", onStyleData);
+    map.on("idle", onIdle);
+
+    // Click + hover handlers — use refs so onSelect / clickEnabled
+    // changes don't tear the layer down.
+    const clickHandler = (e: MapMouseEvent) => {
+      if (!clickEnabledRef.current) return;
+      const feature = map.queryRenderedFeatures(e.point, {
+        layers: [extrusionId],
+      })[0];
+      if (!feature) return;
+      const id = (feature.properties?.id ?? feature.id) as string | undefined;
+      if (id && onSelectRef.current) onSelectRef.current(id);
+    };
+    const hoverEnter = () => {
+      if (!clickEnabledRef.current) return;
+      map.getCanvas().style.cursor = "pointer";
+    };
+    const hoverLeave = () => {
+      map.getCanvas().style.cursor = "";
+    };
+    map.on("click", extrusionId, clickHandler);
+    map.on("mouseenter", extrusionId, hoverEnter);
+    map.on("mouseleave", extrusionId, hoverLeave);
+
+    return () => {
+      map.off("style.load", onStyleLoad);
+      map.off("styledata", onStyleData);
+      map.off("idle", onIdle);
+      map.off("click", extrusionId, clickHandler);
+      map.off("mouseenter", extrusionId, hoverEnter);
+      map.off("mouseleave", extrusionId, hoverLeave);
+      try {
+        if (map.getLayer(labelId)) map.removeLayer(labelId);
+        if (map.getLayer(highlightLayerId)) map.removeLayer(highlightLayerId);
+        if (map.getLayer(outlineId)) map.removeLayer(outlineId);
+        if (map.getLayer(extrusionId)) map.removeLayer(extrusionId);
+        if (map.getSource(sourceId)) map.removeSource(sourceId);
+      } catch {
+        /* ignore */
+      }
+    };
+  }, [
+    map,
+    sourceId,
+    extrusionId,
+    outlineId,
+    highlightLayerId,
+    labelId,
+    showLabels,
+    fillOpacity,
+    outlineColor,
+    outlineOpacity,
+    outlineWidth,
+    highlightColor,
+    highlightWidth,
+    labelColor,
+    labelHaloColor,
+    labelSize,
+  ]);
+
+  // ─── 2. data + level filter ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!map) return;
+    const data = buildFeatureCollection(features);
+    const apply = () => {
+      const src = map.getSource(sourceId) as GeoJSONSource | undefined;
+      if (src) src.setData(data);
+      const filter = levelFilter(activeLevel, showAllLevels);
+      try {
+        if (map.getLayer(extrusionId))
+          map.setFilter(extrusionId, filter as never);
+        if (map.getLayer(outlineId)) map.setFilter(outlineId, filter as never);
+        if (showLabels && map.getLayer(labelId))
+          map.setFilter(labelId, filter as never);
+      } catch {
+        /* layer may be detached during a style swap */
+      }
+    };
+    apply();
+    const onStyleData = () => apply();
+    map.on("styledata", onStyleData);
+    return () => {
+      map.off("styledata", onStyleData);
+    };
+  }, [
+    map,
+    features,
+    activeLevel,
+    showAllLevels,
+    sourceId,
+    extrusionId,
+    outlineId,
+    labelId,
+    showLabels,
+  ]);
+
+  // ─── 3. highlight filter ─────────────────────────────────────────────────
+  useEffect(() => {
+    if (!map) return;
+    const apply = () => {
+      try {
+        if (map.getLayer(highlightLayerId)) {
+          map.setFilter(
+            highlightLayerId,
+            highlightFilter(highlightId) as never,
+          );
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    apply();
+    const onStyleData = () => apply();
+    map.on("styledata", onStyleData);
+    return () => {
+      map.off("styledata", onStyleData);
+    };
+  }, [map, highlightId, highlightLayerId]);
+}


### PR DESCRIPTION
## Summary

**Phase 1** of the indoor-immersion arc — turn campus buildings from solid extruded shells into navigable interiors. The workbench MapView shipped on day one with the room and floor-slab layers stubbed (`Plans + rooms are passed empty for v1`). The public viewer always rendered the full 3D interior; the editor didn't. This PR closes that gap and lifts the rendering kernel into the engine package so every Klorad vertical can reuse it.

3 commits, +638 / −282, one new reusable DS primitive (`FloorSwitcher`), one new engine hook (`useMapboxIndoorExtrusion`).

## What ships

### 1. Workbench MapView mounts the real indoor layers

Reads `FloorPlan` and `Room` entities from `ctx.entities` and mounts the same three layer hooks the public viewer has used since launch:

- `useMapboxDrawnBuildingsLayer` — now receives real plans + rooms (was empty arrays)
- `useMapboxFloorSlabsLayer` — floor plates, click to drill into a floor
- `useMapboxRoomsLayer` — semi-transparent extruded room volumes, scoped to the focused building

Selection drives `activeFloor`:

| Focused entity | selectedBuildingId | activeFloor |
|---|---|---|
| POI with `linkedBuilding` | the POI id | `null` (all floors stacked) |
| `FloorPlan` | the plan's building | the plan's floor |
| `Room` | the room's building | the room's floor |
| anything else | `null` | `null` |

Single source of truth — every existing entry point (Workflow drill, table click, hierarchy, ⌘K, right-click, 3D click, FloorSwitcher) produces the immersive view through the same selection update.

Rooms are scoped to the focused building rather than painting every room in every building. Phase 1 trade-off; revisit with a viewport-based filter once we have a sample campus with hundreds of rooms to profile.

### 2. `FloorSwitcher` — new DS primitive

```tsx
<FloorSwitcher
  floors={[3, 2, 1, 0, -1]}    // pre-ordered, top-down
  activeFloor={1}               // null = "All"
  onChange={(floor) => …}       // null fired by the All pill
  formatLabel={(n) => …}        // default: G / 1 / 2 / B1
  hideAllPill={false}           // hide if focus is always required
/>
```

Vertical pill stack — the standard floor-selector pattern on Apple Maps / Google Maps / Mappedin. Anchored to the right edge of the workbench map at mid-height; renders only when the focused building has plans to switch between.

Reusable across every Klorad vertical because nothing here is building-specific: Mobility's route levels and Heritage's archaeology layers reuse it with a different `formatLabel`.

The "All" pill clears `activeFloor` and collapses the X-ray back to the full stacked shell. Picking a numbered floor selects the matching `FloorPlan` entity — the same path a 3D floor-slab click already triggers.

### 3. `useMapboxIndoorExtrusion` — lifted into `@klorad/engine-mapbox`

The room-rendering pipeline in campus was a self-contained Mapbox `fill-extrusion` controller with idempotent install across style swaps, refs to avoid teardown-on-callback-change, and a three-effect split (install / data+filter / highlight). None of that logic is campus-specific.

```ts
useMapboxIndoorExtrusion({
  namespace: "campus-rooms",      // → -source, -extrusion, -outline, -highlight, -label
  features,                        // IndoorExtrusionFeature[] (polygon + level + base + height + color + name)
  activeLevel,                     // number | null — null hides everything
  showAllLevels,                   // skip the level filter entirely
  highlightId,
  onSelect,
  clickEnabled,
  showLabels,
  paint,                           // every key optional, sensible defaults
})
```

Campus's `useMapboxRoomsLayer` shrunk **295 → 64 lines**. Its sole remaining job: compute per-room base/height from `FLOOR_HEIGHT_M` and `roomHeightM`, resolve color via `roomColor`, hand the rest to the engine hook. Public API of the campus wrapper is unchanged — both consumers (workbench + public viewer) keep calling `useMapboxRoomsLayer(rooms, opts)` with the same options shape.

Future Phase 2 work (wayfinding) reuses the same primitive for the highlighted "you-are-here" room and the routed corridor floor plates — different `namespace` per use case keeps them visually distinct without code duplication.

## Reusability — per `memory/reusable-feature-primitives.md`

| Primitive | Lives in | Reused by |
|---|---|---|
| `FloorSwitcher` | `@klorad/design-system` | Campus (today), Mobility (route levels), Heritage (archaeology layers), Urban (zoning tiers) — different `formatLabel` |
| `useMapboxIndoorExtrusion` | `@klorad/engine-mapbox` | Campus rooms (today), Phase 2 routed corridors, Heritage stratigraphy, Mobility transit-floor view |
| `IndoorExtrusionFeature` / `IndoorExtrusionPaint` | `@klorad/engine-mapbox` | Adapter contract for every vertical that maps interior space |

`useMapboxFloorSlabsLayer` and `useMapboxDrawnBuildingsLayer` stay in campus for now — they're more campus-specific (POI-shaped buildings, drawn-on-the-map slabs). Lifting them is a future refactor when a second vertical needs them.

## Schema

**No migration.** `FloorPlan` and `Room` were already on the Prisma model + exposed through the entity index (the room editing work landed earlier in `feature/indoor-rooms`). This PR just wires them through the workbench MapView for rendering.

## Files

| | |
|---|---|
| `packages/engine-mapbox/src/hooks/useMapboxIndoorExtrusion.ts` *(new)* | The generic primitive |
| `packages/engine-mapbox/src/hooks/index.ts` | Re-export |
| `packages/design-system/src/components/floor-switcher.tsx` *(new)* | DS primitive |
| `packages/design-system/src/index.ts` | Re-export |
| `apps/campus/app/hooks/useMapboxRoomsLayer.ts` | Now a thin adapter (−231 lines) |
| `apps/campus/lib/workbench/views/map.tsx` | Mount indoor layers + FloorSwitcher overlay (+86 / −11) |

## Test plan

- [ ] Open workbench on a campus with at least one building containing floor plans + rooms → buildings render as before
- [ ] Click a building POI → buildings stay solid, no FloorSwitcher yet (no plans selected)
- [ ] Click a building POI that has plans → FloorSwitcher appears at the right edge of the map
- [ ] Click a floor pill (e.g. "1") → building shell lifts off, that floor's rooms become visible inside
- [ ] Click "All" → X-ray collapses, full shell returns, all floors stacked
- [ ] Click a floor slab in the 3D scene → FloorSwitcher updates to match
- [ ] Click a room in the 3D scene → room highlighted with white outline, drawer opens to room details
- [ ] Open the same campus in the public viewer (`/campus/{id}`) → unchanged behaviour (same `useMapboxRoomsLayer` API, just thinner implementation)
- [ ] Open ⌘K, pick any room from the entity list → focus jumps, FloorSwitcher reflects the room's floor
- [ ] No flicker on idle (the original three-effect split is preserved through the lift)

## Next

**Phase 2 — Wayfinding.** Outdoor walking routes via the Mapbox Directions API, indoor routing via an A* graph over door + corridor nodes, stitched at building entrances, accessibility-filterable (`step-free`). Reuses `useMapboxIndoorExtrusion` for the routed-corridor highlight. New branch off main once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
