### PR TITLE
feat(campus): public home hero banner + georeferenced news

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "react-toastify";
+import { uploadFile } from "@klorad/storage/client";
+import { Button, Field, Input, Panel, Textarea } from "@klorad/design-system";
+import { type HomePageConfig, readHomePage } from "@/lib/home-page";
+
+interface Props {
+  mapId: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+interface ServerMap {
+  sceneData?: Record<string, unknown> & { homePage?: HomePageConfig };
+}
+
+/**
+ * The public home page builder — a Settings section.
+ *
+ * Configures the campus's public landing page: a hero image, the
+ * hero text, the map CTA label, and which sections show. Saved into
+ * `sceneData.homePage`; the public page reads it with fallbacks, so
+ * leaving a field blank keeps the sensible default.
+ */
+export default function HomePagePanel({ mapId }: Props) {
+  const { data: serverMap } = useSWR<ServerMap>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
+
+  const [heroImage, setHeroImage] = useState("");
+  const [headline, setHeadline] = useState("");
+  const [tagline, setTagline] = useState("");
+  const [ctaLabel, setCtaLabel] = useState("");
+  const [showEvents, setShowEvents] = useState(true);
+  const [showNews, setShowNews] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const home = readHomePage(serverMap?.sceneData);
+    setHeroImage(home.heroImage ?? "");
+    setHeadline(home.headline ?? "");
+    setTagline(home.tagline ?? "");
+    setCtaLabel(home.ctaLabel ?? "");
+    setShowEvents(home.showEvents !== false);
+    setShowNews(home.showNews !== false);
+  }, [serverMap]);
+
+  const handleUpload = async (file: File) => {
+    setUploading(true);
+    try {
+      const { publicUrl } = await uploadFile(file, { prefix: "campus-hero" });
+      setHeroImage(publicUrl);
+      toast.success("Hero image uploaded — Save to apply");
+    } catch {
+      toast.error("Could not upload the image");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const homePage: HomePageConfig = {
+        heroImage: heroImage.trim() || undefined,
+        headline: headline.trim() || undefined,
+        tagline: tagline.trim() || undefined,
+        ctaLabel: ctaLabel.trim() || undefined,
+        showEvents,
+        showNews,
+      };
+      const nextSceneData = {
+        ...(serverMap?.sceneData ?? {}),
+        homePage,
+      };
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneData: nextSceneData }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      await mutate(`/api/maps/${mapId}`);
+      toast.success("Home page saved");
+    } catch {
+      toast.error("Could not save the home page");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Panel className="space-y-5 rounded-2xl p-6">
+      <Field
+        label="Hero image"
+        hint="The banner behind your campus name on the public home page. A wide image (≈1600×600) works best."
+      >
+        <input
+          type="file"
+          accept="image/*"
+          disabled={uploading}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void handleUpload(file);
+          }}
+          className="block w-full text-sm text-text-secondary file:mr-3 file:rounded-md file:border-0 file:bg-accent-soft file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-accent"
+        />
+      </Field>
+
+      {heroImage ? (
+        <div className="space-y-2">
+          <div className="overflow-hidden rounded-xl bg-surface-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={heroImage}
+              alt="Hero preview"
+              className="h-36 w-full object-cover"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => setHeroImage("")}
+            className="text-xs font-medium text-text-secondary transition-colors hover:text-accent"
+          >
+            Remove image
+          </button>
+        </div>
+      ) : null}
+
+      <Field
+        label="Headline"
+        hint="Overrides the campus name in the hero. Leave blank to use the campus name."
+      >
+        <Input
+          value={headline}
+          onChange={(e) => setHeadline(e.target.value)}
+          placeholder="Welcome to our campus"
+        />
+      </Field>
+
+      <Field
+        label="Tagline"
+        hint="A short line under the headline. Leave blank to use the campus description."
+      >
+        <Textarea
+          rows={2}
+          value={tagline}
+          onChange={(e) => setTagline(e.target.value)}
+          placeholder="Find your way — buildings, rooms, events and step-free routes."
+        />
+      </Field>
+
+      <Field label="Map button label">
+        <Input
+          value={ctaLabel}
+          onChange={(e) => setCtaLabel(e.target.value)}
+          placeholder="Explore the campus map"
+        />
+      </Field>
+
+      <div className="space-y-2 rounded-xl bg-surface-2 p-3">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+          <input
+            type="checkbox"
+            checked={showEvents}
+            onChange={(e) => setShowEvents(e.target.checked)}
+            className="h-4 w-4 rounded accent-accent"
+          />
+          Show the events section
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+          <input
+            type="checkbox"
+            checked={showNews}
+            onChange={(e) => setShowNews(e.target.checked)}
+            className="h-4 w-4 rounded accent-accent"
+          />
+          Show the news section
+        </label>
+      </div>
+
+      <Button size="sm" onClick={handleSave} disabled={saving || uploading}>
+        {uploading ? "Uploading…" : saving ? "Saving…" : "Save home page"}
+      </Button>
+    </Panel>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "react-toastify";
 import { uploadFile } from "@klorad/storage/client";
