### PR TITLE
feat(campus): public campus page — home, news & events

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
@@ -15,6 +15,7 @@ import {
   cn,
 } from "@klorad/design-system";
 import OverviewTab from "./tabs/OverviewTab";
+import NewsTab from "./tabs/NewsTab";
 import IndoorTab from "./tabs/IndoorTab";
 import SettingsTab from "./tabs/SettingsTab";
 import IntegrationsTab from "./tabs/IntegrationsTab";
@@ -36,9 +37,10 @@ interface CampusMap {
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-type TabKey = "overview" | "indoor" | "settings" | "integrations";
+type TabKey = "overview" | "news" | "indoor" | "settings" | "integrations";
 const TABS: { key: TabKey; label: string }[] = [
   { key: "overview", label: "Overview" },
+  { key: "news", label: "News" },
   { key: "indoor", label: "Indoor" },
   { key: "settings", label: "Settings" },
   { key: "integrations", label: "Integrations" },
@@ -135,6 +137,7 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
         {activeTab === "overview" && (
           <OverviewTab orgId={orgId} mapId={mapId} map={map} />
         )}
+        {activeTab === "news" && <NewsTab mapId={mapId} />}
         {activeTab === "indoor" && (
           <IndoorTab map={map} onConfigure={() => setTab("settings")} />
         )}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
@@ -144,7 +144,7 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
         {activeTab === "settings" && (
           <SettingsTab orgId={orgId} mapId={mapId} map={map} />
         )}
-        {activeTab === "integrations" && <IntegrationsTab />}
+        {activeTab === "integrations" && <IntegrationsTab mapId={mapId} />}
       </div>
     </div>
   );

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IntegrationsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IntegrationsTab.tsx
@@ -1,28 +1,38 @@
 "use client";
 
+import { useState } from "react";
 import type { ReactNode } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "react-toastify";
 import EventIcon from "@mui/icons-material/Event";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
-import RssFeedIcon from "@mui/icons-material/RssFeed";
 import FacebookIcon from "@mui/icons-material/Facebook";
-import { Badge, Button, Panel } from "@klorad/design-system";
+import { Badge, Button, Field, Input, Panel } from "@klorad/design-system";
+import { readEventFeeds } from "@/lib/events";
 
-interface Integration {
+interface Props {
+  mapId: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+interface ServerMap {
+  sceneData?: Record<string, unknown> & { eventFeeds?: string[] };
+}
+
+/** Integrations that aren't built yet — shown as informational cards. */
+const COMING_SOON: {
   id: string;
   name: string;
   description: string;
   icon: ReactNode;
-  status: "available" | "deferred";
-}
-
-const INTEGRATIONS: Integration[] = [
+}[] = [
   {
     id: "google",
     name: "Google Calendar",
     description:
-      "Sync events from any Google Calendar. Attach calendars to POIs so events appear at the right building.",
+      "One-click sync from a Google Calendar — no public ICS URL needed. Coming in a later phase.",
     icon: <CalendarMonthIcon />,
-    status: "available",
   },
   {
     id: "outlook",
@@ -30,55 +40,167 @@ const INTEGRATIONS: Integration[] = [
     description:
       "Pull events from your institution's Exchange or Microsoft 365 tenant.",
     icon: <EventIcon />,
-    status: "available",
-  },
-  {
-    id: "ics",
-    name: "ICS feeds",
-    description:
-      "Subscribe to any public ICS URL. Universal fallback for calendars that don't expose a formal API.",
-    icon: <RssFeedIcon />,
-    status: "available",
   },
   {
     id: "facebook",
     name: "Facebook Events",
     description:
-      "Surface your page's public events on the map. Coming in a later phase.",
+      "Meta restricts public event access — likely manual entry rather than a feed.",
     icon: <FacebookIcon />,
-    status: "deferred",
   },
 ];
 
-export default function IntegrationsTab() {
+/**
+ * Integrations tab — event feeds.
+ *
+ * ICS feeds are live: paste a public calendar URL and its events
+ * appear on the campus's public home page (fetched + parsed server-
+ * side). Feed URLs are stored in `sceneData.eventFeeds`. The other
+ * providers are informational cards until built.
+ */
+export default function IntegrationsTab({ mapId }: Props) {
+  const { data: serverMap } = useSWR<ServerMap>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
+  const feeds = readEventFeeds(serverMap?.sceneData);
+
+  const [url, setUrl] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const persist = async (nextFeeds: string[]) => {
+    const nextSceneData = {
+      ...(serverMap?.sceneData ?? {}),
+      eventFeeds: nextFeeds,
+    };
+    const res = await fetch(`/api/maps/${mapId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sceneData: nextSceneData }),
+    });
+    if (!res.ok) throw new Error("Save failed");
+    await mutate(`/api/maps/${mapId}`);
+  };
+
+  const handleAdd = async () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    if (!/^https?:\/\//i.test(trimmed)) {
+      toast.error("Enter a full URL starting with http(s)://");
+      return;
+    }
+    if (feeds.includes(trimmed)) {
+      toast.error("That feed is already added");
+      return;
+    }
+    setSaving(true);
+    try {
+      await persist([...feeds, trimmed]);
+      setUrl("");
+      toast.success("Feed added");
+    } catch {
+      toast.error("Could not add the feed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemove = async (feed: string) => {
+    setSaving(true);
+    try {
+      await persist(feeds.filter((f) => f !== feed));
+      toast.success("Feed removed");
+    } catch {
+      toast.error("Could not remove the feed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <div className="space-y-4 pt-6">
-      <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
-        Event feeds
-      </h2>
-      <div className="space-y-3">
-        {INTEGRATIONS.map((int) => (
-          <Panel key={int.id} className="flex items-center gap-4 rounded-2xl p-4">
-            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
-              {int.icon}
+    <div className="space-y-8 pt-6">
+      <section className="space-y-3">
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          ICS calendar feeds
+        </h2>
+        <Panel className="space-y-4 rounded-2xl p-6">
+          <p className="text-sm text-text-secondary">
+            Subscribe to any public ICS calendar URL — its upcoming events
+            appear on this campus&apos;s public home page automatically.
+          </p>
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="min-w-[240px] flex-1">
+              <Field label="ICS feed URL">
+                <Input
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="https://…/calendar.ics"
+                />
+              </Field>
             </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-text-primary">
-                  {int.name}
-                </span>
-                {int.status === "deferred" && <Badge>Later</Badge>}
-              </div>
-              <p className="mt-0.5 text-sm text-text-secondary">
-                {int.description}
-              </p>
-            </div>
-            <Button variant="secondary" size="sm" disabled className="shrink-0">
-              {int.status === "deferred" ? "Not yet" : "Connect"}
+            <Button
+              size="sm"
+              onClick={handleAdd}
+              disabled={saving || !url.trim()}
+            >
+              Add feed
             </Button>
-          </Panel>
-        ))}
-      </div>
+          </div>
+          {feeds.length > 0 ? (
+            <ul className="space-y-1.5">
+              {feeds.map((feed) => (
+                <li
+                  key={feed}
+                  className="flex items-center gap-3 rounded-xl bg-surface-2 px-3 py-2"
+                >
+                  <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-primary">
+                    {feed}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={saving}
+                    onClick={() => handleRemove(feed)}
+                  >
+                    Remove
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-text-tertiary">No feeds yet.</p>
+          )}
+        </Panel>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          More providers
+        </h2>
+        <div className="space-y-3">
+          {COMING_SOON.map((int) => (
+            <Panel
+              key={int.id}
+              className="flex items-center gap-4 rounded-2xl p-4"
+            >
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                {int.icon}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-text-primary">
+                    {int.name}
+                  </span>
+                  <Badge>Later</Badge>
+                </div>
+                <p className="mt-0.5 text-sm text-text-secondary">
+                  {int.description}
+                </p>
+              </div>
+            </Panel>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "react-toastify";
+import { Button, Field, Input, Panel, Textarea } from "@klorad/design-system";
+import { type CampusPost, formatPostDate, readPosts } from "@/lib/posts";
+
+interface Props {
+  mapId: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+interface ServerMap {
+  sceneData?: Record<string, unknown> & { posts?: CampusPost[] };
+}
+
+/**
+ * Campus news authoring — the "News" tab of the campus profile.
+ *
+ * Posts are stored in `sceneData.posts` (see {@link readPosts}); each
+ * save merges the full post list into the campus's `sceneData` via
+ * the same PATCH branding uses. The public home page renders them.
+ */
+export default function NewsTab({ mapId }: Props) {
+  const { data: serverMap } = useSWR<ServerMap>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
+  const posts = readPosts(serverMap?.sceneData);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const resetForm = () => {
+    setEditingId(null);
+    setTitle("");
+    setBody("");
+  };
+
+  const startEdit = (post: CampusPost) => {
+    setEditingId(post.id);
+    setTitle(post.title);
+    setBody(post.body);
+  };
+
+  const persist = async (nextPosts: CampusPost[]) => {
+    const nextSceneData = {
+      ...(serverMap?.sceneData ?? {}),
+      posts: nextPosts,
+    };
+    const res = await fetch(`/api/maps/${mapId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sceneData: nextSceneData }),
+    });
+    if (!res.ok) throw new Error("Save failed");
+    await mutate(`/api/maps/${mapId}`);
+  };
+
+  const handleSave = async () => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) return;
+    setSaving(true);
+    try {
+      const current = readPosts(serverMap?.sceneData);
+      const next: CampusPost[] = editingId
+        ? current.map((p) =>
+            p.id === editingId
+              ? { ...p, title: trimmedTitle, body: body.trim() }
+              : p,
+          )
+        : [
+            {
+              id: crypto.randomUUID(),
+              title: trimmedTitle,
+              body: body.trim(),
+              publishedAt: new Date().toISOString(),
+            },
+            ...current,
+          ];
+      await persist(next);
+      toast.success(editingId ? "Post updated" : "Post published");
+      resetForm();
+    } catch {
+      toast.error("Could not save the post");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setSaving(true);
+    try {
+      await persist(readPosts(serverMap?.sceneData).filter((p) => p.id !== id));
+      toast.success("Post deleted");
+      if (editingId === id) resetForm();
+    } catch {
+      toast.error("Could not delete the post");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8 pt-6">
+      <Section title={editingId ? "Edit post" : "New post"}>
+        <Panel className="space-y-4 rounded-2xl p-6">
+          <Field label="Title">
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Open day, exam schedule, campus closure…"
+            />
+          </Field>
+          <Field label="Body">
+            <Textarea
+              rows={4}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="What's happening on campus…"
+            />
+          </Field>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={saving || !title.trim()}
+            >
+              {saving
+                ? "Saving…"
+                : editingId
+                  ? "Update post"
+                  : "Publish post"}
+            </Button>
+            {editingId ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={resetForm}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+            ) : null}
+          </div>
+        </Panel>
+      </Section>
+
+      <Section title="Published">
+        {posts.length > 0 ? (
+          <ul className="space-y-2">
+            {posts.map((post) => (
+              <li
+                key={post.id}
+                className="flex items-start gap-3 rounded-2xl bg-surface-2 p-4"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs text-text-tertiary">
+                    {formatPostDate(post.publishedAt)}
+                  </div>
+                  <div className="truncate text-sm font-medium text-text-primary">
+                    {post.title}
+                  </div>
+                  {post.body ? (
+                    <p className="mt-0.5 line-clamp-2 text-xs text-text-secondary">
+                      {post.body}
+                    </p>
+                  ) : null}
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => startEdit(post)}
+                  disabled={saving}
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleDelete(post.id)}
+                  disabled={saving}
+                >
+                  Delete
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Panel className="rounded-2xl p-6">
+            <p className="text-sm text-text-secondary">
+              No posts yet. Publish your first campus update above — it
+              appears on the public campus home page.
+            </p>
+          </Panel>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
@@ -37,7 +37,9 @@ interface ServerMap {
 export default function SettingsTab({ orgId, mapId, map }: Props) {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const publicUrl = `${origin}/campus/${mapId}`;
-  const embedCode = `<iframe src="${publicUrl}" width="100%" height="600" frameborder="0" allowfullscreen></iframe>`;
+  // Embeds point at the map (`/map`), not the home page — a campus
+  // embedded in another site wants the interactive map.
+  const embedCode = `<iframe src="${publicUrl}/map" width="100%" height="600" frameborder="0" allowfullscreen></iframe>`;
 
   const [copied, setCopied] = useState<"url" | "embed" | null>(null);
   const copy = (text: string, kind: "url" | "embed") => {

--- a/apps/campus/app/(public)/campus/[token]/NotPublishedPlaceholder.tsx
+++ b/apps/campus/app/(public)/campus/[token]/NotPublishedPlaceholder.tsx
@@ -1,0 +1,24 @@
+import { KloradMark } from "@klorad/design-system";
+
+/**
+ * Friendly "coming soon" placeholder for an unpublished campus —
+ * shared by the public home and map routes. No internal data leaked:
+ * the visitor sees only the campus name (already known via the URL).
+ */
+export default function NotPublishedPlaceholder({ name }: { name: string }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center">
+      <KloradMark className="h-10 w-10" />
+      <h1 className="mt-6 text-2xl font-semibold tracking-tight text-text-primary">
+        {name}
+      </h1>
+      <p className="mt-3 max-w-sm text-sm text-text-secondary">
+        This campus isn&apos;t published yet. The author is still building
+        it — check back soon.
+      </p>
+      <p className="mt-8 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
+        Powered by Klorad
+      </p>
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import PublicViewerClient from "../PublicViewerClient";
+import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
+
+type Params = Promise<{ token: string }>;
+
+/**
+ * `/campus/[token]/map` — the interactive 3D campus map.
+ *
+ * The map was the campus's entire public surface; Phase B moved it
+ * here so `/campus/[token]` can be the branded home page. Same
+ * `isPublished` gate as the home.
+ */
+export default async function CampusMapPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { token } = await params;
+
+  const map = await prisma.project
+    .findUnique({
+      where: { id: token },
+      select: { id: true, title: true, isPublished: true },
+    })
+    .catch(() => null);
+
+  if (!map) notFound();
+  if (!map.isPublished) return <NotPublishedPlaceholder name={map.title} />;
+
+  return <PublicViewerClient mapId={token} />;
+}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -1,13 +1,29 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { KloradMark } from "@klorad/design-system";
 import { prisma } from "@/lib/prisma";
-import PublicViewerClient from "./PublicViewerClient";
+import { formatPostDate, readPosts } from "@/lib/posts";
+import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 
 type Params = Promise<{ token: string }>;
 
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
 /** Dynamic metadata so shared URLs preview nicely in Slack / WhatsApp / LinkedIn. */
-export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
   const { token } = await params;
   const map = await prisma.project
     .findUnique({
@@ -16,10 +32,11 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     })
     .catch(() => null);
 
-  const scene = (map?.sceneData ?? null) as { branding?: { name?: string } } | null;
-  const name = scene?.branding?.name || map?.title || "Campus Map";
-  const description =
-    `${name} — an interactive 3D campus map. Explore buildings, find rooms, and get step-free directions.`;
+  const scene = (map?.sceneData ?? null) as {
+    branding?: { name?: string };
+  } | null;
+  const name = scene?.branding?.name || map?.title || "Campus";
+  const description = `${name} — campus news, events, and an interactive 3D map with step-free indoor wayfinding.`;
 
   return {
     title: name,
@@ -39,57 +56,129 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
 }
 
 /**
- * Public viewer entry point.
+ * `/campus/[token]` — the public campus home page.
  *
- * Gates the campus on `isPublished`:
- *   - Map not found  → standard 404
- *   - Found but not published → branded "Coming soon" placeholder
- *   - Published      → mount the real client viewer
+ * The branded landing for a campus: news, and a route into the 3D
+ * map (`/campus/[token]/map`). Server-rendered so news is in the
+ * HTML for SEO and link previews.
  *
- * Anonymous-only — the page doesn't try to detect an authenticated
- * owner. A future enhancement could let the owner preview their own
- * draft via a short-lived signed link; for now, drafts are private
- * until the author flips the switch.
+ * Gated on `isPublished`: unknown → 404, draft → "coming soon"
+ * placeholder, published → the home.
  */
-export default async function PublicViewerPage({ params }: { params: Params }) {
+export default async function CampusHomePage({
+  params,
+}: {
+  params: Params;
+}) {
   const { token } = await params;
 
   const map = await prisma.project
     .findUnique({
-      where: { id: token },
-      select: { id: true, title: true, isPublished: true },
+      where: {
+        id: token,
+      },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        isPublished: true,
+        sceneData: true,
+      },
     })
     .catch(() => null);
 
   if (!map) notFound();
+  if (!map.isPublished) return <NotPublishedPlaceholder name={map.title} />;
 
-  if (!map.isPublished) {
-    return <NotPublishedPlaceholder name={map.title} />;
-  }
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const displayName = branding.name || map.title;
+  const accent = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : "#158ca3";
+  const posts = readPosts(map.sceneData);
+  const mapHref = `/campus/${token}/map`;
 
-  return <PublicViewerClient mapId={token} />;
-}
-
-/**
- * Friendly "coming soon" placeholder for drafts. No internal data
- * leaked — visitor sees the campus name (already publicly known via
- * the URL share) and a generic note. Looks branded so the page
- * doesn't read as a 404.
- */
-function NotPublishedPlaceholder({ name }: { name: string }) {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center">
-      <KloradMark className="h-10 w-10" />
-      <h1 className="mt-6 text-2xl font-semibold tracking-tight text-text-primary">
-        {name}
-      </h1>
-      <p className="mt-3 max-w-sm text-sm text-text-secondary">
-        This campus isn&apos;t published yet. The author is still building
-        it — check back soon.
-      </p>
-      <p className="mt-8 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
-        Powered by Klorad
-      </p>
+    <main className="min-h-screen bg-bg">
+      <header className="flex items-center justify-between gap-4 px-6 py-4 md:px-10">
+        {branding.logo ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={branding.logo}
+            alt={displayName}
+            className="h-8 max-w-[200px] object-contain"
+          />
+        ) : (
+          <span className="text-lg font-semibold text-text-primary">
+            {displayName}
+          </span>
+        )}
+        <Link
+          href={mapHref}
+          className="text-sm font-medium transition-opacity hover:opacity-80"
+          style={{ color: accent }}
+        >
+          Open map →
+        </Link>
+      </header>
+
+      <section className="px-6 py-12 md:px-10 md:py-20">
+        <h1 className="text-3xl font-semibold tracking-tight text-text-primary md:text-4xl">
+          {displayName}
+        </h1>
+        {map.description ? (
+          <p className="mt-3 max-w-2xl text-base leading-relaxed text-text-secondary">
+            {map.description}
+          </p>
+        ) : null}
+        <Link
+          href={mapHref}
+          className="mt-7 inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+          style={{ backgroundColor: accent }}
+        >
+          Explore the campus map →
+        </Link>
+      </section>
+
+      <section className="px-6 pb-20 md:px-10">
+        <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
+          News
+        </h2>
+        {posts.length > 0 ? (
+          <div className="mt-4 space-y-4">
+            {posts.map((post) => (
+              <article
+                key={post.id}
+                className="rounded-2xl bg-surface-1 p-6 shadow-glass"
+              >
+                <time className="text-xs text-text-tertiary">
+                  {formatPostDate(post.publishedAt)}
+                </time>
+                <h3 className="mt-1 text-lg font-semibold text-text-primary">
+                  {post.title}
+                </h3>
+                {post.body ? (
+                  <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-text-secondary">
+                    {post.body}
+                  </p>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-text-tertiary">
+            No news yet — check back soon.
+          </p>
+        )}
+      </section>
+
+      <footer className="border-t border-solid border-line-soft px-6 py-6 text-center md:px-10">
+        <span className="inline-flex items-center gap-1.5 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
+          <KloradMark className="h-4 w-4" />
+          Powered by Klorad
+        </span>
+      </footer>
     </main>
   );
 }

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -4,6 +4,11 @@ import { notFound } from "next/navigation";
 import { KloradMark } from "@klorad/design-system";
 import { prisma } from "@/lib/prisma";
 import { formatPostDate, readPosts } from "@/lib/posts";
+import {
+  fetchCampusEvents,
+  formatEventWhen,
+  readEventFeeds,
+} from "@/lib/events";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 
 type Params = Promise<{ token: string }>;
@@ -97,6 +102,7 @@ export default async function CampusHomePage({
     ? branding.primaryColor
     : "#158ca3";
   const posts = readPosts(map.sceneData);
+  const events = await fetchCampusEvents(readEventFeeds(map.sceneData));
   const mapHref = `/campus/${token}/map`;
 
   return (
@@ -141,7 +147,40 @@ export default async function CampusHomePage({
         </Link>
       </section>
 
-      <section className="px-6 pb-20 md:px-10">
+      {events.length > 0 ? (
+        <section className="px-6 pb-4 md:px-10">
+          <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
+            Upcoming events
+          </h2>
+          <div className="mt-4 space-y-3">
+            {events.map((event) => (
+              <article
+                key={event.id}
+                className="flex items-baseline gap-4 rounded-2xl bg-surface-1 px-5 py-4 shadow-glass"
+              >
+                <time
+                  className="shrink-0 text-xs font-medium"
+                  style={{ color: accent }}
+                >
+                  {formatEventWhen(event.start, event.allDay)}
+                </time>
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-semibold text-text-primary">
+                    {event.title}
+                  </h3>
+                  {event.location ? (
+                    <p className="truncate text-xs text-text-tertiary">
+                      {event.location}
+                    </p>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="px-6 pb-20 pt-8 md:px-10">
         <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
           News
         </h2>

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -4,11 +4,8 @@ import { notFound } from "next/navigation";
 import { KloradMark } from "@klorad/design-system";
 import { prisma } from "@/lib/prisma";
 import { formatPostDate, readPosts } from "@/lib/posts";
-import {
-  fetchCampusEvents,
-  formatEventWhen,
-  readEventFeeds,
-} from "@/lib/events";
+import { formatEventWhen, readEventFeeds } from "@/lib/events";
+import { fetchCampusEvents } from "@/lib/events-server";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 
 type Params = Promise<{ token: string }>;

--- a/apps/campus/lib/events-server.ts
+++ b/apps/campus/lib/events-server.ts
@@ -1,0 +1,77 @@
+import { expandRecurringEvent, sync } from "node-ical";
+import type { CampusEvent } from "./events";
+
+/**
+ * Campus events — server-only ICS fetching + parsing.
+ *
+ * Pulls in `node-ical` (and Node built-ins like `node:crypto`), so
+ * this module must only be imported from server code (the public
+ * home page). Client code uses `events.ts` instead — importing this
+ * from a client component breaks the build (`node:crypto` can't be
+ * bundled for the browser).
+ */
+
+/** How far ahead to surface events, and how many to show. */
+const HORIZON_DAYS = 60;
+const MAX_EVENTS = 12;
+/** Per-feed fetch timeout — a slow feed must not hang the page. */
+const FEED_TIMEOUT_MS = 8000;
+
+/** ICS string values can be plain or `{ params, val }` — flatten them. */
+function text(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "val" in value) {
+    const v = (value as { val?: unknown }).val;
+    return typeof v === "string" ? v : "";
+  }
+  return "";
+}
+
+/**
+ * Fetch + parse the given ICS feeds and return upcoming events,
+ * soonest first. Recurring events are expanded; a bad or slow feed
+ * is skipped so the rest still render.
+ */
+export async function fetchCampusEvents(
+  feedUrls: string[],
+): Promise<CampusEvent[]> {
+  const now = new Date();
+  const horizon = new Date(now.getTime() + HORIZON_DAYS * 86_400_000);
+  const events: CampusEvent[] = [];
+
+  for (const url of feedUrls) {
+    try {
+      const res = await fetch(url, {
+        next: { revalidate: 1800 },
+        signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
+      });
+      if (!res.ok) continue;
+      const parsed = sync.parseICS(await res.text());
+
+      for (const key of Object.keys(parsed)) {
+        const component = parsed[key];
+        if (!component || component.type !== "VEVENT") continue;
+        for (const instance of expandRecurringEvent(component, {
+          from: now,
+          to: horizon,
+        })) {
+          const start = new Date(instance.start);
+          events.push({
+            id: `${key}::${start.toISOString()}`,
+            title: text(instance.summary) || "Event",
+            start: start.toISOString(),
+            end: new Date(instance.end).toISOString(),
+            allDay: instance.isFullDay,
+            location: text(instance.event.location) || undefined,
+          });
+        }
+      }
+    } catch {
+      // Skip an unreachable / malformed feed — others still render.
+    }
+  }
+
+  return events
+    .sort((a, b) => Date.parse(a.start) - Date.parse(b.start))
+    .slice(0, MAX_EVENTS);
+}

--- a/apps/campus/lib/events.ts
+++ b/apps/campus/lib/events.ts
@@ -1,0 +1,112 @@
+import { expandRecurringEvent, sync } from "node-ical";
+
+/**
+ * Campus events — pulled from ICS calendar feeds.
+ *
+ * Feed URLs are stored per-campus in `sceneData.eventFeeds`; the
+ * public home page fetches + parses them server-side (Next caches
+ * the fetch) and shows what's upcoming. ICS is the reliable spine —
+ * Google Calendar / Outlook OAuth and Facebook are deferred.
+ */
+export interface CampusEvent {
+  id: string;
+  title: string;
+  /** ISO start. */
+  start: string;
+  /** ISO end. */
+  end: string;
+  allDay: boolean;
+  location?: string;
+}
+
+/** How far ahead to surface events, and how many to show. */
+const HORIZON_DAYS = 60;
+const MAX_EVENTS = 12;
+/** Per-feed fetch timeout — a slow feed must not hang the page. */
+const FEED_TIMEOUT_MS = 8000;
+
+/** Read a campus's ICS feed URLs from its `sceneData`. */
+export function readEventFeeds(sceneData: unknown): string[] {
+  const raw = (sceneData as { eventFeeds?: unknown } | null | undefined)
+    ?.eventFeeds;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (u): u is string => typeof u === "string" && u.length > 0,
+  );
+}
+
+/** ICS string values can be plain or `{ params, val }` — flatten them. */
+function text(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "val" in value) {
+    const v = (value as { val?: unknown }).val;
+    return typeof v === "string" ? v : "";
+  }
+  return "";
+}
+
+/**
+ * Fetch + parse the given ICS feeds and return upcoming events,
+ * soonest first. Recurring events are expanded; a bad or slow feed
+ * is skipped so the rest still render.
+ */
+export async function fetchCampusEvents(
+  feedUrls: string[],
+): Promise<CampusEvent[]> {
+  const now = new Date();
+  const horizon = new Date(now.getTime() + HORIZON_DAYS * 86_400_000);
+  const events: CampusEvent[] = [];
+
+  for (const url of feedUrls) {
+    try {
+      const res = await fetch(url, {
+        next: { revalidate: 1800 },
+        signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
+      });
+      if (!res.ok) continue;
+      const parsed = sync.parseICS(await res.text());
+
+      for (const key of Object.keys(parsed)) {
+        const component = parsed[key];
+        if (!component || component.type !== "VEVENT") continue;
+        for (const instance of expandRecurringEvent(component, {
+          from: now,
+          to: horizon,
+        })) {
+          const start = new Date(instance.start);
+          events.push({
+            id: `${key}::${start.toISOString()}`,
+            title: text(instance.summary) || "Event",
+            start: start.toISOString(),
+            end: new Date(instance.end).toISOString(),
+            allDay: instance.isFullDay,
+            location: text(instance.event.location) || undefined,
+          });
+        }
+      }
+    } catch {
+      // Skip an unreachable / malformed feed — others still render.
+    }
+  }
+
+  return events
+    .sort((a, b) => Date.parse(a.start) - Date.parse(b.start))
+    .slice(0, MAX_EVENTS);
+}
+
+/** Format an event's start for display. */
+export function formatEventWhen(startIso: string, allDay: boolean): string {
+  const date = new Date(startIso);
+  if (Number.isNaN(date.getTime())) return "";
+  const datePart = date.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  if (allDay) return datePart;
+  const timePart = date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${datePart} · ${timePart}`;
+}

--- a/apps/campus/lib/events.ts
+++ b/apps/campus/lib/events.ts
@@ -1,12 +1,10 @@
-import { expandRecurringEvent, sync } from "node-ical";
-
 /**
- * Campus events — pulled from ICS calendar feeds.
+ * Campus events — client-safe helpers and types.
  *
- * Feed URLs are stored per-campus in `sceneData.eventFeeds`; the
- * public home page fetches + parses them server-side (Next caches
- * the fetch) and shows what's upcoming. ICS is the reliable spine —
- * Google Calendar / Outlook OAuth and Facebook are deferred.
+ * This module is import-safe from client components (it has no Node
+ * dependencies). The actual ICS fetching + parsing — which pulls in
+ * `node-ical` and Node built-ins — lives in `events-server.ts` and
+ * must only be imported from server code.
  */
 export interface CampusEvent {
   id: string;
@@ -19,12 +17,6 @@ export interface CampusEvent {
   location?: string;
 }
 
-/** How far ahead to surface events, and how many to show. */
-const HORIZON_DAYS = 60;
-const MAX_EVENTS = 12;
-/** Per-feed fetch timeout — a slow feed must not hang the page. */
-const FEED_TIMEOUT_MS = 8000;
-
 /** Read a campus's ICS feed URLs from its `sceneData`. */
 export function readEventFeeds(sceneData: unknown): string[] {
   const raw = (sceneData as { eventFeeds?: unknown } | null | undefined)
@@ -33,65 +25,6 @@ export function readEventFeeds(sceneData: unknown): string[] {
   return raw.filter(
     (u): u is string => typeof u === "string" && u.length > 0,
   );
-}
-
-/** ICS string values can be plain or `{ params, val }` — flatten them. */
-function text(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value && typeof value === "object" && "val" in value) {
-    const v = (value as { val?: unknown }).val;
-    return typeof v === "string" ? v : "";
-  }
-  return "";
-}
-
-/**
- * Fetch + parse the given ICS feeds and return upcoming events,
- * soonest first. Recurring events are expanded; a bad or slow feed
- * is skipped so the rest still render.
- */
-export async function fetchCampusEvents(
-  feedUrls: string[],
-): Promise<CampusEvent[]> {
-  const now = new Date();
-  const horizon = new Date(now.getTime() + HORIZON_DAYS * 86_400_000);
-  const events: CampusEvent[] = [];
-
-  for (const url of feedUrls) {
-    try {
-      const res = await fetch(url, {
-        next: { revalidate: 1800 },
-        signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
-      });
-      if (!res.ok) continue;
-      const parsed = sync.parseICS(await res.text());
-
-      for (const key of Object.keys(parsed)) {
-        const component = parsed[key];
-        if (!component || component.type !== "VEVENT") continue;
-        for (const instance of expandRecurringEvent(component, {
-          from: now,
-          to: horizon,
-        })) {
-          const start = new Date(instance.start);
-          events.push({
-            id: `${key}::${start.toISOString()}`,
-            title: text(instance.summary) || "Event",
-            start: start.toISOString(),
-            end: new Date(instance.end).toISOString(),
-            allDay: instance.isFullDay,
-            location: text(instance.event.location) || undefined,
-          });
-        }
-      }
-    } catch {
-      // Skip an unreachable / malformed feed — others still render.
-    }
-  }
-
-  return events
-    .sort((a, b) => Date.parse(a.start) - Date.parse(b.start))
-    .slice(0, MAX_EVENTS);
 }
 
 /** Format an event's start for display. */

--- a/apps/campus/lib/posts.ts
+++ b/apps/campus/lib/posts.ts
@@ -1,0 +1,36 @@
+/**
+ * Campus news posts.
+ *
+ * Posts live in the campus `sceneData` JSON (`sceneData.posts`) — the
+ * same store branding and the indoor map id use — so adding news
+ * needs no schema migration. If news grows (pagination, scheduling,
+ * per-post media) this graduates to its own Prisma model.
+ */
+export interface CampusPost {
+  id: string;
+  title: string;
+  body: string;
+  /** ISO timestamp. */
+  publishedAt: string;
+}
+
+/** Read a campus's news posts from its `sceneData`, newest first. */
+export function readPosts(sceneData: unknown): CampusPost[] {
+  const raw = (sceneData as { posts?: unknown } | null | undefined)?.posts;
+  if (!Array.isArray(raw)) return [];
+  return (raw as CampusPost[])
+    .filter((p): p is CampusPost => Boolean(p) && typeof p.title === "string")
+    .slice()
+    .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt));
+}
+
+/** Format a post's ISO date for display. */
+export function formatPostDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/campus/next.config.mjs
+++ b/apps/campus/next.config.mjs
@@ -8,6 +8,10 @@ const nextConfig = {
     "@klorad/engine-mapbox",
     "@klorad/engine-three",
   ],
+  // `node-ical` (ICS event parsing) is a Node library that doesn't
+  // survive webpack bundling — load it at runtime instead of bundling
+  // it into the server output.
+  serverExternalPackages: ["node-ical"],
   webpack(config) {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -38,6 +38,7 @@
     "mapbox-gl": "^3.9.4",
     "next": "^15.1.9",
     "next-auth": "5.0.0-beta.30",
+    "node-ical": "^0.26.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-toastify": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       next-auth:
         specifier: 5.0.0-beta.30
         version: 5.0.0-beta.30(next@15.5.7(@babel/core@7.28.5)(@playwright/test@1.56.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      node-ical:
+        specifier: ^0.26.1
+        version: 0.26.1
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2385,6 +2388,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
 
   '@mapbox/geojson-area@0.2.2':
     resolution: {integrity: sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==}
@@ -5959,6 +5966,9 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
   jsep@1.4.0:
     resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
     engines: {node: '>= 10.16.0'}
@@ -6393,6 +6403,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-ical@0.26.1:
+    resolution: {integrity: sha512-KoYLpsz7Ga9lPDpt9vy0iKcgcb/9Ix7ICRZd0csLXMl2lZOSONGj7HrcktJFR7Jid1l44Zu1H4k/1nB04rWPgQ==}
+    engines: {node: '>=20'}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -7119,6 +7133,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrule-temporal@1.5.3:
+    resolution: {integrity: sha512-qALnXyu4MKNUeykkkO0r6Xxl5or3rM8Cf6ibKIe/29sgmq3tGm1oNq4G1Ddp8Ku3mnKmvC3+3yFAJ3OgOu6OJw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -7572,6 +7589,12 @@ packages:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
 
+  temporal-polyfill@0.3.2:
+    resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
+
+  temporal-spec@0.3.1:
+    resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
+
   tempy@0.6.0:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
     engines: {node: '>=10'}
@@ -7920,6 +7943,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8n@1.5.1:
@@ -9961,6 +9985,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
 
   '@mapbox/geojson-area@0.2.2':
     dependencies:
@@ -13879,6 +13907,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbi@4.3.2: {}
+
   jsep@1.4.0: {}
 
   jsesc@3.1.0: {}
@@ -14310,6 +14340,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-ical@0.26.1:
+    dependencies:
+      rrule-temporal: 1.5.3
+      temporal-polyfill: 0.3.2
 
   node-releases@2.0.27: {}
 
@@ -15105,6 +15140,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.5
       fsevents: 2.3.3
 
+  rrule-temporal@1.5.3:
+    dependencies:
+      '@js-temporal/polyfill': 0.5.1
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -15691,6 +15730,12 @@ snapshots:
   tapable@2.3.0: {}
 
   temp-dir@2.0.0: {}
+
+  temporal-polyfill@0.3.2:
+    dependencies:
+      temporal-spec: 0.3.1
+
+  temporal-spec@0.3.1: {}
 
   tempy@0.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

Phase B + C — turns the public surface from a bare map viewer into a branded **campus site** with news and events.

## Public site

- **`/campus/[token]` is now the public home page** — branded header (logo or campus name), a hero with the campus description, an **Upcoming events** section, a **news feed**, and a CTA into the map. Server-rendered, so content is in the HTML for SEO and link previews.
- **The 3D map moved to `/campus/[token]/map`** — `PublicViewerClient` unchanged, just remounted. `NotPublishedPlaceholder` extracted, shared by both routes. Embed code now points at `/map`.

## News

- A new **"News" tab** in the campus profile authors posts (create / edit / delete). Stored in `sceneData.posts` (`lib/posts.ts`) — no schema migration.

## Events (ICS feeds)

- **`lib/events.ts`** — `fetchCampusEvents()` pulls public ICS calendar feeds, parses them with `node-ical` (recurring events expanded, EXDATEs honoured), returns upcoming events. Each feed fetch is Next-cached and time-boxed so a slow/broken feed can't hang or break the page.
- The **Integrations tab** now has live ICS feed management — paste a public ICS URL, add/remove feeds (stored in `sceneData.eventFeeds`). Google / Outlook / Facebook stay as honest "Later" cards (Meta restricts public event access; Google/Outlook OAuth is a later phase).
- The home page renders the configured feeds' upcoming events.

## Routing change — note

`/campus/[id]` previously showed the map; it now shows the home page, map one click away at `/campus/[id]/map`. Existing share links still resolve (land on home); embeds are updated to `/map`.

## Deferred

- Google Calendar / Outlook OAuth ingestion.
- Promoting `sceneData.posts` to a real `Post` model if news grows.
- Linking events to map locations.

## Testing

`tsc --noEmit` clean; pre-commit (audits + lint + typecheck) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)