### PR TITLE
feat: wayfinding infrastructure — graph data model, A* routing, stitched outdoor+indoor routes

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/workbench/WorkbenchClient.tsx
@@ -14,6 +14,8 @@ import { createSceneAPI } from "@klorad/api";
 import type {
   CampusAPI,
   FloorPlan,
+  NavEdge,
+  NavNode,
   POI,
   Room,
   TourStop,
@@ -48,6 +50,8 @@ export default function WorkbenchClient({ mapId }: Props) {
   const [plans, setPlans] = useState<FloorPlan[]>([]);
   const [rooms, setRooms] = useState<Room[]>([]);
   const [tourStops] = useState<TourStop[]>([]);
+  const [navNodes, setNavNodes] = useState<NavNode[]>([]);
+  const [navEdges, setNavEdges] = useState<NavEdge[]>([]);
   const apiRef = useRef<CampusAPI | null>(null);
 
   // Save state — the version counter ticks on every op mutation; the
@@ -77,6 +81,8 @@ export default function WorkbenchClient({ mapId }: Props) {
         setPois(api.poi.getAll());
         setPlans(api.floorPlans.getAll());
         setRooms(api.rooms.getAll());
+        setNavNodes(api.navNodes.getAll());
+        setNavEdges(api.navEdges.getAll());
       } catch {
         // New or unreachable map — fall through to empty defaults.
       } finally {
@@ -97,6 +103,8 @@ export default function WorkbenchClient({ mapId }: Props) {
     setPois(apiRef.current.poi.getAll());
     setPlans(apiRef.current.floorPlans.getAll());
     setRooms(apiRef.current.rooms.getAll());
+    setNavNodes(apiRef.current.navNodes.getAll());
+    setNavEdges(apiRef.current.navEdges.getAll());
   }, [apiVersion, sceneReady]);
 
   const entities = useMemo(
@@ -107,8 +115,10 @@ export default function WorkbenchClient({ mapId }: Props) {
         floorPlans: plans,
         rooms,
         tourStops,
+        navNodes,
+        navEdges,
       }),
-    [mapId, pois, plans, rooms, tourStops],
+    [mapId, pois, plans, rooms, tourStops, navNodes, navEdges],
   );
 
   const toast = useCallback<WorkbenchToast>((msg, tone) => {

--- a/apps/campus/lib/wayfinding/find-campus-path.ts
+++ b/apps/campus/lib/wayfinding/find-campus-path.ts
@@ -1,0 +1,82 @@
+/**
+ * Campus-side adapter over the generic graph router in
+ * `@klorad/core/routing`. Translates the campus `NavNode` / `NavEdge`
+ * shape into the engine's `RouteGraph` and applies the campus rule
+ * for step-free routing (exclude stair nodes + stair edges).
+ *
+ * Verticals share the same router but ship their own adapter — a
+ * heritage adapter would treat "elevation tier" differently, a
+ * mobility adapter would weigh transfers vs walks separately.
+ */
+
+import { findPath, type RouteGraph, type RoutePath } from "@klorad/core";
+import type { NavEdge, NavNode } from "@klorad/api";
+
+export interface FindCampusPathOptions {
+  /** Step-free mode — drop stair nodes/edges and any explicit `accessible:false`. */
+  stepFree?: boolean;
+}
+
+/**
+ * Build a generic `RouteGraph<NavNode, NavEdge>` from the campus
+ * graph storage. Vertical metadata rides in the `meta` slot so the
+ * router doesn't need to know about it, and the consumer recovers
+ * the original record on the returned path via `node.meta`.
+ */
+export function buildCampusRouteGraph(
+  navNodes: NavNode[],
+  navEdges: NavEdge[],
+): RouteGraph<NavNode, NavEdge> {
+  return {
+    nodes: navNodes.map((n) => ({
+      id: n.id,
+      position: n.position,
+      level: n.floor ?? null,
+      meta: n,
+    })),
+    edges: navEdges.map((e) => ({
+      id: e.id,
+      fromNodeId: e.fromNodeId,
+      toNodeId: e.toNodeId,
+      cost: e.cost,
+      meta: e,
+    })),
+  };
+}
+
+/**
+ * Find the lowest-cost walking route between two graph nodes.
+ *
+ * Returns `null` if either endpoint is missing, filtered out by
+ * step-free mode, or the destination is unreachable from the
+ * source. Cost is in metres, the same units as
+ * `haversineDistanceMeters`.
+ */
+export function findCampusPath(
+  navNodes: NavNode[],
+  navEdges: NavEdge[],
+  fromId: string,
+  toId: string,
+  opts: FindCampusPathOptions = {},
+): RoutePath<NavNode, NavEdge> | null {
+  const graph = buildCampusRouteGraph(navNodes, navEdges);
+  if (!opts.stepFree) return findPath(graph, fromId, toId);
+
+  const isStepFreeNode = (n: NavNode) =>
+    n.type !== "stair" && n.accessible !== false;
+
+  return findPath(graph, fromId, toId, {
+    nodeFilter: (node) => (node.meta ? isStepFreeNode(node.meta) : true),
+    edgeFilter: (edge, from, to) => {
+      // Explicit edge-level opt-out overrides everything.
+      if (edge.meta?.accessible === false) return false;
+      // Otherwise, both endpoints must be step-free. The node filter
+      // already dropped non-step-free nodes; this second check is
+      // belt-and-braces for the case where the edge filter runs
+      // before the node filter on a given iteration order.
+      const fromOk = from.meta ? isStepFreeNode(from.meta) : true;
+      const toOk = to.meta ? isStepFreeNode(to.meta) : true;
+      return fromOk && toOk;
+    },
+  });
+}

--- a/apps/campus/lib/wayfinding/find-stitched-route.ts
+++ b/apps/campus/lib/wayfinding/find-stitched-route.ts
@@ -1,0 +1,247 @@
+/**
+ * Stitched outdoor + indoor wayfinding.
+ *
+ * Walks the user from an arbitrary start point (their location, a
+ * POI, or another room) through outdoor space to the closest
+ * external door of the destination building, then continues on the
+ * indoor graph to the room's anchor node.
+ *
+ * The two segments are returned separately so the renderer can
+ * style them differently (outdoor: thick blue line, indoor: dashed
+ * line that follows the building's X-ray view), and so the
+ * summary card can break out walking distance vs. building
+ * distance for users planning ahead.
+ *
+ * If the destination is itself outdoor (or the user's start is
+ * already inside the same building), the corresponding segment is
+ * `null` — consumers handle one-leg routes naturally.
+ */
+
+import { haversineDistanceMeters, type RoutePath } from "@klorad/core";
+import { fetchMapboxDirections } from "@klorad/engine-mapbox";
+import type { NavEdge, NavNode, POI, Room } from "@klorad/api";
+import { findCampusPath } from "./find-campus-path";
+
+export interface StitchedRouteOrigin {
+  /** Lng/lat the user starts from. */
+  position: [number, number];
+  /** Optional human label ("Front gate", "Library"). */
+  label?: string;
+}
+
+export interface StitchedRouteDestination {
+  /** Either a room (resolved via room-anchor node) or a POI. */
+  roomId?: string;
+  poiId?: string;
+}
+
+export interface FindStitchedRouteOptions {
+  stepFree?: boolean;
+  /** Override the Mapbox access token (else NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN). */
+  mapboxAccessToken?: string;
+  /** AbortSignal forwarded to the outdoor Directions call. */
+  signal?: AbortSignal;
+}
+
+export interface StitchedRouteResult {
+  /** Outdoor walking polyline, or `null` if no outdoor segment. */
+  outdoor: {
+    coordinates: [number, number][];
+    distanceM: number;
+    durationS: number;
+  } | null;
+  /** Indoor A* path through the building, or `null` if no indoor segment. */
+  indoor: RoutePath<NavNode, NavEdge> | null;
+  /** Total walking distance in metres (outdoor + indoor). */
+  totalDistanceM: number;
+  /** Total estimated duration in seconds. */
+  totalDurationS: number;
+  /** Number of distinct floors visited (1 if the route doesn't change level). */
+  floorsTouched: number;
+}
+
+interface RouteInputs {
+  rooms: Room[];
+  pois: POI[];
+  navNodes: NavNode[];
+  navEdges: NavEdge[];
+}
+
+const WALKING_SPEED_MPS = 1.3; // Average campus walking pace.
+
+function nearestExternalDoor(
+  navNodes: NavNode[],
+  buildingId: string,
+  from: [number, number],
+): NavNode | null {
+  const doors = navNodes.filter(
+    (n) => n.type === "door-external" && n.buildingId === buildingId,
+  );
+  if (doors.length === 0) return null;
+  let best: NavNode | null = null;
+  let bestDist = Infinity;
+  for (const door of doors) {
+    const d = haversineDistanceMeters(from, door.position);
+    if (d < bestDist) {
+      bestDist = d;
+      best = door;
+    }
+  }
+  return best;
+}
+
+function roomAnchor(navNodes: NavNode[], roomId: string): NavNode | null {
+  return (
+    navNodes.find((n) => n.type === "room-anchor" && n.roomId === roomId) ??
+    null
+  );
+}
+
+/**
+ * Compute the stitched route from `origin` to `destination`.
+ *
+ * Resolves the destination's anchor node + nearest external door,
+ * fetches the outdoor walking polyline via Mapbox Directions, then
+ * runs A* over the indoor graph for the building segment.
+ *
+ * Returns `null` if the indoor graph can't get from the chosen
+ * entrance to the destination (room anchor missing, graph not
+ * connected, step-free filter eliminates the only path). Outdoor
+ * failure (no Mapbox route between the points) doesn't fail the
+ * whole call — `outdoor` is null and the consumer can fall back
+ * to a great-circle hint line.
+ */
+export async function findStitchedRoute(
+  origin: StitchedRouteOrigin,
+  destination: StitchedRouteDestination,
+  data: RouteInputs,
+  opts: FindStitchedRouteOptions = {},
+): Promise<StitchedRouteResult | null> {
+  const { rooms, pois, navNodes, navEdges } = data;
+
+  // Resolve destination → an anchor node id + which building it's in.
+  let destNode: NavNode | null = null;
+  let destBuildingId: string | null = null;
+  if (destination.roomId) {
+    const room = rooms.find((r) => r.id === destination.roomId);
+    if (!room) return null;
+    destNode = roomAnchor(navNodes, room.id);
+    destBuildingId = room.buildingId;
+  } else if (destination.poiId) {
+    const poi = pois.find((p) => p.id === destination.poiId);
+    if (!poi) return null;
+    // For a POI destination, the building it lives in (if any) is its
+    // parent — otherwise treat the POI itself as the endpoint and skip
+    // the indoor leg entirely.
+    if (poi.parentBuildingId) {
+      destBuildingId = poi.parentBuildingId;
+      // Use the room-anchor if one exists for the POI; else nearest door.
+      destNode = roomAnchor(navNodes, poi.id);
+    }
+  }
+
+  // If we have an indoor destination, find the nearest external door.
+  // The outdoor leg ends here; the indoor leg starts here.
+  let entranceNode: NavNode | null = null;
+  if (destBuildingId) {
+    entranceNode = nearestExternalDoor(
+      navNodes,
+      destBuildingId,
+      origin.position,
+    );
+  }
+
+  // Outdoor segment — origin → (entrance OR final destination position).
+  const outdoorTarget: [number, number] | null = entranceNode
+    ? entranceNode.position
+    : destination.poiId
+      ? pois.find((p) => p.id === destination.poiId)?.position
+        ? [
+            pois.find((p) => p.id === destination.poiId)!.position[0],
+            pois.find((p) => p.id === destination.poiId)!.position[1],
+          ]
+        : null
+      : null;
+
+  let outdoor: StitchedRouteResult["outdoor"] = null;
+  if (outdoorTarget) {
+    try {
+      const dir = await fetchMapboxDirections({
+        from: origin.position,
+        to: outdoorTarget,
+        profile: "walking",
+        accessToken: opts.mapboxAccessToken,
+        signal: opts.signal,
+      });
+      if (dir) {
+        outdoor = {
+          coordinates: dir.coordinates,
+          distanceM: dir.distanceM,
+          durationS: dir.durationS,
+        };
+      } else {
+        // Fall back to a single great-circle line so the renderer
+        // can still show a hint even without a routable network.
+        const fallbackD = haversineDistanceMeters(
+          origin.position,
+          outdoorTarget,
+        );
+        outdoor = {
+          coordinates: [origin.position, outdoorTarget],
+          distanceM: fallbackD,
+          durationS: fallbackD / WALKING_SPEED_MPS,
+        };
+      }
+    } catch (err) {
+      if ((err as { name?: string })?.name === "AbortError") throw err;
+      // Same fallback for missing-token cases — render a hint line.
+      const fallbackD = haversineDistanceMeters(origin.position, outdoorTarget);
+      outdoor = {
+        coordinates: [origin.position, outdoorTarget],
+        distanceM: fallbackD,
+        durationS: fallbackD / WALKING_SPEED_MPS,
+      };
+    }
+  }
+
+  // Indoor segment — entrance → destination anchor.
+  let indoor: RoutePath<NavNode, NavEdge> | null = null;
+  if (entranceNode && destNode) {
+    indoor = findCampusPath(
+      navNodes,
+      navEdges,
+      entranceNode.id,
+      destNode.id,
+      { stepFree: opts.stepFree },
+    );
+    if (!indoor) {
+      // Indoor unreachable under current filter — surface a null
+      // result so the consumer can prompt for a different door /
+      // disable step-free.
+      return null;
+    }
+  }
+
+  const totalDistanceM =
+    (outdoor?.distanceM ?? 0) + (indoor?.cost ?? 0);
+  const totalDurationS =
+    (outdoor?.durationS ?? 0) +
+    (indoor ? indoor.cost / WALKING_SPEED_MPS : 0);
+
+  const floorsTouched = (() => {
+    if (!indoor) return 1;
+    const floors = new Set<number>();
+    for (const n of indoor.nodes) {
+      if (typeof n.level === "number") floors.add(n.level);
+    }
+    return Math.max(1, floors.size);
+  })();
+
+  return {
+    outdoor,
+    indoor,
+    totalDistanceM,
+    totalDurationS,
+    floorsTouched,
+  };
+}

--- a/apps/campus/lib/wayfinding/index.ts
+++ b/apps/campus/lib/wayfinding/index.ts
@@ -3,3 +3,10 @@ export {
   findCampusPath,
   type FindCampusPathOptions,
 } from "./find-campus-path";
+export {
+  findStitchedRoute,
+  type FindStitchedRouteOptions,
+  type StitchedRouteDestination,
+  type StitchedRouteOrigin,
+  type StitchedRouteResult,
+} from "./find-stitched-route";

--- a/apps/campus/lib/wayfinding/index.ts
+++ b/apps/campus/lib/wayfinding/index.ts
@@ -1,0 +1,5 @@
+export {
+  buildCampusRouteGraph,
+  findCampusPath,
+  type FindCampusPathOptions,
+} from "./find-campus-path";

--- a/apps/campus/lib/workbench/entities/index.ts
+++ b/apps/campus/lib/workbench/entities/index.ts
@@ -4,3 +4,5 @@ export { floorPlanEntity } from "./floor-plan";
 export { roomEntity } from "./room";
 export { tourStopEntity } from "./tour-stop";
 export { eventEntity } from "./event";
+export { navNodeEntity } from "./nav-node";
+export { navEdgeEntity } from "./nav-edge";

--- a/apps/campus/lib/workbench/entities/nav-edge.ts
+++ b/apps/campus/lib/workbench/entities/nav-edge.ts
@@ -1,0 +1,28 @@
+import type { NavEdge } from "@klorad/api";
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+/**
+ * An edge in the wayfinding graph — a walkable connection between
+ * two {@link NavNode} waypoints. Carries optional cost overrides for
+ * elevator/stair transitions where great-circle distance is ~0, and
+ * an accessibility flag that defaults to the AND of its endpoints.
+ *
+ * Promoting it to a workbench entity lets graph operations
+ * (`nav.connect`, `nav.delete-edge`, `nav.toggle-accessible`)
+ * surface generically with `scope: ["campus.nav-edge"]`.
+ */
+const defaults: NavEdge = {
+  id: "",
+  fromNodeId: "",
+  toNodeId: "",
+};
+
+export const navEdgeEntity: EntityType<NavEdge> = {
+  id: "campus.nav-edge",
+  label: "Nav edge",
+  schema: identitySchema<NavEdge>(),
+  defaults,
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/entities/nav-node.ts
+++ b/apps/campus/lib/workbench/entities/nav-node.ts
@@ -1,0 +1,31 @@
+import type { NavNode } from "@klorad/api";
+import type { EntityType } from "@klorad/config/workbench";
+import { identitySchema } from "../schema";
+
+/**
+ * A waypoint in the wayfinding graph — corridor intersection, door,
+ * elevator/stair landing, room anchor, or outdoor path junction.
+ *
+ * The shape comes from `@klorad/api`'s `NavNode`; promoting it to a
+ * first-class workbench entity lets graph operations (`nav.add-node`,
+ * `nav.connect`, `nav.delete-node`) surface generically through the
+ * selection panel, ⌘K, and the right-click menu.
+ *
+ * Verticals that map indoor space (Heritage, Mobility) reuse the same
+ * underlying graph by registering their own per-vertical entity ids
+ * that point at the same NavNode payload.
+ */
+const defaults: NavNode = {
+  id: "",
+  type: "corridor",
+  position: [0, 0],
+};
+
+export const navNodeEntity: EntityType<NavNode> = {
+  id: "campus.nav-node",
+  label: "Nav node",
+  schema: identitySchema<NavNode>(),
+  defaults,
+  views: [],
+  operations: [],
+};

--- a/apps/campus/lib/workbench/runtime/campus-entity-index.ts
+++ b/apps/campus/lib/workbench/runtime/campus-entity-index.ts
@@ -4,7 +4,15 @@ import type {
   EntityIndex,
   EntityTypeId,
 } from "@klorad/config/workbench";
-import type { FloorPlan, POI, POIEvent, Room, TourStop } from "@klorad/api";
+import type {
+  FloorPlan,
+  NavEdge,
+  NavNode,
+  POI,
+  POIEvent,
+  Room,
+  TourStop,
+} from "@klorad/api";
 import type { Building } from "../entities/building";
 
 /**
@@ -28,6 +36,14 @@ export interface CampusEntitySources {
   floorPlans: FloorPlan[];
   rooms: Room[];
   tourStops: TourStop[];
+  /**
+   * Wayfinding graph waypoints — corridor, door, elevator/stair,
+   * room-anchor, outdoor. Pass `[]` if the campus hasn't started
+   * authoring its nav graph yet.
+   */
+  navNodes: NavNode[];
+  /** Edges between {@link navNodes}. */
+  navEdges: NavEdge[];
 }
 
 /**
@@ -61,6 +77,8 @@ export function createCampusEntityIndex({
   floorPlans,
   rooms,
   tourStops,
+  navNodes,
+  navEdges,
 }: CampusEntitySources): EntityIndex {
   const poiEntities: Entity<POI>[] = pois.map((poi) => ({
     id: poi.id,
@@ -130,6 +148,24 @@ export function createCampusEntityIndex({
     })),
   );
 
+  const navNodeEntities: Entity<NavNode>[] = navNodes.map((node) => ({
+    id: node.id,
+    typeId: "campus.nav-node",
+    worldId,
+    payload: node,
+    createdAt: "",
+    updatedAt: "",
+  }));
+
+  const navEdgeEntities: Entity<NavEdge>[] = navEdges.map((edge) => ({
+    id: edge.id,
+    typeId: "campus.nav-edge",
+    worldId,
+    payload: edge,
+    createdAt: "",
+    updatedAt: "",
+  }));
+
   const all: Entity[] = [
     ...poiEntities,
     ...buildingEntities,
@@ -137,6 +173,8 @@ export function createCampusEntityIndex({
     ...roomEntities,
     ...tourStopEntities,
     ...eventEntities,
+    ...navNodeEntities,
+    ...navEdgeEntities,
   ];
 
   const byIdMap = new Map<EntityId, Entity>(all.map((e) => [e.id, e]));
@@ -148,6 +186,8 @@ export function createCampusEntityIndex({
     ["campus.room", roomEntities],
     ["campus.tour-stop", tourStopEntities],
     ["campus.event", eventEntities],
+    ["campus.nav-node", navNodeEntities],
+    ["campus.nav-edge", navEdgeEntities],
   ]);
 
   return {

--- a/apps/campus/workbench.config.ts
+++ b/apps/campus/workbench.config.ts
@@ -6,6 +6,8 @@ import {
   roomEntity,
   tourStopEntity,
   eventEntity,
+  navNodeEntity,
+  navEdgeEntity,
   mapView,
   overviewView,
   tableView,
@@ -72,6 +74,8 @@ const workbenchConfig = defineWorkbench({
     roomEntity,
     tourStopEntity,
     eventEntity,
+    navNodeEntity,
+    navEdgeEntity,
   ],
   views: [
     mapView,

--- a/packages/api/src/extensions/campus.ts
+++ b/packages/api/src/extensions/campus.ts
@@ -10,6 +10,12 @@ import type {
   Room,
   RoomInput,
   RoomsAPI,
+  NavNode,
+  NavNodeInput,
+  NavNodesAPI,
+  NavEdge,
+  NavEdgeInput,
+  NavEdgesAPI,
 } from "../types/interfaces";
 import type { POI, POIInput, DataLayer } from "../types/campus";
 
@@ -310,6 +316,106 @@ export function createRoomsAPI(): RoomsAPI {
   };
 }
 
+export function createNavNodesAPI(): NavNodesAPI {
+  const get = () => useSceneStore.getState();
+
+  const readNodes = (): NavNode[] => {
+    const raw = get().mapboxSceneData.navNodes ?? [];
+    return raw.map((n) => ({ ...n })) as NavNode[];
+  };
+  const writeNodes = (nodes: NavNode[]) => {
+    get().setMapboxSceneData({
+      navNodes: nodes.map((n) => ({ ...n })),
+    });
+  };
+
+  return {
+    add(input: NavNodeInput): NavNode {
+      const node: NavNode = {
+        id: input.id ?? uuidv4(),
+        type: input.type,
+        position: input.position,
+        floor: input.floor,
+        buildingId: input.buildingId,
+        roomId: input.roomId,
+        accessible: input.accessible ?? input.type !== "stair",
+        name: input.name,
+      };
+      writeNodes([...readNodes(), node]);
+      return node;
+    },
+    update(id, patch) {
+      writeNodes(readNodes().map((n) => (n.id === id ? { ...n, ...patch } : n)));
+    },
+    remove(id) {
+      writeNodes(readNodes().filter((n) => n.id !== id));
+    },
+    getAll(): NavNode[] {
+      return readNodes();
+    },
+    forBuilding(buildingId: string, floor?: number): NavNode[] {
+      return readNodes().filter(
+        (n) =>
+          n.buildingId === buildingId &&
+          (floor === undefined || n.floor === floor),
+      );
+    },
+    outdoor(): NavNode[] {
+      return readNodes().filter(
+        (n) => !n.buildingId || n.type === "outdoor",
+      );
+    },
+    forRoom(roomId: string): NavNode | undefined {
+      return readNodes().find(
+        (n) => n.type === "room-anchor" && n.roomId === roomId,
+      );
+    },
+  };
+}
+
+export function createNavEdgesAPI(): NavEdgesAPI {
+  const get = () => useSceneStore.getState();
+
+  const readEdges = (): NavEdge[] => {
+    const raw = get().mapboxSceneData.navEdges ?? [];
+    return raw.map((e) => ({ ...e })) as NavEdge[];
+  };
+  const writeEdges = (edges: NavEdge[]) => {
+    get().setMapboxSceneData({
+      navEdges: edges.map((e) => ({ ...e })),
+    });
+  };
+
+  return {
+    add(input: NavEdgeInput): NavEdge {
+      const edge: NavEdge = {
+        id: input.id ?? uuidv4(),
+        fromNodeId: input.fromNodeId,
+        toNodeId: input.toNodeId,
+        cost: input.cost,
+        accessible: input.accessible,
+        name: input.name,
+      };
+      writeEdges([...readEdges(), edge]);
+      return edge;
+    },
+    update(id, patch) {
+      writeEdges(readEdges().map((e) => (e.id === id ? { ...e, ...patch } : e)));
+    },
+    remove(id) {
+      writeEdges(readEdges().filter((e) => e.id !== id));
+    },
+    getAll(): NavEdge[] {
+      return readEdges();
+    },
+    forNode(nodeId: string): NavEdge[] {
+      return readEdges().filter(
+        (e) => e.fromNodeId === nodeId || e.toNodeId === nodeId,
+      );
+    },
+  };
+}
+
 export function createLayersAPI(): LayersAPI {
   const layers = new Map<string, DataLayer>();
 
@@ -334,12 +440,14 @@ export function createLayersAPI(): LayersAPI {
   };
 }
 
-export function createCampusExtension(): Pick<CampusAPI, "poi" | "layers" | "floorPlans" | "rooms" | "setLocation"> {
+export function createCampusExtension(): Pick<CampusAPI, "poi" | "layers" | "floorPlans" | "rooms" | "navNodes" | "navEdges" | "setLocation"> {
   return {
     poi: createPOIManagerAPI(),
     layers: createLayersAPI(),
     floorPlans: createFloorPlansAPI(),
     rooms: createRoomsAPI(),
+    navNodes: createNavNodesAPI(),
+    navEdges: createNavEdgesAPI(),
     setLocation(lng, lat, options = {}) {
       const { zoom, pitch, bearing, fly = true } = options;
       const s = useSceneStore.getState();

--- a/packages/api/src/types/interfaces.ts
+++ b/packages/api/src/types/interfaces.ts
@@ -308,11 +308,104 @@ export interface RoomsAPI {
   forFloor(buildingId: string, floor: number): Room[];
 }
 
+/**
+ * A waypoint in the wayfinding graph. Mirrors `MapboxNavNode` in
+ * `@klorad/core` — the {@link RoomsAPI}/`FloorPlansAPI` already
+ * follow the same pattern of "core defines persistence, api defines
+ * the consumer-facing shape."
+ *
+ * Node types:
+ *   - `corridor` — intermediate point along a hallway
+ *   - `door-external` — building entrance (outdoor ↔ indoor bridge)
+ *   - `door-internal` — door between two indoor spaces on one floor
+ *   - `elevator` — vertical-transit waypoint (step-free)
+ *   - `stair` — vertical-transit waypoint (excluded from step-free routes)
+ *   - `room-anchor` — marks the entry point for a specific {@link Room}
+ *   - `outdoor` — outdoor path junction or campus gate
+ */
+export type NavNodeType =
+  | "corridor"
+  | "door-external"
+  | "door-internal"
+  | "elevator"
+  | "stair"
+  | "room-anchor"
+  | "outdoor";
+
+export interface NavNode {
+  id: string;
+  type: NavNodeType;
+  /** [lng, lat]. */
+  position: [number, number];
+  /** Floor for indoor nodes. `null`/undefined for outdoor. */
+  floor?: number | null;
+  /** Building POI id (omit for outdoor nodes). */
+  buildingId?: string;
+  /** Room id for `type === "room-anchor"`. */
+  roomId?: string;
+  /**
+   * Step-free? Defaults to `true` for everything except `stair`. The
+   * router excludes non-accessible nodes (and edges touching them)
+   * when the user toggles accessibility mode.
+   */
+  accessible?: boolean;
+  /** Human label — surfaced in the editor and search. */
+  name?: string;
+}
+
+export type NavNodeInput = Omit<NavNode, "id"> & { id?: string };
+
+export interface NavEdge {
+  id: string;
+  fromNodeId: string;
+  toNodeId: string;
+  /**
+   * Override the auto-computed walking cost (in metres). Set for
+   * elevators (~3m per floor + dwell) and stairs (~6m per floor)
+   * where the great-circle distance is ~0.
+   */
+  cost?: number;
+  /**
+   * Step-free? Defaults to (fromNode.accessible && toNode.accessible).
+   * Override to mark a passage non-step-free without changing the
+   * node types.
+   */
+  accessible?: boolean;
+  /** Human label ("Stair B", "Elevator 2"). */
+  name?: string;
+}
+
+export type NavEdgeInput = Omit<NavEdge, "id"> & { id?: string };
+
+export interface NavNodesAPI {
+  add(input: NavNodeInput): NavNode;
+  update(id: string, patch: Partial<NavNode>): void;
+  remove(id: string): void;
+  getAll(): NavNode[];
+  /** Nodes scoped to a building, optionally filtered by floor. */
+  forBuilding(buildingId: string, floor?: number): NavNode[];
+  /** Outdoor nodes only (no building scope). */
+  outdoor(): NavNode[];
+  /** Anchor node for a room, if defined. */
+  forRoom(roomId: string): NavNode | undefined;
+}
+
+export interface NavEdgesAPI {
+  add(input: NavEdgeInput): NavEdge;
+  update(id: string, patch: Partial<NavEdge>): void;
+  remove(id: string): void;
+  getAll(): NavEdge[];
+  /** Edges touching a given node id (either endpoint). */
+  forNode(nodeId: string): NavEdge[];
+}
+
 export interface CampusAPI extends SceneAPI {
   readonly poi: POIManagerAPI;
   readonly layers: LayersAPI;
   readonly floorPlans: FloorPlansAPI;
   readonly rooms: RoomsAPI;
+  readonly navNodes: NavNodesAPI;
+  readonly navEdges: NavEdgesAPI;
   /** Re-center the campus map on a new location (persisted on save). */
   setLocation(lng: number, lat: number, options?: { zoom?: number; pitch?: number; bearing?: number; fly?: boolean }): void;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,6 @@ export * from "./state";
 export * from "./utils";
 export * from "./services";
 export * from "./hooks";
+export * from "./routing";
 // Explicitly export logger for use by other packages
 export * from "./utils/logger";

--- a/packages/core/src/routing/find-path.ts
+++ b/packages/core/src/routing/find-path.ts
@@ -1,0 +1,297 @@
+/**
+ * A* shortest-path routing over a generic node/edge graph.
+ *
+ * Pure function. No React, no DOM, no domain types. Verticals provide
+ * their own per-node and per-edge metadata via the type parameters
+ * and feed filters/costs as plain callbacks.
+ *
+ * Cost defaults to great-circle (Haversine) distance between node
+ * positions in metres — appropriate when nodes carry `[lng, lat]`.
+ * Override `costFn` for non-geographic graphs or where edges need
+ * explicit costs (elevator dwell, stair penalties, route mode
+ * multipliers).
+ *
+ * Algorithm: A* with a binary-heap priority queue and Haversine
+ * heuristic. Runs in O((V + E) log V) and handles graphs into the
+ * tens of thousands of nodes comfortably. For typical campus
+ * graphs (hundreds of nodes) the running time is dominated by the
+ * graph build, not the search.
+ */
+
+export interface RouteNode<TMeta = unknown> {
+  id: string;
+  /**
+   * Node position. `[lng, lat]` for geographic graphs; any 2D point
+   * if `costFn` is overridden.
+   */
+  position: [number, number];
+  /**
+   * Vertical level for stacked graphs (floor index for indoor,
+   * elevation tier for terraced sites). The router doesn't read this
+   * directly — use `nodeFilter` to scope a search by floor — but
+   * it's a load-bearing shape on the node so verticals don't have
+   * to wrap their own.
+   */
+  level?: number | null;
+  /** Vertical-specific metadata, untouched by the router. */
+  meta?: TMeta;
+}
+
+export interface RouteEdge<TMeta = unknown> {
+  id: string;
+  fromNodeId: string;
+  toNodeId: string;
+  /**
+   * Explicit cost override (in the same units as `costFn`). Used
+   * for elevator/stair edges where the great-circle distance
+   * between endpoints is ~0 but the actual traversal isn't free.
+   */
+  cost?: number;
+  meta?: TMeta;
+}
+
+export interface RouteGraph<TNodeMeta = unknown, TEdgeMeta = unknown> {
+  nodes: RouteNode<TNodeMeta>[];
+  edges: RouteEdge<TEdgeMeta>[];
+}
+
+export type NodeFilter<TNodeMeta> = (
+  node: RouteNode<TNodeMeta>,
+) => boolean;
+
+export type EdgeFilter<TNodeMeta, TEdgeMeta> = (
+  edge: RouteEdge<TEdgeMeta>,
+  from: RouteNode<TNodeMeta>,
+  to: RouteNode<TNodeMeta>,
+) => boolean;
+
+export type CostFn<TNodeMeta, TEdgeMeta> = (
+  edge: RouteEdge<TEdgeMeta>,
+  from: RouteNode<TNodeMeta>,
+  to: RouteNode<TNodeMeta>,
+) => number;
+
+export interface FindPathOptions<TNodeMeta = unknown, TEdgeMeta = unknown> {
+  /** Drop a candidate node before it ever enters the frontier. */
+  nodeFilter?: NodeFilter<TNodeMeta>;
+  /** Drop a candidate edge — useful for the step-free filter. */
+  edgeFilter?: EdgeFilter<TNodeMeta, TEdgeMeta>;
+  /**
+   * Override the default cost (Haversine in metres + `edge.cost`).
+   * Returning a non-finite or negative number drops the edge.
+   */
+  costFn?: CostFn<TNodeMeta, TEdgeMeta>;
+}
+
+export interface RoutePath<TNodeMeta = unknown, TEdgeMeta = unknown> {
+  nodeIds: string[];
+  /** Ordered node objects from start to end. */
+  nodes: RouteNode<TNodeMeta>[];
+  /** Ordered edges traversed (length = nodes.length - 1). */
+  edges: RouteEdge<TEdgeMeta>[];
+  /** Sum of `costFn` over the traversed edges. */
+  cost: number;
+}
+
+/**
+ * Great-circle distance between two `[lng, lat]` points in metres.
+ * Exported so verticals can reuse the heuristic in their own custom
+ * `costFn`.
+ */
+export function haversineDistanceMeters(
+  a: [number, number],
+  b: [number, number],
+): number {
+  const R = 6_371_000; // Earth radius in metres.
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const lat1 = toRad(a[1]);
+  const lat2 = toRad(b[1]);
+  const dLat = lat2 - lat1;
+  const dLng = toRad(b[0] - a[0]);
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const h =
+    sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Find the lowest-cost path from `fromId` to `toId` over `graph`,
+ * optionally filtered and cost-overridden.
+ *
+ * Returns `null` if either endpoint is missing/filtered or the
+ * destination is unreachable under the filters.
+ */
+export function findPath<TNodeMeta = unknown, TEdgeMeta = unknown>(
+  graph: RouteGraph<TNodeMeta, TEdgeMeta>,
+  fromId: string,
+  toId: string,
+  opts: FindPathOptions<TNodeMeta, TEdgeMeta> = {},
+): RoutePath<TNodeMeta, TEdgeMeta> | null {
+  const { nodeFilter, edgeFilter, costFn } = opts;
+
+  // Index nodes by id and build per-node adjacency. Buckets are
+  // built fresh per call rather than cached on the graph so callers
+  // who mutate the graph object don't have to invalidate anything.
+  const nodeById = new Map<string, RouteNode<TNodeMeta>>();
+  for (const n of graph.nodes) {
+    if (nodeFilter && !nodeFilter(n)) continue;
+    nodeById.set(n.id, n);
+  }
+
+  const from = nodeById.get(fromId);
+  const to = nodeById.get(toId);
+  if (!from || !to) return null;
+
+  const adjacency = new Map<string, RouteEdge<TEdgeMeta>[]>();
+  for (const edge of graph.edges) {
+    const a = nodeById.get(edge.fromNodeId);
+    const b = nodeById.get(edge.toNodeId);
+    if (!a || !b) continue;
+    if (edgeFilter && !edgeFilter(edge, a, b)) continue;
+
+    // Graphs are undirected — walkable both ways. Append the edge
+    // twice (once per direction) so the search expands in either
+    // direction without special-casing.
+    let outA = adjacency.get(a.id);
+    if (!outA) {
+      outA = [];
+      adjacency.set(a.id, outA);
+    }
+    outA.push(edge);
+
+    let outB = adjacency.get(b.id);
+    if (!outB) {
+      outB = [];
+      adjacency.set(b.id, outB);
+    }
+    outB.push(edge);
+  }
+
+  const defaultCost: CostFn<TNodeMeta, TEdgeMeta> = (edge, a, b) => {
+    if (edge.cost != null) return edge.cost;
+    return haversineDistanceMeters(a.position, b.position);
+  };
+  const cost = costFn ?? defaultCost;
+
+  // A* heuristic — straight-line distance to the goal. Admissible
+  // for great-circle metres; verticals using a non-geo cost can
+  // pass `costFn` to keep monotonicity (the heuristic just becomes
+  // less informative, never wrong).
+  const heuristic = (n: RouteNode<TNodeMeta>) =>
+    haversineDistanceMeters(n.position, to.position);
+
+  // Min-heap keyed by f-score. Inline implementation — a few dozen
+  // lines avoids a runtime dependency and matches the rest of the
+  // routing module's "no deps" rule.
+  interface HeapEntry {
+    nodeId: string;
+    f: number;
+  }
+  const open: HeapEntry[] = [];
+  const openSet = new Set<string>();
+
+  const heapPush = (entry: HeapEntry) => {
+    open.push(entry);
+    let i = open.length - 1;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (open[parent].f <= open[i].f) break;
+      [open[parent], open[i]] = [open[i], open[parent]];
+      i = parent;
+    }
+  };
+  const heapPop = (): HeapEntry | undefined => {
+    if (open.length === 0) return undefined;
+    const top = open[0];
+    const last = open.pop()!;
+    if (open.length > 0) {
+      open[0] = last;
+      let i = 0;
+      const n = open.length;
+      for (;;) {
+        const l = i * 2 + 1;
+        const r = i * 2 + 2;
+        let smallest = i;
+        if (l < n && open[l].f < open[smallest].f) smallest = l;
+        if (r < n && open[r].f < open[smallest].f) smallest = r;
+        if (smallest === i) break;
+        [open[i], open[smallest]] = [open[smallest], open[i]];
+        i = smallest;
+      }
+    }
+    return top;
+  };
+
+  const gScore = new Map<string, number>();
+  const cameFrom = new Map<string, { nodeId: string; edge: RouteEdge<TEdgeMeta> }>();
+
+  gScore.set(from.id, 0);
+  heapPush({ nodeId: from.id, f: heuristic(from) });
+  openSet.add(from.id);
+
+  while (open.length > 0) {
+    const current = heapPop()!;
+    openSet.delete(current.nodeId);
+    if (current.nodeId === to.id) break;
+
+    const currentNode = nodeById.get(current.nodeId)!;
+    const currentG = gScore.get(current.nodeId) ?? Infinity;
+    const edges = adjacency.get(current.nodeId) ?? [];
+
+    for (const edge of edges) {
+      const neighbourId =
+        edge.fromNodeId === current.nodeId ? edge.toNodeId : edge.fromNodeId;
+      const neighbour = nodeById.get(neighbourId);
+      if (!neighbour) continue;
+
+      const c = cost(edge, currentNode, neighbour);
+      if (!Number.isFinite(c) || c < 0) continue;
+
+      const tentativeG = currentG + c;
+      const existingG = gScore.get(neighbourId);
+      if (existingG !== undefined && tentativeG >= existingG) continue;
+
+      gScore.set(neighbourId, tentativeG);
+      cameFrom.set(neighbourId, { nodeId: current.nodeId, edge });
+      const f = tentativeG + heuristic(neighbour);
+      if (!openSet.has(neighbourId)) {
+        heapPush({ nodeId: neighbourId, f });
+        openSet.add(neighbourId);
+      } else {
+        // Already on the open set — push the improved score. The
+        // node may sit in the heap with an outdated f; we accept
+        // the duplicate and let the older entry be discarded when
+        // popped (its gScore is stale). This is standard A*
+        // "lazy update" — simpler than decrease-key and equally
+        // correct because the visited check trims duplicates.
+        heapPush({ nodeId: neighbourId, f });
+      }
+    }
+  }
+
+  // Reconstruct.
+  if (!gScore.has(to.id)) return null;
+  const nodeIds: string[] = [];
+  const nodes: RouteNode<TNodeMeta>[] = [];
+  const edges: RouteEdge<TEdgeMeta>[] = [];
+
+  let cursor: string | null = to.id;
+  while (cursor) {
+    const node = nodeById.get(cursor);
+    if (!node) return null;
+    nodeIds.unshift(cursor);
+    nodes.unshift(node);
+    const link = cameFrom.get(cursor);
+    if (!link) break;
+    edges.unshift(link.edge);
+    cursor = link.nodeId;
+  }
+
+  return {
+    nodeIds,
+    nodes,
+    edges,
+    cost: gScore.get(to.id) ?? 0,
+  };
+}

--- a/packages/core/src/routing/index.ts
+++ b/packages/core/src/routing/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Generic graph routing — pure functions, no React, no DOM, no
+ * domain dependencies. The wayfinding engine for every Klorad
+ * vertical: campus indoor/outdoor walking, mobility transit
+ * connections, heritage site paths.
+ *
+ * The router doesn't know what a "room" or a "stair" is — verticals
+ * carry domain meaning in the per-node and per-edge `meta` slot, and
+ * filter via `nodeFilter` / `edgeFilter`. Costs default to
+ * great-circle distance between node positions (in metres);
+ * verticals override per-edge for elevator dwell, stair penalties,
+ * or non-geographic graphs.
+ */
+
+import { findPath, haversineDistanceMeters } from "./find-path";
+
+export {
+  findPath,
+  haversineDistanceMeters,
+};
+
+export type {
+  RouteNode,
+  RouteEdge,
+  RouteGraph,
+  RoutePath,
+  FindPathOptions,
+  CostFn,
+  EdgeFilter,
+  NodeFilter,
+} from "./find-path";

--- a/packages/core/src/types/mapbox-scene.ts
+++ b/packages/core/src/types/mapbox-scene.ts
@@ -48,6 +48,74 @@ export interface MapboxRoom {
   searchKeywords?: string[];
 }
 
+/**
+ * A waypoint in the building / outdoor walking graph.
+ *
+ *   - `corridor` — intermediate point along a hallway
+ *   - `door-external` — a building entrance: connects an outdoor walk
+ *     segment to an indoor corridor on a specific floor
+ *   - `door-internal` — a door between two indoor spaces on the same
+ *     floor (e.g. corridor ↔ classroom)
+ *   - `elevator` — vertical-transit waypoint. Two elevator nodes on
+ *     different floors at the same lng/lat connected by an edge form
+ *     a single elevator shaft.
+ *   - `stair` — vertical-transit waypoint that excludes step-free routing.
+ *   - `room-anchor` — marks "navigation enters Room X here". Used so a
+ *     route to a room doesn't terminate at the room's centroid (which
+ *     may be inside furniture) but at its actual entry point.
+ *   - `outdoor` — free outdoor waypoint, e.g. a path junction between
+ *     buildings or at a campus gate.
+ */
+export type MapboxNavNodeType =
+  | "corridor"
+  | "door-external"
+  | "door-internal"
+  | "elevator"
+  | "stair"
+  | "room-anchor"
+  | "outdoor";
+
+export interface MapboxNavNode {
+  id: string;
+  type: MapboxNavNodeType;
+  /** [lng, lat]. */
+  position: MapboxLngLat;
+  /** Floor for indoor nodes; null/undefined for outdoor. */
+  floor?: number | null;
+  /** Building POI id for indoor nodes. Omit for outdoor. */
+  buildingId?: string;
+  /** Room id for type=`room-anchor`. */
+  roomId?: string;
+  /**
+   * Step-free? Defaults to true for everything except `stair`. Used
+   * by the wayfinding engine when the user toggles accessibility mode
+   * — non-accessible nodes (and edges that touch them) are excluded.
+   */
+  accessible?: boolean;
+  /** Optional human label — surfaced in the editor and search. */
+  name?: string;
+}
+
+export interface MapboxNavEdge {
+  id: string;
+  fromNodeId: string;
+  toNodeId: string;
+  /**
+   * Override the auto-computed walking cost (in metres). Useful for
+   * elevators (~3 m per floor + dwell) and stairs (~6 m per floor)
+   * where the great-circle distance between the two nodes is 0.
+   */
+  cost?: number;
+  /**
+   * Step-free? Defaults to (fromNode.accessible && toNode.accessible).
+   * Override to mark a corridor "no wheelchair" without changing the
+   * node types.
+   */
+  accessible?: boolean;
+  /** Optional human label ("Stair B", "Elevator 2"). */
+  name?: string;
+}
+
 /** Georeferenced floor plan / overlay (Mapbox image source). */
 export interface MapboxFloorPlanRaster {
   id: string;
@@ -116,6 +184,14 @@ export interface MapboxSceneData {
   layers: MapboxSceneLayer[];
   floorPlanRasters?: MapboxFloorPlanRaster[];
   rooms?: MapboxRoom[];
+  /**
+   * Walking-graph waypoints used by the wayfinding engine — corridor
+   * intersections, doors, elevator/stair landings, room anchors,
+   * outdoor path junctions.
+   */
+  navNodes?: MapboxNavNode[];
+  /** Edges between {@link navNodes} forming the wayfinding graph. */
+  navEdges?: MapboxNavEdge[];
 
   projection?: MapboxProjection;
   terrain?: MapboxTerrainSettings;
@@ -133,6 +209,8 @@ export const DEFAULT_MAPBOX_SCENE_DATA: MapboxSceneData = {
   layers: [],
   floorPlanRasters: [],
   rooms: [],
+  navNodes: [],
+  navEdges: [],
   projection: "mercator",
   terrain: {
     enabled: false,

--- a/packages/design-system/src/components/wayfinding-panel.tsx
+++ b/packages/design-system/src/components/wayfinding-panel.tsx
@@ -1,0 +1,284 @@
+import type { ComponentProps, ComponentType, ReactNode } from "react";
+import { cn } from "../utils/cn";
+
+/**
+ * A waypoint shown in the wayfinding card. Verticals pass whatever
+ * shape they like — a campus room, a transit stop, a heritage site
+ * waypoint — as long as it resolves to a `label` and optional icon.
+ *
+ * Picking happens upstream of the panel (search drawer, map click,
+ * "current location"). The panel only renders the current selection
+ * and emits callbacks when the user wants to edit/swap/clear.
+ */
+export interface WayfindingPoint {
+  label: string;
+  sublabel?: string;
+  icon?: ComponentType<{ className?: string }>;
+}
+
+export interface WayfindingSummary {
+  /** Total walking distance in metres. */
+  distanceM: number;
+  /** Total estimated duration in seconds. */
+  durationS: number;
+  /** Number of distinct floors traversed (1 if no level change). */
+  floorsTouched: number;
+}
+
+export interface WayfindingPanelProps extends Omit<ComponentProps<"div">, "onSubmit"> {
+  from: WayfindingPoint | null;
+  to: WayfindingPoint | null;
+  /** Step-free mode toggle. */
+  stepFree: boolean;
+  onStepFreeChange: (value: boolean) => void;
+  /** Click "From" pill → edit (open search drawer, etc.). */
+  onEditFrom?: () => void;
+  /** Click "To" pill → edit. */
+  onEditTo?: () => void;
+  /** Swap the two endpoints. */
+  onSwap?: () => void;
+  /**
+   * The action CTA — typically "Get directions" before a route is
+   * computed, "Start navigation" after.
+   */
+  onAction?: () => void;
+  /** Action button label. Defaults: route ? "Start" : "Get directions". */
+  actionLabel?: string;
+  /** Disable the action button (e.g. while routing in-flight). */
+  actionDisabled?: boolean;
+  /** Summary card shown once the route is computed. */
+  summary?: WayfindingSummary | null;
+  /** Optional inline error (no route found, step-free blocked, etc.). */
+  error?: string | null;
+  /** Extra content (e.g. floor-by-floor breakdown) below the summary. */
+  children?: ReactNode;
+}
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${Math.round(meters)} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return "< 1 min";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const rem = minutes % 60;
+  return rem === 0 ? `${hours} h` : `${hours} h ${rem} min`;
+}
+
+/**
+ * The wayfinding control panel — two endpoint pills, a swap button,
+ * a step-free toggle, an action CTA, and (when computed) a summary
+ * card.
+ *
+ * Visual language: glass + accent, matches the rest of the Klorad
+ * DS. Reusable across every vertical that does wayfinding because
+ * nothing here is campus-specific.
+ */
+export function WayfindingPanel({
+  from,
+  to,
+  stepFree,
+  onStepFreeChange,
+  onEditFrom,
+  onEditTo,
+  onSwap,
+  onAction,
+  actionLabel,
+  actionDisabled,
+  summary,
+  error,
+  children,
+  className,
+  ...props
+}: WayfindingPanelProps) {
+  const computedLabel =
+    actionLabel ?? (summary ? "Start navigation" : "Get directions");
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-2xl border border-line-soft bg-surface-1/95 p-4 shadow-glass backdrop-blur",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex items-stretch gap-2">
+        <div className="flex flex-1 flex-col gap-1">
+          <PointPill
+            point={from}
+            placeholder="Choose start"
+            onClick={onEditFrom}
+            kind="from"
+          />
+          <PointPill
+            point={to}
+            placeholder="Choose destination"
+            onClick={onEditTo}
+            kind="to"
+          />
+        </div>
+        {onSwap ? (
+          <button
+            type="button"
+            onClick={onSwap}
+            aria-label="Swap start and destination"
+            className="grid h-8 w-8 self-center place-items-center rounded-full border border-line-soft bg-bg text-text-secondary transition-colors hover:bg-accent-soft hover:text-accent"
+          >
+            <SwapIcon className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+
+      <label className="flex items-center gap-2 text-xs text-text-secondary">
+        <input
+          type="checkbox"
+          checked={stepFree}
+          onChange={(e) => onStepFreeChange(e.target.checked)}
+          className="h-3.5 w-3.5 rounded border-line-soft accent-accent"
+        />
+        Step-free route only
+      </label>
+
+      {error ? (
+        <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300">
+          {error}
+        </p>
+      ) : null}
+
+      {summary ? (
+        <div className="flex items-center justify-between rounded-xl bg-accent-soft px-3 py-2 text-xs text-text-primary">
+          <span className="font-medium text-accent">
+            {formatDuration(summary.durationS)}
+          </span>
+          <span>·</span>
+          <span>{formatDistance(summary.distanceM)}</span>
+          <span>·</span>
+          <span>
+            {summary.floorsTouched} {summary.floorsTouched === 1 ? "floor" : "floors"}
+          </span>
+        </div>
+      ) : null}
+
+      {children}
+
+      <button
+        type="button"
+        onClick={onAction}
+        disabled={actionDisabled || !from || !to}
+        className={cn(
+          "rounded-full px-4 py-2 text-sm font-medium transition-colors",
+          actionDisabled || !from || !to
+            ? "bg-surface-2 text-text-tertiary"
+            : "bg-accent text-accent-contrast hover:bg-accent-hover",
+        )}
+      >
+        {computedLabel}
+      </button>
+    </div>
+  );
+}
+
+function PointPill({
+  point,
+  placeholder,
+  onClick,
+  kind,
+}: {
+  point: WayfindingPoint | null;
+  placeholder: string;
+  onClick?: () => void;
+  kind: "from" | "to";
+}) {
+  const Icon = point?.icon;
+  const disabled = !onClick;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "group flex w-full items-center gap-2 rounded-xl border border-line-soft bg-bg px-3 py-2 text-left transition-colors",
+        disabled ? "cursor-default" : "hover:bg-accent-soft",
+      )}
+    >
+      <span
+        className={cn(
+          "grid h-6 w-6 shrink-0 place-items-center rounded-full",
+          kind === "from"
+            ? "border border-line-soft bg-surface-2 text-text-tertiary"
+            : "bg-accent text-accent-contrast",
+        )}
+      >
+        {Icon ? (
+          <Icon className="h-3 w-3" />
+        ) : kind === "from" ? (
+          <CircleIcon className="h-2.5 w-2.5" />
+        ) : (
+          <PinIcon className="h-3 w-3" />
+        )}
+      </span>
+      <span className="min-w-0 flex-1">
+        {point ? (
+          <>
+            <span className="block truncate text-sm text-text-primary">
+              {point.label}
+            </span>
+            {point.sublabel ? (
+              <span className="block truncate text-[0.65rem] text-text-tertiary">
+                {point.sublabel}
+              </span>
+            ) : null}
+          </>
+        ) : (
+          <span className="block truncate text-sm text-text-tertiary">
+            {placeholder}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+function SwapIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M16 3l4 4-4 4" />
+      <path d="M20 7H4" />
+      <path d="M8 21l-4-4 4-4" />
+      <path d="M4 17h16" />
+    </svg>
+  );
+}
+
+function CircleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 10 10" fill="currentColor" aria-hidden>
+      <circle cx="5" cy="5" r="4" />
+    </svg>
+  );
+}
+
+function PinIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 2C8 2 5 5 5 9c0 5.5 7 13 7 13s7-7.5 7-13c0-4-3-7-7-7zm0 9.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" />
+    </svg>
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -38,6 +38,12 @@ export {
   defaultFloorLabel,
   type FloorSwitcherProps,
 } from "./components/floor-switcher";
+export {
+  WayfindingPanel,
+  type WayfindingPanelProps,
+  type WayfindingPoint,
+  type WayfindingSummary,
+} from "./components/wayfinding-panel";
 export { Select, type SelectProps } from "./components/select";
 export { Modal, type ModalProps } from "./components/modal";
 export {

--- a/packages/engine-mapbox/src/hooks/index.ts
+++ b/packages/engine-mapbox/src/hooks/index.ts
@@ -8,3 +8,9 @@ export {
   type IndoorExtrusionPaint,
   type UseMapboxIndoorExtrusionOptions,
 } from "./useMapboxIndoorExtrusion";
+export {
+  useMapboxRouteLayer,
+  type IndoorRouteSegment,
+  type RouteLayerPaint,
+  type UseMapboxRouteLayerOptions,
+} from "./useMapboxRouteLayer";

--- a/packages/engine-mapbox/src/hooks/useMapboxRouteLayer.ts
+++ b/packages/engine-mapbox/src/hooks/useMapboxRouteLayer.ts
@@ -1,0 +1,311 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Map as MapboxMap, GeoJSONSource } from "mapbox-gl";
+import { useSceneStore } from "@klorad/core";
+
+/**
+ * One indoor segment of a stitched route. The route may cross
+ * floors, so it's modelled as an array of segments — each segment
+ * sits on a single level and the renderer joins them visually
+ * (vertical-transit edges connect adjacent segments).
+ */
+export interface IndoorRouteSegment {
+  coordinates: [number, number][];
+  level: number;
+}
+
+export interface RouteLayerPaint {
+  /** Color of the outdoor polyline. Defaults to the brand accent. */
+  outdoorColor?: string;
+  /** Color of the indoor route. Defaults to a lighter accent tint. */
+  indoorColor?: string;
+  /** Line width in px. Defaults to 6. */
+  width?: number;
+  /** Dasharray for the indoor segment. Defaults to a 1/2 ratio. */
+  indoorDasharray?: [number, number];
+  /** Color of the start/end markers. Defaults to the brand accent. */
+  markerColor?: string;
+  /** Marker radius in px. Defaults to 7. */
+  markerRadius?: number;
+}
+
+export interface UseMapboxRouteLayerOptions {
+  /**
+   * Namespace for source + layer ids. Pass a vertical-specific
+   * prefix like `"campus-wayfinding"` so two route renderers (e.g.
+   * a preview + a confirmed selection) can coexist.
+   */
+  namespace: string;
+  /** Outdoor polyline (Mapbox Directions output, or fallback line). */
+  outdoor?: [number, number][] | null;
+  /** Indoor segments, one per floor traversed. */
+  indoor?: IndoorRouteSegment[] | null;
+  /** Optional start marker. */
+  start?: [number, number] | null;
+  /** Optional end marker. */
+  end?: [number, number] | null;
+  paint?: RouteLayerPaint;
+}
+
+interface FeatureCollections {
+  outdoor: GeoJSON.FeatureCollection;
+  indoor: GeoJSON.FeatureCollection;
+  markers: GeoJSON.FeatureCollection;
+}
+
+function buildCollections(
+  outdoor: [number, number][] | null | undefined,
+  indoor: IndoorRouteSegment[] | null | undefined,
+  start: [number, number] | null | undefined,
+  end: [number, number] | null | undefined,
+): FeatureCollections {
+  const outdoorFC: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: outdoor && outdoor.length >= 2
+      ? [
+          {
+            type: "Feature",
+            geometry: { type: "LineString", coordinates: outdoor },
+            properties: {},
+          },
+        ]
+      : [],
+  };
+
+  const indoorFC: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: (indoor ?? [])
+      .filter((seg) => seg.coordinates.length >= 2)
+      .map((seg) => ({
+        type: "Feature",
+        geometry: { type: "LineString", coordinates: seg.coordinates },
+        properties: { level: seg.level },
+      })),
+  };
+
+  const markerFeatures: GeoJSON.Feature[] = [];
+  if (start) {
+    markerFeatures.push({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: start },
+      properties: { kind: "start" },
+    });
+  }
+  if (end) {
+    markerFeatures.push({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: end },
+      properties: { kind: "end" },
+    });
+  }
+  const markersFC: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: markerFeatures,
+  };
+
+  return { outdoor: outdoorFC, indoor: indoorFC, markers: markersFC };
+}
+
+/**
+ * Render a stitched wayfinding route onto the map — outdoor segment
+ * as a solid line, indoor segments as dashed lines, plus start/end
+ * markers. The hook installs once per namespace and updates the
+ * three feature collections in place; idempotent across style swaps
+ * (re-installs on `style.load`, `styledata`, `idle`).
+ *
+ * Verticals reuse the same primitive: campus walking, mobility
+ * transit, heritage trails. The `namespace` keeps multiple instances
+ * isolated on the same map.
+ */
+export function useMapboxRouteLayer(opts: UseMapboxRouteLayerOptions) {
+  const map = useSceneStore((s) => s.mapboxMap as MapboxMap | null);
+  const { namespace, outdoor, indoor, start, end, paint } = opts;
+
+  const outdoorSourceId = `${namespace}-outdoor-source`;
+  const indoorSourceId = `${namespace}-indoor-source`;
+  const markerSourceId = `${namespace}-markers-source`;
+  const outdoorLineId = `${namespace}-outdoor-line`;
+  const outdoorCasingId = `${namespace}-outdoor-casing`;
+  const indoorLineId = `${namespace}-indoor-line`;
+  const markerLayerId = `${namespace}-markers`;
+
+  const outdoorColor = paint?.outdoorColor ?? "#158ca3";
+  const indoorColor = paint?.indoorColor ?? "#5dbcd0";
+  const width = paint?.width ?? 6;
+  const indoorDasharray = paint?.indoorDasharray ?? [1, 2];
+  const markerColor = paint?.markerColor ?? "#158ca3";
+  const markerRadius = paint?.markerRadius ?? 7;
+
+  // Refs for the install effect to read the latest paint config
+  // without re-installing on every paint tweak.
+  const paintRef = useRef({
+    outdoorColor,
+    indoorColor,
+    width,
+    indoorDasharray,
+    markerColor,
+    markerRadius,
+  });
+  paintRef.current = {
+    outdoorColor,
+    indoorColor,
+    width,
+    indoorDasharray,
+    markerColor,
+    markerRadius,
+  };
+
+  // ─── install ─────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!map) return;
+
+    const install = () => {
+      const p = paintRef.current;
+      try {
+        if (!map.getSource(outdoorSourceId)) {
+          map.addSource(outdoorSourceId, {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          });
+        }
+        if (!map.getSource(indoorSourceId)) {
+          map.addSource(indoorSourceId, {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          });
+        }
+        if (!map.getSource(markerSourceId)) {
+          map.addSource(markerSourceId, {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          });
+        }
+      } catch {
+        return;
+      }
+
+      // Casing → outdoor → indoor (dashed) → markers, in that paint
+      // order so the route reads cleanly even where it crosses
+      // labels and basemap chrome.
+      if (!map.getLayer(outdoorCasingId)) {
+        map.addLayer({
+          id: outdoorCasingId,
+          type: "line",
+          source: outdoorSourceId,
+          paint: {
+            "line-color": "rgba(255,255,255,0.9)",
+            "line-width": p.width + 3,
+            "line-opacity": 0.85,
+          },
+          layout: { "line-cap": "round", "line-join": "round" },
+        });
+      }
+      if (!map.getLayer(outdoorLineId)) {
+        map.addLayer({
+          id: outdoorLineId,
+          type: "line",
+          source: outdoorSourceId,
+          paint: {
+            "line-color": p.outdoorColor,
+            "line-width": p.width,
+          },
+          layout: { "line-cap": "round", "line-join": "round" },
+        });
+      }
+      if (!map.getLayer(indoorLineId)) {
+        map.addLayer({
+          id: indoorLineId,
+          type: "line",
+          source: indoorSourceId,
+          paint: {
+            "line-color": p.indoorColor,
+            "line-width": p.width,
+            "line-dasharray": p.indoorDasharray,
+          },
+          layout: { "line-cap": "round", "line-join": "round" },
+        });
+      }
+      if (!map.getLayer(markerLayerId)) {
+        map.addLayer({
+          id: markerLayerId,
+          type: "circle",
+          source: markerSourceId,
+          paint: {
+            "circle-color": p.markerColor,
+            "circle-radius": p.markerRadius,
+            "circle-stroke-color": "#ffffff",
+            "circle-stroke-width": 3,
+          },
+        });
+      }
+    };
+
+    install();
+    const onStyleLoad = () => install();
+    const onStyleData = () => install();
+    const onIdle = () => install();
+    map.on("style.load", onStyleLoad);
+    map.on("styledata", onStyleData);
+    map.on("idle", onIdle);
+
+    return () => {
+      map.off("style.load", onStyleLoad);
+      map.off("styledata", onStyleData);
+      map.off("idle", onIdle);
+      try {
+        for (const id of [
+          markerLayerId,
+          indoorLineId,
+          outdoorLineId,
+          outdoorCasingId,
+        ]) {
+          if (map.getLayer(id)) map.removeLayer(id);
+        }
+        for (const id of [outdoorSourceId, indoorSourceId, markerSourceId]) {
+          if (map.getSource(id)) map.removeSource(id);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+  }, [
+    map,
+    outdoorSourceId,
+    indoorSourceId,
+    markerSourceId,
+    outdoorCasingId,
+    outdoorLineId,
+    indoorLineId,
+    markerLayerId,
+  ]);
+
+  // ─── data ────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!map) return;
+    const fc = buildCollections(outdoor, indoor, start, end);
+    const apply = () => {
+      const o = map.getSource(outdoorSourceId) as GeoJSONSource | undefined;
+      const i = map.getSource(indoorSourceId) as GeoJSONSource | undefined;
+      const m = map.getSource(markerSourceId) as GeoJSONSource | undefined;
+      if (o) o.setData(fc.outdoor);
+      if (i) i.setData(fc.indoor);
+      if (m) m.setData(fc.markers);
+    };
+    apply();
+    const onStyleData = () => apply();
+    map.on("styledata", onStyleData);
+    return () => {
+      map.off("styledata", onStyleData);
+    };
+  }, [
+    map,
+    outdoor,
+    indoor,
+    start,
+    end,
+    outdoorSourceId,
+    indoorSourceId,
+    markerSourceId,
+  ]);
+}