@@ -64,8 +64,15 @@ export default function HomePagePanel({ mapId }: Props) {
   const [uploading, setUploading] = useState(false);
   const [saving, setSaving] = useState(false);
 
+  // Initialise the form from the saved config exactly once. SWR
+  // revalidates `serverMap` (on window focus — which opening a file
+  // picker triggers); re-running this would clobber unsaved edits,
+  // including a just-uploaded hero image before it is saved.
+  const loadedRef = useRef(false);
   useEffect(() => {
-    const home = readHomePage(serverMap?.sceneData);
+    if (loadedRef.current || !serverMap) return;
+    loadedRef.current = true;
+    const home = readHomePage(serverMap.sceneData);
     setHeroImage(home.heroImage ?? "");
     setHeadline(toFields(home.headline));
     setTagline(toFields(home.tagline));

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
@@ -6,6 +6,12 @@ import { toast } from "react-toastify";
 import { uploadFile } from "@klorad/storage/client";
 import { Button, Field, Input, Panel, Textarea } from "@klorad/design-system";
 import { type HomePageConfig, readHomePage } from "@/lib/home-page";
+import {
+  type Localizable,
+  type Locale,
+  type LocalizedText,
+} from "@/app/lib/i18n-core";
+import { LangToggle } from "./LangToggle";
 
 interface Props {
   mapId: string;
@@ -17,13 +23,30 @@ interface ServerMap {
   sceneData?: Record<string, unknown> & { homePage?: HomePageConfig };
 }
 
+type LangFields = { en: string; el: string };
+const EMPTY_FIELDS: LangFields = { en: "", el: "" };
+
+/** Expand a possibly-legacy {@link Localizable} into editable fields. */
+function toFields(value: Localizable | undefined): LangFields {
+  if (!value) return { ...EMPTY_FIELDS };
+  if (typeof value === "string") return { en: value, el: "" };
+  return { en: value.en ?? "", el: value.el ?? "" };
+}
+
+/** Collapse edited fields to localized text, dropping empty languages. */
+function toLocalized(fields: LangFields): LocalizedText | undefined {
+  const en = fields.en.trim() || undefined;
+  const el = fields.el.trim() || undefined;
+  return en || el ? { en, el } : undefined;
+}
+
 /**
  * The public home page builder — a Settings section.
  *
- * Configures the campus's public landing page: a hero image, the
- * hero text, the map CTA label, and which sections show. Saved into
- * `sceneData.homePage`; the public page reads it with fallbacks, so
- * leaving a field blank keeps the sensible default.
+ * Configures the campus's public landing page. Hero text is
+ * bilingual (English + Greek), edited one language at a time via the
+ * toggle. Saved into `sceneData.homePage`; the public page reads it
+ * with fallbacks, so a blank field keeps the sensible default.
  */
 export default function HomePagePanel({ mapId }: Props) {
   const { data: serverMap } = useSWR<ServerMap>(
@@ -31,10 +54,11 @@ export default function HomePagePanel({ mapId }: Props) {
     fetcher,
   );
 
+  const [lang, setLang] = useState<Locale>("en");
   const [heroImage, setHeroImage] = useState("");
-  const [headline, setHeadline] = useState("");
-  const [tagline, setTagline] = useState("");
-  const [ctaLabel, setCtaLabel] = useState("");
+  const [headline, setHeadline] = useState<LangFields>({ ...EMPTY_FIELDS });
+  const [tagline, setTagline] = useState<LangFields>({ ...EMPTY_FIELDS });
+  const [ctaLabel, setCtaLabel] = useState<LangFields>({ ...EMPTY_FIELDS });
   const [showEvents, setShowEvents] = useState(true);
   const [showNews, setShowNews] = useState(true);
   const [uploading, setUploading] = useState(false);
@@ -43,9 +67,9 @@ export default function HomePagePanel({ mapId }: Props) {
   useEffect(() => {
     const home = readHomePage(serverMap?.sceneData);
     setHeroImage(home.heroImage ?? "");
-    setHeadline(home.headline ?? "");
-    setTagline(home.tagline ?? "");
-    setCtaLabel(home.ctaLabel ?? "");
+    setHeadline(toFields(home.headline));
+    setTagline(toFields(home.tagline));
+    setCtaLabel(toFields(home.ctaLabel));
     setShowEvents(home.showEvents !== false);
     setShowNews(home.showNews !== false);
   }, [serverMap]);
@@ -68,9 +92,9 @@ export default function HomePagePanel({ mapId }: Props) {
     try {
       const homePage: HomePageConfig = {
         heroImage: heroImage.trim() || undefined,
-        headline: headline.trim() || undefined,
-        tagline: tagline.trim() || undefined,
-        ctaLabel: ctaLabel.trim() || undefined,
+        headline: toLocalized(headline),
+        tagline: toLocalized(tagline),
+        ctaLabel: toLocalized(ctaLabel),
         showEvents,
         showNews,
       };
@@ -131,13 +155,22 @@ export default function HomePagePanel({ mapId }: Props) {
         </div>
       ) : null}
 
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-text-tertiary">
+          Editing the {lang === "en" ? "English" : "Greek"} text
+        </span>
+        <LangToggle value={lang} onChange={setLang} />
+      </div>
+
       <Field
         label="Headline"
         hint="Overrides the campus name in the hero. Leave blank to use the campus name."
       >
         <Input
-          value={headline}
-          onChange={(e) => setHeadline(e.target.value)}
+          value={headline[lang]}
+          onChange={(e) =>
+            setHeadline((h) => ({ ...h, [lang]: e.target.value }))
+          }
           placeholder="Welcome to our campus"
         />
       </Field>
@@ -148,16 +181,20 @@ export default function HomePagePanel({ mapId }: Props) {
       >
         <Textarea
           rows={2}
-          value={tagline}
-          onChange={(e) => setTagline(e.target.value)}
+          value={tagline[lang]}
+          onChange={(e) =>
+            setTagline((t) => ({ ...t, [lang]: e.target.value }))
+          }
           placeholder="Find your way — buildings, rooms, events and step-free routes."
         />
       </Field>
 
       <Field label="Map button label">
         <Input
-          value={ctaLabel}
-          onChange={(e) => setCtaLabel(e.target.value)}
+          value={ctaLabel[lang]}
+          onChange={(e) =>
+            setCtaLabel((c) => ({ ...c, [lang]: e.target.value }))
+          }
           placeholder="Explore the campus map"
         />
       </Field>

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/LangToggle.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/LangToggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { cn } from "@klorad/design-system";
+import { LOCALES, type Locale } from "@/app/lib/i18n-core";
+
+const LABEL: Record<Locale, string> = { en: "EN", el: "ΕΛ" };
+
+/**
+ * EN / ΕΛ toggle for the content editors. Campus-authored text is
+ * bilingual; the editors hold both languages and show one at a time —
+ * this switches which one you're editing.
+ */
+export function LangToggle({
+  value,
+  onChange,
+}: {
+  value: Locale;
+  onChange: (locale: Locale) => void;
+}) {
+  return (
+    <div className="inline-flex gap-0.5 rounded-lg bg-surface-2 p-0.5">
+      {LOCALES.map((l) => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => onChange(l)}
+          aria-pressed={value === l}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+            value === l
+              ? "bg-accent text-accent-contrast"
+              : "text-text-secondary hover:text-text-primary",
+          )}
+        >
+          {LABEL[l]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
@@ -19,9 +19,22 @@ import {
   readPosts,
 } from "@/lib/posts";
 import { readCampusPlaces } from "@/lib/places";
+import {
+  type Localizable,
+  type Locale,
+  type LocalizedText,
+  pickText,
+} from "@/app/lib/i18n-core";
+import { LangToggle } from "./LangToggle";
 
 interface Props {
   mapId: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+interface ServerMap {
+  sceneData?: Record<string, unknown> & { posts?: CampusPost[] };
 }
 
 const GROUP_LABEL: Record<"building" | "floor" | "room", string> = {
@@ -30,18 +43,30 @@ const GROUP_LABEL: Record<"building" | "floor" | "room", string> = {
   room: "Rooms",
 };
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
+type LangFields = { en: string; el: string };
+const EMPTY_FIELDS: LangFields = { en: "", el: "" };
 
-interface ServerMap {
-  sceneData?: Record<string, unknown> & { posts?: CampusPost[] };
+/** Expand a possibly-legacy {@link Localizable} into editable fields. */
+function toFields(value: Localizable | undefined): LangFields {
+  if (!value) return { ...EMPTY_FIELDS };
+  if (typeof value === "string") return { en: value, el: "" };
+  return { en: value.en ?? "", el: value.el ?? "" };
+}
+
+/** Collapse edited fields to localized text, dropping empty languages. */
+function toLocalized(fields: LangFields): LocalizedText {
+  return {
+    en: fields.en.trim() || undefined,
+    el: fields.el.trim() || undefined,
+  };
 }
 
 /**
  * Campus news authoring — the "News" tab of the campus profile.
  *
- * Posts are stored in `sceneData.posts` (see {@link readPosts}); each
- * save merges the full post list into the campus's `sceneData` via
- * the same PATCH branding uses. The public home page renders them.
+ * Posts are bilingual: the form holds English + Greek and shows one
+ * at a time via the language toggle. Stored in `sceneData.posts`; the
+ * public home page renders the visitor's language.
  */
 export default function NewsTab({ mapId }: Props) {
   const { data: serverMap } = useSWR<ServerMap>(
@@ -55,22 +80,25 @@ export default function NewsTab({ mapId }: Props) {
   );
 
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
+  const [lang, setLang] = useState<Locale>("en");
+  const [title, setTitle] = useState<LangFields>({ ...EMPTY_FIELDS });
+  const [body, setBody] = useState<LangFields>({ ...EMPTY_FIELDS });
   const [placeId, setPlaceId] = useState("");
   const [saving, setSaving] = useState(false);
 
+  const titleFilled = title.en.trim() !== "" || title.el.trim() !== "";
+
   const resetForm = () => {
     setEditingId(null);
-    setTitle("");
-    setBody("");
+    setTitle({ ...EMPTY_FIELDS });
+    setBody({ ...EMPTY_FIELDS });
     setPlaceId("");
   };
 
   const startEdit = (post: CampusPost) => {
     setEditingId(post.id);
-    setTitle(post.title);
-    setBody(post.body);
+    setTitle(toFields(post.title));
+    setBody(toFields(post.body));
     setPlaceId(post.place?.id ?? "");
   };
 
@@ -89,8 +117,7 @@ export default function NewsTab({ mapId }: Props) {
   };
 
   const handleSave = async () => {
-    const trimmedTitle = title.trim();
-    if (!trimmedTitle) return;
+    if (!titleFilled) return;
     setSaving(true);
     try {
       const current = readPosts(serverMap?.sceneData);
@@ -98,17 +125,19 @@ export default function NewsTab({ mapId }: Props) {
       const place: PostPlace | undefined = linked
         ? { id: linked.id, kind: linked.kind, name: linked.name }
         : undefined;
+      const titleValue = toLocalized(title);
+      const bodyValue = toLocalized(body);
       const next: CampusPost[] = editingId
         ? current.map((p) =>
             p.id === editingId
-              ? { ...p, title: trimmedTitle, body: body.trim(), place }
+              ? { ...p, title: titleValue, body: bodyValue, place }
               : p,
           )
         : [
             {
               id: crypto.randomUUID(),
-              title: trimmedTitle,
-              body: body.trim(),
+              title: titleValue,
+              body: bodyValue,
               publishedAt: new Date().toISOString(),
               place,
             },
@@ -141,18 +170,28 @@ export default function NewsTab({ mapId }: Props) {
     <div className="space-y-8 pt-6">
       <Section title={editingId ? "Edit post" : "New post"}>
         <Panel className="space-y-4 rounded-2xl p-6">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-text-tertiary">
+              Editing the {lang === "en" ? "English" : "Greek"} version
+            </span>
+            <LangToggle value={lang} onChange={setLang} />
+          </div>
           <Field label="Title">
             <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              value={title[lang]}
+              onChange={(e) =>
+                setTitle((t) => ({ ...t, [lang]: e.target.value }))
+              }
               placeholder="Open day, exam schedule, campus closure…"
             />
           </Field>
           <Field label="Body">
             <Textarea
               rows={4}
-              value={body}
-              onChange={(e) => setBody(e.target.value)}
+              value={body[lang]}
+              onChange={(e) =>
+                setBody((b) => ({ ...b, [lang]: e.target.value }))
+              }
               placeholder="What's happening on campus…"
             />
           </Field>
@@ -184,7 +223,7 @@ export default function NewsTab({ mapId }: Props) {
             <Button
               size="sm"
               onClick={handleSave}
-              disabled={saving || !title.trim()}
+              disabled={saving || !titleFilled}
             >
               {saving
                 ? "Saving…"
@@ -209,47 +248,51 @@ export default function NewsTab({ mapId }: Props) {
       <Section title="Published">
         {posts.length > 0 ? (
           <ul className="space-y-2">
-            {posts.map((post) => (
-              <li
-                key={post.id}
-                className="flex items-start gap-3 rounded-2xl bg-surface-2 p-4"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="text-xs text-text-tertiary">
-                    {formatPostDate(post.publishedAt)}
-                  </div>
-                  <div className="truncate text-sm font-medium text-text-primary">
-                    {post.title}
-                  </div>
-                  {post.body ? (
-                    <p className="mt-0.5 line-clamp-2 text-xs text-text-secondary">
-                      {post.body}
-                    </p>
-                  ) : null}
-                  {post.place ? (
-                    <div className="mt-1 text-xs font-medium text-accent">
-                      {post.place.name}
+            {posts.map((post) => {
+              const postTitle = pickText(post.title, lang);
+              const postBody = pickText(post.body, lang);
+              return (
+                <li
+                  key={post.id}
+                  className="flex items-start gap-3 rounded-2xl bg-surface-2 p-4"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs text-text-tertiary">
+                      {formatPostDate(post.publishedAt)}
                     </div>
-                  ) : null}
-                </div>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => startEdit(post)}
-                  disabled={saving}
-                >
-                  Edit
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => handleDelete(post.id)}
-                  disabled={saving}
-                >
-                  Delete
-                </Button>
-              </li>
-            ))}
+                    <div className="truncate text-sm font-medium text-text-primary">
+                      {postTitle || "Untitled"}
+                    </div>
+                    {postBody ? (
+                      <p className="mt-0.5 line-clamp-2 text-xs text-text-secondary">
+                        {postBody}
+                      </p>
+                    ) : null}
+                    {post.place ? (
+                      <div className="mt-1 text-xs font-medium text-accent">
+                        {post.place.name}
+                      </div>
+                    ) : null}
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => startEdit(post)}
+                    disabled={saving}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleDelete(post.id)}
+                    disabled={saving}
+                  >
+                    Delete
+                  </Button>
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <Panel className="rounded-2xl p-6">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
@@ -1,15 +1,34 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "react-toastify";
-import { Button, Field, Input, Panel, Textarea } from "@klorad/design-system";
-import { type CampusPost, formatPostDate, readPosts } from "@/lib/posts";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Select,
+  Textarea,
+} from "@klorad/design-system";
+import {
+  type CampusPost,
+  type PostPlace,
+  formatPostDate,
+  readPosts,
+} from "@/lib/posts";
+import { readCampusPlaces } from "@/lib/places";
 
 interface Props {
   mapId: string;
 }
+
+const GROUP_LABEL: Record<"building" | "floor" | "room", string> = {
+  building: "Buildings",
+  floor: "Floors",
+  room: "Rooms",
+};
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -30,22 +49,29 @@ export default function NewsTab({ mapId }: Props) {
     fetcher,
   );
   const posts = readPosts(serverMap?.sceneData);
+  const places = useMemo(
+    () => readCampusPlaces(serverMap?.sceneData),
+    [serverMap],
+  );
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const [placeId, setPlaceId] = useState("");
   const [saving, setSaving] = useState(false);
 
   const resetForm = () => {
     setEditingId(null);
     setTitle("");
     setBody("");
+    setPlaceId("");
   };
 
   const startEdit = (post: CampusPost) => {
     setEditingId(post.id);
     setTitle(post.title);
     setBody(post.body);
+    setPlaceId(post.place?.id ?? "");
   };
 
   const persist = async (nextPosts: CampusPost[]) => {
@@ -68,10 +94,14 @@ export default function NewsTab({ mapId }: Props) {
     setSaving(true);
     try {
       const current = readPosts(serverMap?.sceneData);
+      const linked = places.find((p) => p.id === placeId);
+      const place: PostPlace | undefined = linked
+        ? { id: linked.id, kind: linked.kind, name: linked.name }
+        : undefined;
       const next: CampusPost[] = editingId
         ? current.map((p) =>
             p.id === editingId
-              ? { ...p, title: trimmedTitle, body: body.trim() }
+              ? { ...p, title: trimmedTitle, body: body.trim(), place }
               : p,
           )
         : [
@@ -80,6 +110,7 @@ export default function NewsTab({ mapId }: Props) {
               title: trimmedTitle,
               body: body.trim(),
               publishedAt: new Date().toISOString(),
+              place,
             },
             ...current,
           ];
@@ -124,6 +155,30 @@ export default function NewsTab({ mapId }: Props) {
               onChange={(e) => setBody(e.target.value)}
               placeholder="What's happening on campus…"
             />
+          </Field>
+          <Field
+            label="Linked place (optional)"
+            hint="Connect this post to a building, floor or room — it shows as a location on the public page."
+          >
+            <Select
+              value={placeId}
+              onChange={(e) => setPlaceId(e.target.value)}
+            >
+              <option value="">— No place —</option>
+              {(["building", "floor", "room"] as const).map((kind) => {
+                const group = places.filter((p) => p.kind === kind);
+                if (group.length === 0) return null;
+                return (
+                  <optgroup key={kind} label={GROUP_LABEL[kind]}>
+                    {group.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                );
+              })}
+            </Select>
           </Field>
           <div className="flex gap-2">
             <Button
@@ -170,6 +225,11 @@ export default function NewsTab({ mapId }: Props) {
                     <p className="mt-0.5 line-clamp-2 text-xs text-text-secondary">
                       {post.body}
                     </p>
+                  ) : null}
+                  {post.place ? (
+                    <div className="mt-1 text-xs font-medium text-accent">
+                      {post.place.name}
+                    </div>
                   ) : null}
                 </div>
                 <Button

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
@@ -9,6 +9,7 @@ import { toast } from "react-toastify";
 import { Button, Field, IconButton, Input, Panel, Textarea } from "@klorad/design-system";
 import type { Branding, SceneData } from "@klorad/api";
 import MembersPanel from "./MembersPanel";
+import HomePagePanel from "./HomePagePanel";
 
 interface Props {
   orgId: string;
@@ -189,6 +190,10 @@ export default function SettingsTab({ orgId, mapId, map }: Props) {
             {savingBrand ? "Saving…" : "Save branding"}
           </Button>
         </Panel>
+      </Section>
+
+      <Section title="Home page">
+        <HomePagePanel mapId={mapId} />
       </Section>
 
       <Section title="Indoor map">

--- a/apps/campus/app/(public)/campus/[token]/HomeLangToggle.tsx
+++ b/apps/campus/app/(public)/campus/[token]/HomeLangToggle.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { cn } from "@klorad/design-system";
+import { LOCALES, type Locale } from "@/app/lib/i18n-core";
+
+const LABEL: Record<Locale, string> = { en: "EN", el: "ΕΛ" };
+
+/**
+ * EN / ΕΛ switcher for the public campus home page. The home page is
+ * server-rendered and reads `?lang`, so switching is just a link to
+ * the same page with a different `lang` param — no client state.
+ */
+export function HomeLangToggle({
+  token,
+  current,
+}: {
+  token: string;
+  current: Locale;
+}) {
+  return (
+    <div className="inline-flex gap-0.5 rounded-lg bg-surface-2 p-0.5">
+      {LOCALES.map((l) => (
+        <Link
+          key={l}
+          href={`/campus/${token}?lang=${l}`}
+          aria-current={l === current ? "true" : undefined}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+            l === current
+              ? "bg-accent text-accent-contrast"
+              : "text-text-secondary hover:text-text-primary",
+          )}
+        >
+          {LABEL[l]}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/PublicViewerClient.tsx
+++ b/apps/campus/app/(public)/campus/[token]/PublicViewerClient.tsx
@@ -368,6 +368,50 @@ function PublicViewerInner({ mapId }: Props) {
     apiRef.current?.poi.flyTo(room.buildingId);
   };
 
+  // Deep link in — focus the building / floor / room named by the
+  // `?place` URL param once the scene has loaded. A building, floor
+  // or room id is accepted; each resolves to its place + camera fly.
+  const deepLinkedRef = useRef(false);
+  useEffect(() => {
+    if (!sceneReady || deepLinkedRef.current) return;
+    const api = apiRef.current;
+    const placeId = searchParams.get("place");
+    if (!api || !placeId) return;
+    deepLinkedRef.current = true;
+
+    const poi = api.poi.getAll().find((p) => p.id === placeId);
+    if (poi) {
+      goToBuilding(poi);
+      return;
+    }
+    const room = api.rooms.getAll().find((r) => r.id === placeId);
+    if (room) {
+      goToRoom(room);
+      return;
+    }
+    const plan = api.floorPlans.getAll().find((fp) => fp.id === placeId);
+    if (plan) {
+      const building = api.poi.getAll().find((p) => p.id === plan.buildingId);
+      if (building) {
+        goToBuilding(building);
+        // Activate the floor once the fly-to settles (~1800ms).
+        window.setTimeout(() => setActivePlanId(plan.id), 1400);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sceneReady]);
+
+  // Deep link out — mirror the current selection into `?place` so the
+  // address bar is always a shareable link to what's on screen.
+  useEffect(() => {
+    if (!sceneReady) return;
+    const placeId = activeRoomId ?? activePlanId ?? selectedPoiId;
+    const url = new URL(window.location.href);
+    if (placeId) url.searchParams.set("place", placeId);
+    else url.searchParams.delete("place");
+    window.history.replaceState(null, "", url);
+  }, [sceneReady, selectedPoiId, activePlanId, activeRoomId]);
+
   const backFromBuilding = () => {
     setSelectedPoiId(null);
     setActivePlanId(null);

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -20,6 +20,20 @@ function isValidHex(value: string | undefined): value is string {
   return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
 }
 
+/** Location-pin glyph for a post's linked place. */
+function PinIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 2C8 2 5 5 5 9c0 5.5 7 13 7 13s7-7.5 7-13c0-4-3-7-7-7zm0 9.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" />
+    </svg>
+  );
+}
+
 /** Dynamic metadata so shared URLs preview nicely in Slack / WhatsApp / LinkedIn. */
 export async function generateMetadata({
   params,
@@ -84,6 +98,7 @@ export default async function CampusHomePage({
         title: true,
         description: true,
         isPublished: true,
+        thumbnail: true,
         sceneData: true,
       },
     })
@@ -126,22 +141,37 @@ export default async function CampusHomePage({
         </Link>
       </header>
 
-      <section className="px-6 py-12 md:px-10 md:py-20">
-        <h1 className="text-3xl font-semibold tracking-tight text-text-primary md:text-4xl">
-          {displayName}
-        </h1>
-        {map.description ? (
-          <p className="mt-3 max-w-2xl text-base leading-relaxed text-text-secondary">
-            {map.description}
-          </p>
-        ) : null}
-        <Link
-          href={mapHref}
-          className="mt-7 inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
-          style={{ backgroundColor: accent }}
-        >
-          Explore the campus map →
-        </Link>
+      <section
+        className="relative flex min-h-[56vh] items-end overflow-hidden px-6 py-12 md:px-10 md:py-16"
+        style={
+          map.thumbnail
+            ? {
+                backgroundImage: `linear-gradient(to top, rgba(11,17,22,0.9), rgba(11,17,22,0.35)), url("${map.thumbnail}")`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }
+            : {
+                background: `linear-gradient(155deg, ${accent} 0%, #0b1116 100%)`,
+              }
+        }
+      >
+        <div className="max-w-3xl">
+          <h1 className="text-4xl font-semibold tracking-tight text-white md:text-5xl">
+            {displayName}
+          </h1>
+          {map.description ? (
+            <p className="mt-3 max-w-2xl text-base leading-relaxed text-white/85">
+              {map.description}
+            </p>
+          ) : null}
+          <Link
+            href={mapHref}
+            className="mt-7 inline-flex items-center gap-2 rounded-full bg-white px-5 py-2.5 text-sm font-semibold shadow-sm transition-transform hover:scale-[1.02]"
+            style={{ color: accent }}
+          >
+            Explore the campus map →
+          </Link>
+        </div>
       </section>
 
       {events.length > 0 ? (
@@ -198,6 +228,15 @@ export default async function CampusHomePage({
                   <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-text-secondary">
                     {post.body}
                   </p>
+                ) : null}
+                {post.place ? (
+                  <Link
+                    href={mapHref}
+                    className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition-opacity hover:opacity-80"
+                  >
+                    <PinIcon className="h-3 w-3" />
+                    {post.place.name}
+                  </Link>
                 ) : null}
               </article>
             ))}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { formatPostDate, readPosts } from "@/lib/posts";
 import { formatEventWhen, readEventFeeds } from "@/lib/events";
 import { fetchCampusEvents } from "@/lib/events-server";
+import { readHomePage } from "@/lib/home-page";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 
 type Params = Promise<{ token: string }>;
@@ -117,6 +118,16 @@ export default async function CampusHomePage({
   const events = await fetchCampusEvents(readEventFeeds(map.sceneData));
   const mapHref = `/campus/${token}/map`;
 
+  // Home page builder config — every field falls back to a sensible
+  // default (campus name / description / thumbnail).
+  const home = readHomePage(map.sceneData);
+  const heroBg = home.heroImage || map.thumbnail || null;
+  const headline = home.headline || displayName;
+  const tagline = home.tagline || map.description;
+  const ctaLabel = home.ctaLabel || "Explore the campus map";
+  const showEvents = home.showEvents !== false;
+  const showNews = home.showNews !== false;
+
   return (
     <main className="min-h-screen bg-bg">
       <header className="flex items-center justify-between gap-4 px-6 py-4 md:px-10">
@@ -144,9 +155,9 @@ export default async function CampusHomePage({
       <section
         className="relative flex min-h-[56vh] items-end overflow-hidden px-6 py-12 md:px-10 md:py-16"
         style={
-          map.thumbnail
+          heroBg
             ? {
-                backgroundImage: `linear-gradient(to top, rgba(11,17,22,0.9), rgba(11,17,22,0.35)), url("${map.thumbnail}")`,
+                backgroundImage: `linear-gradient(to top, rgba(11,17,22,0.9), rgba(11,17,22,0.35)), url("${heroBg}")`,
                 backgroundSize: "cover",
                 backgroundPosition: "center",
               }
@@ -157,11 +168,11 @@ export default async function CampusHomePage({
       >
         <div className="max-w-3xl">
           <h1 className="text-4xl font-semibold tracking-tight text-white md:text-5xl">
-            {displayName}
+            {headline}
           </h1>
-          {map.description ? (
+          {tagline ? (
             <p className="mt-3 max-w-2xl text-base leading-relaxed text-white/85">
-              {map.description}
+              {tagline}
             </p>
           ) : null}
           <Link
@@ -169,12 +180,12 @@ export default async function CampusHomePage({
             className="mt-7 inline-flex items-center gap-2 rounded-full bg-white px-5 py-2.5 text-sm font-semibold shadow-sm transition-transform hover:scale-[1.02]"
             style={{ color: accent }}
           >
-            Explore the campus map →
+            {ctaLabel} →
           </Link>
         </div>
       </section>
 
-      {events.length > 0 ? (
+      {showEvents && events.length > 0 ? (
         <section className="px-6 pb-4 md:px-10">
           <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
             Upcoming events
@@ -207,6 +218,7 @@ export default async function CampusHomePage({
         </section>
       ) : null}
 
+      {showNews ? (
       <section className="px-6 pb-20 pt-8 md:px-10">
         <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
           News
@@ -247,6 +259,7 @@ export default async function CampusHomePage({
           </p>
         )}
       </section>
+      ) : null}
 
       <footer className="border-t border-solid border-line-soft px-6 py-6 text-center md:px-10">
         <span className="inline-flex items-center gap-1.5 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -253,7 +253,7 @@ export default async function CampusHomePage({
                 ) : null}
                 {post.place ? (
                   <Link
-                    href={mapHref}
+                    href={`${mapHref}?place=${encodeURIComponent(post.place.id)}`}
                     className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition-opacity hover:opacity-80"
                   >
                     <PinIcon className="h-3 w-3" />

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -7,7 +7,9 @@ import { formatPostDate, readPosts } from "@/lib/posts";
 import { formatEventWhen, readEventFeeds } from "@/lib/events";
 import { fetchCampusEvents } from "@/lib/events-server";
 import { readHomePage } from "@/lib/home-page";
+import { detectLocale, pickText, translate } from "@/app/lib/i18n-core";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
+import { HomeLangToggle } from "./HomeLangToggle";
 
 type Params = Promise<{ token: string }>;
 
@@ -84,10 +86,14 @@ export async function generateMetadata({
  */
 export default async function CampusHomePage({
   params,
+  searchParams,
 }: {
   params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { token } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
   const map = await prisma.project
     .findUnique({
@@ -118,18 +124,19 @@ export default async function CampusHomePage({
   const events = await fetchCampusEvents(readEventFeeds(map.sceneData));
   const mapHref = `/campus/${token}/map`;
 
-  // Home page builder config — every field falls back to a sensible
-  // default (campus name / description / thumbnail).
+  // Home page builder config — bilingual fields resolved to the
+  // visitor's locale, each falling back to a sensible default.
   const home = readHomePage(map.sceneData);
   const heroBg = home.heroImage || map.thumbnail || null;
-  const headline = home.headline || displayName;
-  const tagline = home.tagline || map.description;
-  const ctaLabel = home.ctaLabel || "Explore the campus map";
+  const headline = pickText(home.headline, locale) || displayName;
+  const tagline = pickText(home.tagline, locale) || map.description || "";
+  const ctaLabel =
+    pickText(home.ctaLabel, locale) || translate(locale, "home.exploreMap");
   const showEvents = home.showEvents !== false;
   const showNews = home.showNews !== false;
 
   return (
-    <main className="min-h-screen bg-bg">
+    <main lang={locale} className="min-h-screen bg-bg">
       <header className="flex items-center justify-between gap-4 px-6 py-4 md:px-10">
         {branding.logo ? (
           // eslint-disable-next-line @next/next/no-img-element
@@ -143,13 +150,16 @@ export default async function CampusHomePage({
             {displayName}
           </span>
         )}
-        <Link
-          href={mapHref}
-          className="text-sm font-medium transition-opacity hover:opacity-80"
-          style={{ color: accent }}
-        >
-          Open map →
-        </Link>
+        <div className="flex items-center gap-3">
+          <HomeLangToggle token={token} current={locale} />
+          <Link
+            href={mapHref}
+            className="text-sm font-medium transition-opacity hover:opacity-80"
+            style={{ color: accent }}
+          >
+            {translate(locale, "home.openMap")} →
+          </Link>
+        </div>
       </header>
 
       <section
@@ -188,7 +198,7 @@ export default async function CampusHomePage({
       {showEvents && events.length > 0 ? (
         <section className="px-6 pb-4 md:px-10">
           <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
-            Upcoming events
+            {translate(locale, "home.events")}
           </h2>
           <div className="mt-4 space-y-3">
             {events.map((event) => (
@@ -221,7 +231,7 @@ export default async function CampusHomePage({
       {showNews ? (
       <section className="px-6 pb-20 pt-8 md:px-10">
         <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
-          News
+          {translate(locale, "home.news")}
         </h2>
         {posts.length > 0 ? (
           <div className="mt-4 space-y-4">
@@ -234,11 +244,11 @@ export default async function CampusHomePage({
                   {formatPostDate(post.publishedAt)}
                 </time>
                 <h3 className="mt-1 text-lg font-semibold text-text-primary">
-                  {post.title}
+                  {pickText(post.title, locale)}
                 </h3>
-                {post.body ? (
+                {pickText(post.body, locale) ? (
                   <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-text-secondary">
-                    {post.body}
+                    {pickText(post.body, locale)}
                   </p>
                 ) : null}
                 {post.place ? (
@@ -255,7 +265,7 @@ export default async function CampusHomePage({
           </div>
         ) : (
           <p className="mt-4 text-sm text-text-tertiary">
-            No news yet — check back soon.
+            {translate(locale, "home.noNews")}
           </p>
         )}
       </section>

--- a/apps/campus/app/api/uploads/route.ts
+++ b/apps/campus/app/api/uploads/route.ts
@@ -7,6 +7,7 @@ const ALLOWED_PREFIXES = new Set([
   "floor-plans",
   "campus-thumbnails",
   "campus-branding",
+  "campus-hero",
 ]);
 const ALLOWED_TYPES = new Set([
   "image/png",

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -1,0 +1,184 @@
+/**
+ * i18n core — locale type, message catalogue, and pure helpers.
+ *
+ * No `"use client"`: this module is import-safe from server
+ * components (the public home page renders translated strings during
+ * SSR). The React provider / hooks live in `i18n.tsx`, which
+ * re-exports everything here.
+ */
+export type Locale = "en" | "el";
+export const LOCALES: Locale[] = ["en", "el"];
+export const DEFAULT_LOCALE: Locale = "en";
+
+const MESSAGES = {
+  en: {
+    // Generic
+    "common.close": "Close",
+    "common.clear": "Clear",
+    "common.cancel": "Cancel",
+    "common.save": "Save",
+    "common.back": "Back",
+
+    // Toolbar tooltips
+    "toolbar.search": "Search",
+    "toolbar.directions": "Directions",
+    "toolbar.tour": "Tour",
+    "toolbar.layers": "Layers",
+    "toolbar.whereAmI": "Where am I",
+
+    // Search panel
+    "search.title": "Search Campus",
+    "search.placeholder": "Buildings, departments, events…",
+    "search.noResults":
+      'No match for "{query}". Try a building, department, or room.',
+    "search.floor": "Floor",
+    "search.happeningNow": "Happening Now",
+    "search.happeningSoon": "Happening",
+    "search.today": "today at {time}",
+    "search.onDay": "{date} at {time}",
+
+    // Wayfinding
+    "wayfind.title": "Directions",
+    "wayfind.from": "From",
+    "wayfind.to": "To",
+    "wayfind.pickFrom": "Pick a starting point…",
+    "wayfind.pickTo": "Pick a destination…",
+    "wayfind.myLocation": "My location",
+    "wayfind.locating": "Locating…",
+    "wayfind.locationDenied": "Location access denied.",
+    "wayfind.locationUnsupported": "Geolocation not supported on this device.",
+    "wayfind.mode.standard": "Standard",
+    "wayfind.mode.stepFree": "Step-free",
+    "wayfind.loading": "Finding route…",
+    "wayfind.duration": "Duration",
+    "wayfind.distance": "Distance",
+    "wayfind.stepFreeCaveat":
+      "Step-free routing uses the walking network. Campus-specific stair and elevator data can be added in the Studio to refine this route.",
+
+    // Tour
+    "tour.title": "Campus Tour",
+
+    // Branded header default alt
+    "branding.logoAlt": "Logo",
+
+    // Public home page
+    "home.openMap": "Open map",
+    "home.exploreMap": "Explore the campus map",
+    "home.events": "Upcoming events",
+    "home.news": "News",
+    "home.noNews": "No news yet — check back soon.",
+    "home.poweredBy": "Powered by Klorad",
+  },
+  el: {
+    // Generic
+    "common.close": "Κλείσιμο",
+    "common.clear": "Καθαρισμός",
+    "common.cancel": "Άκυρο",
+    "common.save": "Αποθήκευση",
+    "common.back": "Πίσω",
+
+    // Toolbar tooltips
+    "toolbar.search": "Αναζήτηση",
+    "toolbar.directions": "Οδηγίες",
+    "toolbar.tour": "Ξενάγηση",
+    "toolbar.layers": "Επίπεδα",
+    "toolbar.whereAmI": "Η τοποθεσία μου",
+
+    // Search panel
+    "search.title": "Αναζήτηση στην Πανεπιστημιούπολη",
+    "search.placeholder": "Κτίρια, τμήματα, εκδηλώσεις…",
+    "search.noResults":
+      'Δεν βρέθηκε "{query}". Δοκιμάστε ένα κτίριο, τμήμα ή αίθουσα.',
+    "search.floor": "Όροφος",
+    "search.happeningNow": "Γίνεται Τώρα",
+    "search.happeningSoon": "Πρόγραμμα",
+    "search.today": "σήμερα στις {time}",
+    "search.onDay": "{date} στις {time}",
+
+    // Wayfinding
+    "wayfind.title": "Οδηγίες",
+    "wayfind.from": "Από",
+    "wayfind.to": "Προς",
+    "wayfind.pickFrom": "Επιλέξτε αφετηρία…",
+    "wayfind.pickTo": "Επιλέξτε προορισμό…",
+    "wayfind.myLocation": "Η τοποθεσία μου",
+    "wayfind.locating": "Εντοπισμός…",
+    "wayfind.locationDenied": "Δεν επιτρέπεται η πρόσβαση στην τοποθεσία.",
+    "wayfind.locationUnsupported": "Ο εντοπισμός τοποθεσίας δεν υποστηρίζεται.",
+    "wayfind.mode.standard": "Κανονικό",
+    "wayfind.mode.stepFree": "Προσβάσιμο",
+    "wayfind.loading": "Υπολογισμός διαδρομής…",
+    "wayfind.duration": "Διάρκεια",
+    "wayfind.distance": "Απόσταση",
+    "wayfind.stepFreeCaveat":
+      "Η προσβάσιμη διαδρομή χρησιμοποιεί το δίκτυο πεζών. Δεδομένα για σκάλες και ανελκυστήρες μπορούν να προστεθούν στο Studio για ακρίβεια.",
+
+    // Tour
+    "tour.title": "Ξενάγηση Πανεπιστημιούπολης",
+
+    // Branded header default alt
+    "branding.logoAlt": "Λογότυπο",
+
+    // Public home page
+    "home.openMap": "Άνοιγμα χάρτη",
+    "home.exploreMap": "Εξερευνήστε τον χάρτη",
+    "home.events": "Προσεχείς εκδηλώσεις",
+    "home.news": "Νέα",
+    "home.noNews": "Δεν υπάρχουν νέα ακόμη — ελάτε σύντομα ξανά.",
+    "home.poweredBy": "Με την υποστήριξη του Klorad",
+  },
+} as const;
+
+export type MessageKey = keyof typeof MESSAGES.en;
+
+/**
+ * URL-only locale detection. Browser-side preferences (localStorage,
+ * navigator.language) are intentionally NOT consulted here — they make
+ * the SSR pass disagree with the first client render and trigger React
+ * hydration warnings.
+ */
+export function detectLocale(urlParam?: string | null): Locale {
+  if (urlParam === "el" || urlParam === "en") return urlParam;
+  return DEFAULT_LOCALE;
+}
+
+/** Message lookup with {placeholder} substitution. */
+export function translate(
+  locale: Locale,
+  key: MessageKey,
+  vars?: Record<string, string | number>,
+): string {
+  const raw = MESSAGES[locale]?.[key] ?? MESSAGES[DEFAULT_LOCALE][key] ?? key;
+  if (!vars) return raw;
+  return Object.entries(vars).reduce(
+    (acc, [k, v]) => acc.replace(new RegExp(`\\{${k}\\}`, "g"), String(v)),
+    raw,
+  );
+}
+
+/**
+ * Campus-authored text in both languages. Stored on news posts, home
+ * page config, etc. A plain `string` is also accepted — legacy
+ * single-language content reads fine via {@link pickText}.
+ */
+export interface LocalizedText {
+  en?: string;
+  el?: string;
+}
+
+/** A field that is either localized text or a legacy plain string. */
+export type Localizable = string | LocalizedText;
+
+/**
+ * Resolve a {@link Localizable} for a locale: the requested language,
+ * else the other language, else empty. So a post written only in
+ * Greek still shows (its Greek) to an English visitor.
+ */
+export function pickText(
+  value: Localizable | null | undefined,
+  locale: Locale,
+): string {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  return value[locale] || value.en || value.el || "";
+}

--- a/apps/campus/app/lib/i18n.tsx
+++ b/apps/campus/app/lib/i18n.tsx
@@ -1,130 +1,21 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import {
+  DEFAULT_LOCALE,
+  type Locale,
+  type MessageKey,
+  translate,
+} from "./i18n-core";
 
-export type Locale = "en" | "el";
-export const LOCALES: Locale[] = ["en", "el"];
-export const DEFAULT_LOCALE: Locale = "en";
+// Re-export the server-safe core so existing `@/app/lib/i18n` imports
+// (the viewer and its components) keep working unchanged.
+export * from "./i18n-core";
 
 const STORAGE_KEY = "campus:locale";
 
-const MESSAGES = {
-  en: {
-    // Generic
-    "common.close": "Close",
-    "common.clear": "Clear",
-    "common.cancel": "Cancel",
-    "common.save": "Save",
-    "common.back": "Back",
-
-    // Toolbar tooltips
-    "toolbar.search": "Search",
-    "toolbar.directions": "Directions",
-    "toolbar.tour": "Tour",
-    "toolbar.layers": "Layers",
-    "toolbar.whereAmI": "Where am I",
-
-    // Search panel
-    "search.title": "Search Campus",
-    "search.placeholder": "Buildings, departments, events…",
-    "search.noResults": 'No match for "{query}". Try a building, department, or room.',
-    "search.floor": "Floor",
-    "search.happeningNow": "Happening Now",
-    "search.happeningSoon": "Happening",
-    "search.today": "today at {time}",
-    "search.onDay": "{date} at {time}",
-
-    // Wayfinding
-    "wayfind.title": "Directions",
-    "wayfind.from": "From",
-    "wayfind.to": "To",
-    "wayfind.pickFrom": "Pick a starting point…",
-    "wayfind.pickTo": "Pick a destination…",
-    "wayfind.myLocation": "My location",
-    "wayfind.locating": "Locating…",
-    "wayfind.locationDenied": "Location access denied.",
-    "wayfind.locationUnsupported": "Geolocation not supported on this device.",
-    "wayfind.mode.standard": "Standard",
-    "wayfind.mode.stepFree": "Step-free",
-    "wayfind.loading": "Finding route…",
-    "wayfind.duration": "Duration",
-    "wayfind.distance": "Distance",
-    "wayfind.stepFreeCaveat":
-      "Step-free routing uses the walking network. Campus-specific stair and elevator data can be added in the Studio to refine this route.",
-
-    // Tour
-    "tour.title": "Campus Tour",
-
-    // Branded header default alt
-    "branding.logoAlt": "Logo",
-  },
-  el: {
-    // Generic
-    "common.close": "Κλείσιμο",
-    "common.clear": "Καθαρισμός",
-    "common.cancel": "Άκυρο",
-    "common.save": "Αποθήκευση",
-    "common.back": "Πίσω",
-
-    // Toolbar tooltips
-    "toolbar.search": "Αναζήτηση",
-    "toolbar.directions": "Οδηγίες",
-    "toolbar.tour": "Ξενάγηση",
-    "toolbar.layers": "Επίπεδα",
-    "toolbar.whereAmI": "Η τοποθεσία μου",
-
-    // Search panel
-    "search.title": "Αναζήτηση στην Πανεπιστημιούπολη",
-    "search.placeholder": "Κτίρια, τμήματα, εκδηλώσεις…",
-    "search.noResults":
-      'Δεν βρέθηκε "{query}". Δοκιμάστε ένα κτίριο, τμήμα ή αίθουσα.',
-    "search.floor": "Όροφος",
-    "search.happeningNow": "Γίνεται Τώρα",
-    "search.happeningSoon": "Πρόγραμμα",
-    "search.today": "σήμερα στις {time}",
-    "search.onDay": "{date} στις {time}",
-
-    // Wayfinding
-    "wayfind.title": "Οδηγίες",
-    "wayfind.from": "Από",
-    "wayfind.to": "Προς",
-    "wayfind.pickFrom": "Επιλέξτε αφετηρία…",
-    "wayfind.pickTo": "Επιλέξτε προορισμό…",
-    "wayfind.myLocation": "Η τοποθεσία μου",
-    "wayfind.locating": "Εντοπισμός…",
-    "wayfind.locationDenied": "Δεν επιτρέπεται η πρόσβαση στην τοποθεσία.",
-    "wayfind.locationUnsupported": "Ο εντοπισμός τοποθεσίας δεν υποστηρίζεται.",
-    "wayfind.mode.standard": "Κανονικό",
-    "wayfind.mode.stepFree": "Προσβάσιμο",
-    "wayfind.loading": "Υπολογισμός διαδρομής…",
-    "wayfind.duration": "Διάρκεια",
-    "wayfind.distance": "Απόσταση",
-    "wayfind.stepFreeCaveat":
-      "Η προσβάσιμη διαδρομή χρησιμοποιεί το δίκτυο πεζών. Δεδομένα για σκάλες και ανελκυστήρες μπορούν να προστεθούν στο Studio για ακρίβεια.",
-
-    // Tour
-    "tour.title": "Ξενάγηση Πανεπιστημιούπολης",
-
-    // Branded header default alt
-    "branding.logoAlt": "Λογότυπο",
-  },
-} as const;
-
-export type MessageKey = keyof typeof MESSAGES.en;
-
 const LocaleContext = createContext<Locale>(DEFAULT_LOCALE);
-
-/**
- * URL-only locale detection. Browser-side preferences (localStorage,
- * navigator.language) are intentionally NOT consulted here — they make
- * the SSR pass disagree with the first client render and trigger React
- * hydration warnings. The provider applies those preferences via
- * useEffect after mount instead.
- */
-export function detectLocale(urlParam?: string | null): Locale {
-  if (urlParam === "el" || urlParam === "en") return urlParam;
-  return DEFAULT_LOCALE;
-}
+const LocaleSetterContext = createContext<(l: Locale) => void>(() => {});
 
 export function LocaleProvider({
   initial,
@@ -164,8 +55,6 @@ export function LocaleProvider({
   );
 }
 
-const LocaleSetterContext = createContext<(l: Locale) => void>(() => {});
-
 export function useLocale(): Locale {
   return useContext(LocaleContext);
 }
@@ -174,22 +63,11 @@ export function useSetLocale(): (l: Locale) => void {
   return useContext(LocaleSetterContext);
 }
 
-/** Message lookup with {placeholder} substitution. */
-export function translate(
-  locale: Locale,
-  key: MessageKey,
-  vars?: Record<string, string | number>
-): string {
-  const raw = MESSAGES[locale]?.[key] ?? MESSAGES[DEFAULT_LOCALE][key] ?? key;
-  if (!vars) return raw;
-  return Object.entries(vars).reduce(
-    (acc, [k, v]) => acc.replace(new RegExp(`\\{${k}\\}`, "g"), String(v)),
-    raw
-  );
-}
-
 /** Hook form — returns a bound translator for the current locale. */
-export function useT(): (key: MessageKey, vars?: Record<string, string | number>) => string {
+export function useT(): (
+  key: MessageKey,
+  vars?: Record<string, string | number>,
+) => string {
   const locale = useLocale();
   return useMemo(() => (k, vars) => translate(locale, k, vars), [locale]);
 }

--- a/apps/campus/lib/home-page.ts
+++ b/apps/campus/lib/home-page.ts
@@ -1,0 +1,31 @@
+/**
+ * Public home page configuration.
+ *
+ * Stored in the campus `sceneData` (`sceneData.homePage`) — the same
+ * store branding, posts and event feeds use. Every field is optional:
+ * the public home page falls back to the campus name, description and
+ * thumbnail when a field is unset, so an unconfigured campus still
+ * renders a sensible page.
+ */
+export interface HomePageConfig {
+  /** Uploaded hero banner image URL. Falls back to the campus thumbnail. */
+  heroImage?: string;
+  /** Hero headline. Falls back to the campus (branding) name. */
+  headline?: string;
+  /** Hero tagline. Falls back to the campus description. */
+  tagline?: string;
+  /** Label of the map CTA. Falls back to "Explore the campus map". */
+  ctaLabel?: string;
+  /** Show the upcoming-events section. Defaults to true. */
+  showEvents?: boolean;
+  /** Show the news section. Defaults to true. */
+  showNews?: boolean;
+}
+
+/** Read the home page config from a campus's `sceneData`. */
+export function readHomePage(sceneData: unknown): HomePageConfig {
+  const raw = (sceneData as { homePage?: unknown } | null | undefined)
+    ?.homePage;
+  if (!raw || typeof raw !== "object") return {};
+  return raw as HomePageConfig;
+}

--- a/apps/campus/lib/home-page.ts
+++ b/apps/campus/lib/home-page.ts
@@ -7,15 +7,17 @@
  * thumbnail when a field is unset, so an unconfigured campus still
  * renders a sensible page.
  */
+import type { Localizable } from "@/app/lib/i18n-core";
+
 export interface HomePageConfig {
   /** Uploaded hero banner image URL. Falls back to the campus thumbnail. */
   heroImage?: string;
-  /** Hero headline. Falls back to the campus (branding) name. */
-  headline?: string;
-  /** Hero tagline. Falls back to the campus description. */
-  tagline?: string;
-  /** Label of the map CTA. Falls back to "Explore the campus map". */
-  ctaLabel?: string;
+  /** Hero headline (bilingual). Falls back to the campus name. */
+  headline?: Localizable;
+  /** Hero tagline (bilingual). Falls back to the campus description. */
+  tagline?: Localizable;
+  /** Map CTA label (bilingual). Falls back to "Explore the campus map". */
+  ctaLabel?: Localizable;
   /** Show the upcoming-events section. Defaults to true. */
   showEvents?: boolean;
   /** Show the news section. Defaults to true. */

--- a/apps/campus/lib/places.ts
+++ b/apps/campus/lib/places.ts
@@ -1,0 +1,59 @@
+import { createSceneAPI } from "@klorad/api";
+import type { CampusAPI } from "@klorad/api";
+import type { PostPlace } from "./posts";
+
+/**
+ * Campus places — the buildings, floors and rooms a news post can be
+ * connected to. Read from the campus `sceneData` via the campus API
+ * (the canonical accessor, so this needn't know the raw JSON shape).
+ */
+export interface PlaceOption extends PostPlace {
+  /** Picker label — floors / rooms include their building for context. */
+  label: string;
+}
+
+/** Extract a campus's buildings, floors and rooms from its sceneData. */
+export function readCampusPlaces(sceneData: unknown): PlaceOption[] {
+  let api: CampusAPI;
+  try {
+    api = createSceneAPI("mapbox", "campus") as CampusAPI;
+    api.load((sceneData ?? {}) as Parameters<CampusAPI["load"]>[0]);
+  } catch {
+    return [];
+  }
+
+  // Buildings are POIs carrying a `linkedBuilding`.
+  const buildings = api.poi.getAll().filter((p) => p.linkedBuilding);
+  const buildingName = new Map(
+    buildings.map((b) => [b.id, b.name || "Building"]),
+  );
+  const places: PlaceOption[] = [];
+
+  for (const b of buildings) {
+    const name = b.name || "Building";
+    places.push({ id: b.id, kind: "building", name, label: name });
+  }
+  for (const f of api.floorPlans.getAll()) {
+    const name =
+      f.name ||
+      (typeof f.floor === "number" ? `Floor ${f.floor}` : "Floor");
+    const ctx = f.buildingId ? buildingName.get(f.buildingId) : undefined;
+    places.push({
+      id: f.id,
+      kind: "floor",
+      name,
+      label: ctx ? `${name} — ${ctx}` : name,
+    });
+  }
+  for (const r of api.rooms.getAll()) {
+    const name = r.name || "Room";
+    const ctx = r.buildingId ? buildingName.get(r.buildingId) : undefined;
+    places.push({
+      id: r.id,
+      kind: "room",
+      name,
+      label: ctx ? `${name} — ${ctx}` : name,
+    });
+  }
+  return places;
+}

--- a/apps/campus/lib/posts.ts
+++ b/apps/campus/lib/posts.ts
@@ -6,6 +6,8 @@
  * needs no schema migration. If news grows (pagination, scheduling,
  * per-post media) this graduates to its own Prisma model.
  */
+import type { Localizable } from "@/app/lib/i18n-core";
+
 export type PlaceKind = "building" | "floor" | "room";
 
 /**
@@ -20,8 +22,10 @@ export interface PostPlace {
 
 export interface CampusPost {
   id: string;
-  title: string;
-  body: string;
+  /** Title — bilingual; legacy posts may carry a plain string. */
+  title: Localizable;
+  /** Body — bilingual; legacy posts may carry a plain string. */
+  body: Localizable;
   /** ISO timestamp. */
   publishedAt: string;
   /** Optional building / floor / room this post is about. */
@@ -33,7 +37,7 @@ export function readPosts(sceneData: unknown): CampusPost[] {
   const raw = (sceneData as { posts?: unknown } | null | undefined)?.posts;
   if (!Array.isArray(raw)) return [];
   return (raw as CampusPost[])
-    .filter((p): p is CampusPost => Boolean(p) && typeof p.title === "string")
+    .filter((p): p is CampusPost => Boolean(p) && p.title != null)
     .slice()
     .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt));
 }

--- a/apps/campus/lib/posts.ts
+++ b/apps/campus/lib/posts.ts
@@ -6,12 +6,26 @@
  * needs no schema migration. If news grows (pagination, scheduling,
  * per-post media) this graduates to its own Prisma model.
  */
+export type PlaceKind = "building" | "floor" | "room";
+
+/**
+ * A campus place a post is connected to. The `name` is denormalised
+ * so the public page can show it without resolving the scene graph.
+ */
+export interface PostPlace {
+  id: string;
+  kind: PlaceKind;
+  name: string;
+}
+
 export interface CampusPost {
   id: string;
   title: string;
   body: string;
   /** ISO timestamp. */
   publishedAt: string;
+  /** Optional building / floor / room this post is about. */
+  place?: PostPlace;
 }
 
 /** Read a campus's news posts from its `sceneData`, newest first. */


### PR DESCRIPTION
## Summary

Polishes the public campus home page (`/campus/[token]`) — a real hero, and news connected to campus places.

## Hero banner

The hero is now a proper banner: the campus **thumbnail** as a full-bleed background (with a legibility gradient over it), or an accent → dark gradient when no thumbnail is set. Large campus name, description, and a white CTA into the map.

## Georeferenced news

News posts can now be **connected to a place** — a building, floor, or room:

- **`lib/places.ts`** — `readCampusPlaces()` extracts the campus's buildings / floors / rooms from the scene via the campus API (no raw-JSON guessing); floors and rooms carry their building for context.
- **News tab** — a "Linked place" picker, grouped by Buildings / Floors / Rooms. The chosen place (id, kind, and a denormalised name) is stored on the post (`CampusPost.place`).
- **Public home** — a post with a place shows a location pill linking to the map.

## Deferred

- Deep-linking the place pill to *focus* that building/floor/room in the map viewer (`/campus/[token]/map?place=…`) — the pill currently opens the map; focus-from-URL is a clean follow-up.

## Testing

`tsc --noEmit` clean; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)