--- a/packages/engine-mapbox/src/index.ts
+++ b/packages/engine-mapbox/src/index.ts
@@ -3,3 +3,4 @@ export { MapboxViewerContent } from "./MapboxViewerContent";
 export * from "./helpers";
 export * from "./utils";
 export * from "./hooks";
+export * from "./services";

--- a/packages/engine-mapbox/src/services/index.ts
+++ b/packages/engine-mapbox/src/services/index.ts
@@ -1,0 +1,6 @@
+export {
+  fetchMapboxDirections,
+  type FetchMapboxDirectionsOptions,
+  type MapboxDirectionsProfile,
+  type MapboxDirectionsResult,
+} from "./mapbox-directions";

--- a/packages/engine-mapbox/src/services/mapbox-directions.ts
+++ b/packages/engine-mapbox/src/services/mapbox-directions.ts
@@ -1,0 +1,97 @@
+/**
+ * Thin wrapper around the Mapbox Directions API
+ * (https://docs.mapbox.com/api/navigation/directions/).
+ *
+ * Returns a walking-mode polyline between two `[lng, lat]` points.
+ * The wayfinding stitcher uses this for outdoor segments before
+ * handing off to the building's indoor A* graph at the nearest
+ * entrance node.
+ *
+ * Provider-agnostic shape: verticals that swap Mapbox for another
+ * directions provider only need to match the `MapboxDirectionsResult`
+ * return shape — the consumers care about `coordinates`,
+ * `distanceM`, and `durationS`.
+ */
+
+export type MapboxDirectionsProfile =
+  | "walking"
+  | "cycling"
+  | "driving"
+  | "driving-traffic";
+
+export interface MapboxDirectionsResult {
+  /** Ordered `[lng, lat]` polyline. */
+  coordinates: [number, number][];
+  /** Total distance in metres. */
+  distanceM: number;
+  /** Estimated duration in seconds. */
+  durationS: number;
+}
+
+export interface FetchMapboxDirectionsOptions {
+  from: [number, number];
+  to: [number, number];
+  /** Defaults to `"walking"`. */
+  profile?: MapboxDirectionsProfile;
+  /** Provide one explicitly, else falls back to `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`. */
+  accessToken?: string;
+  /** Pass an AbortSignal so callers can cancel in-flight requests. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Fetch a walking (or other) route between two coordinates.
+ *
+ * Returns `null` when the API responds without a route — both
+ * "outside the routable network" and a network failure return
+ * `null` so consumers can fall back gracefully without try/catch
+ * sprinkled across the call sites. Real errors (missing token,
+ * abort) are still thrown.
+ */
+export async function fetchMapboxDirections(
+  opts: FetchMapboxDirectionsOptions,
+): Promise<MapboxDirectionsResult | null> {
+  const profile = opts.profile ?? "walking";
+  const token =
+    opts.accessToken ??
+    (typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+      : undefined);
+  if (!token) {
+    throw new Error(
+      "fetchMapboxDirections: no access token (pass `accessToken` or set NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN)",
+    );
+  }
+
+  const [fromLng, fromLat] = opts.from;
+  const [toLng, toLat] = opts.to;
+  const url =
+    `https://api.mapbox.com/directions/v5/mapbox/${profile}/` +
+    `${fromLng},${fromLat};${toLng},${toLat}` +
+    `?geometries=geojson&overview=full&access_token=${token}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, { signal: opts.signal });
+  } catch (err) {
+    if ((err as { name?: string })?.name === "AbortError") throw err;
+    return null;
+  }
+  if (!res.ok) return null;
+
+  const data = (await res.json()) as {
+    routes?: Array<{
+      geometry?: { coordinates?: [number, number][] };
+      distance?: number;
+      duration?: number;
+    }>;
+  };
+  const route = data.routes?.[0];
+  if (!route?.geometry?.coordinates?.length) return null;
+
+  return {
+    coordinates: route.geometry.coordinates,
+    distanceM: route.distance ?? 0,
+    durationS: route.duration ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2 of the campus master plan: the **infrastructure** for accessible wayfinding (outdoor + indoor). This PR ships the data model, routing engine, and rendering/UI primitives — all as reusable primitives in shared packages so future verticals (Mobility, Heritage, Urban) reuse them by configuration.

Public-viewer integration and editor authoring tools are **deliberately deferred** (see below).

## What's in here (4 commits)

1. **`feat(api+campus)`: wayfinding graph data model (NavNode + NavEdge)**
   - `MapboxNavNode` / `MapboxNavEdge` added to `MapboxSceneData` — no Prisma migration, the graph lives in the existing `sceneData` JSON column alongside rooms and floor plans.
   - `NavNodesAPI` / `NavEdgesAPI` on `CampusAPI` (add/update/remove/query). Node `accessible` defaults `true` except `stair`.
   - Workbench entities (`campus.nav-node`, `campus.nav-edge`), entity-index projection, `WorkbenchClient` wiring, config registration.

2. **`feat(core+campus)`: A* graph routing engine + campus adapter**
   - `findPath()` in `@klorad/core/routing` — domain-agnostic A* (inline binary heap, Haversine heuristic, `nodeFilter`/`edgeFilter`/`costFn` hooks).
   - `apps/campus/lib/wayfinding/find-campus-path.ts` — builds a `RouteGraph` from nav data and applies the campus step-free rule (drop `stair` nodes + `accessible:false` edges).

3. **`feat(engine-mapbox+campus)`: stitched outdoor + indoor wayfinding**
   - `fetchMapboxDirections()` service in `@klorad/engine-mapbox`.
   - `findStitchedRoute()` — joins the outdoor Mapbox walking leg to the indoor A* leg at the nearest external door; great-circle fallback when Directions is unavailable. Returns distance/duration/floors-touched.

4. **`feat(engine-mapbox+ds)`: route layer hook + WayfindingPanel primitive**
   - `useMapboxRouteLayer()` — renders the stitched route (solid outdoor line + casing, dashed indoor segments, start/end markers); idempotent across style swaps, namespaced for multiple instances.
   - `WayfindingPanel` DS primitive — endpoint pills, swap, step-free toggle, action CTA, summary card. Generic `WayfindingPoint` / `WayfindingSummary`, nothing campus-specific.

## Deferred to a follow-up PR

- **Public-viewer integration.** The public viewer already has legacy outdoor-only wayfinding (`useMapboxRoute`, a campus-specific `WayfindingPanel.tsx`, `routeMode: "walk"|"a11y"`). Wiring the new stitched routing in cleanly means rewriting that flow end-to-end rather than landing a conflicting double-line render — better as its own focused arc.
- **Editor authoring tools** for the nav graph (`nav.add-node`, `nav.connect`, `nav.delete-node`, `nav.delete-edge` operations + a nav-mode graph view in the workbench).

## Testing

`tsc --noEmit` passes across the touched packages and the campus app. Routing smoke-tested: A→B→C→D (333 m) is chosen over a 999 m shortcut, and the path falls back to 999 m when B is filtered out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)