### PR TITLE
feat(campus): floor-plan design mode

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/NewsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "react-toastify";
@@ -18,7 +18,9 @@ import {
   formatPostDate,
   readPosts,
 } from "@/lib/posts";
-import { readCampusPlaces } from "@/lib/places";
+import { type PlaceOption, readCampusPlaces } from "@/lib/places";
+import { venueForIndoorMap } from "@/lib/mappedin/config";
+import { loadMappedinSpaces } from "@/lib/mappedin/spaces";
 import {
   type Localizable,
   type Locale,
@@ -74,10 +76,35 @@ export default function NewsTab({ mapId }: Props) {
     fetcher,
   );
   const posts = readPosts(serverMap?.sceneData);
-  const places = useMemo(
+  // The picker offers the campus's *real* indoor: MappedIn spaces
+  // when the campus has a MappedIn venue, the workbench buildings /
+  // floors / rooms otherwise.
+  const campusPlaces = useMemo(
     () => readCampusPlaces(serverMap?.sceneData),
     [serverMap],
   );
+  const indoorMapId = (
+    serverMap?.sceneData as { indoorMapId?: string } | undefined
+  )?.indoorMapId;
+  const [mappedinPlaces, setMappedinPlaces] = useState<PlaceOption[]>([]);
+  useEffect(() => {
+    if (!indoorMapId) {
+      setMappedinPlaces([]);
+      return;
+    }
+    let cancelled = false;
+    void loadMappedinSpaces(venueForIndoorMap(indoorMapId))
+      .then((sp) => {
+        if (!cancelled) setMappedinPlaces(sp);
+      })
+      .catch(() => {
+        if (!cancelled) setMappedinPlaces([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [indoorMapId]);
+  const places = indoorMapId ? mappedinPlaces : campusPlaces;
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [lang, setLang] = useState<Locale>("en");
@@ -123,7 +150,12 @@ export default function NewsTab({ mapId }: Props) {
       const current = readPosts(serverMap?.sceneData);
       const linked = places.find((p) => p.id === placeId);
       const place: PostPlace | undefined = linked
-        ? { id: linked.id, kind: linked.kind, name: linked.name }
+        ? {
+            id: linked.id,
+            kind: linked.kind,
+            name: linked.name,
+            source: linked.source,
+          }
         : undefined;
       const titleValue = toLocalized(title);
       const bodyValue = toLocalized(body);

--- a/apps/campus/app/(public)/campus/[token]/indoor/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/indoor/page.tsx
@@ -1,0 +1,59 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { venueForIndoorMap } from "@/lib/mappedin/config";
+import { MappedinViewer } from "@/lib/mappedin/MappedinViewer";
+import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
+
+type Params = Promise<{ token: string }>;
+type Search = Promise<{ space?: string | string[] }>;
+
+/**
+ * `/campus/[token]/indoor` — the campus's public MappedIn viewer.
+ *
+ * The campus-specific counterpart to the account-wide `/indoor`
+ * route: it resolves this campus's own `indoorMapId`. A `?space=`
+ * param deep-links straight to a room — news posts linked to a
+ * MappedIn space point here.
+ */
+export default async function CampusIndoorPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Search;
+}) {
+  const { token } = await params;
+  const sp = await searchParams;
+  const focusSpaceId = typeof sp.space === "string" ? sp.space : undefined;
+
+  const map = await prisma.project
+    .findUnique({
+      where: { id: token },
+      select: { id: true, title: true, isPublished: true, sceneData: true },
+    })
+    .catch(() => null);
+
+  if (!map) notFound();
+  if (!map.isPublished) return <NotPublishedPlaceholder name={map.title} />;
+
+  const indoorMapId = (map.sceneData as { indoorMapId?: string } | null)
+    ?.indoorMapId;
+  if (!indoorMapId) {
+    return (
+      <main className="flex h-screen items-center justify-center bg-bg p-8 text-center">
+        <p className="text-sm text-text-tertiary">
+          This campus doesn’t have an indoor map yet.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main data-mappedin className="h-screen w-full">
+      <MappedinViewer
+        venue={venueForIndoorMap(indoorMapId)}
+        focusSpaceId={focusSpaceId}
+      />
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -253,7 +253,11 @@ export default async function CampusHomePage({
                 ) : null}
                 {post.place ? (
                   <Link
-                    href={`${mapHref}?place=${encodeURIComponent(post.place.id)}`}
+                    href={
+                      post.place.source === "mappedin"
+                        ? `/campus/${token}/indoor?space=${encodeURIComponent(post.place.id)}`
+                        : `${mapHref}?place=${encodeURIComponent(post.place.id)}`
+                    }
                     className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition-opacity hover:opacity-80"
                   >
                     <PinIcon className="h-3 w-3" />

--- a/apps/campus/app/hooks/useMapboxDrawnBuildingsLayer.ts
+++ b/apps/campus/app/hooks/useMapboxDrawnBuildingsLayer.ts
@@ -105,6 +105,8 @@ interface Options {
   onSelect?: (poiId: string) => void;
   /** When false, click + hover are ignored (e.g. during polygon draw). */
   clickEnabled?: boolean;
+  /** Hide every building shell — floor-plan design mode. */
+  hidden?: boolean;
 }
 
 /**
@@ -138,6 +140,16 @@ export function useMapboxDrawnBuildingsLayer(
   useEffect(() => {
     clickEnabledRef.current = clickEnabled;
   }, [clickEnabled]);
+
+  // Floor-plan design mode hides every shell so the user draws on the
+  // bare ground; visibility flips back on exit.
+  useEffect(() => {
+    if (!map) return;
+    const vis = opts.hidden ? "none" : "visible";
+    for (const id of [FILL_LAYER_ID, XRAY_LAYER_ID, OUTLINE_LAYER_ID]) {
+      if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", vis);
+    }
+  }, [map, opts.hidden]);
 
   // Mount layers once per map.
   useEffect(() => {

--- a/apps/campus/app/hooks/useMapboxWallsLayer.ts
+++ b/apps/campus/app/hooks/useMapboxWallsLayer.ts
@@ -52,13 +52,19 @@ function segmentRect(
  * Each wall segment is buffered to its thickness and extruded from
  * the floor's elevation; pass the floor index the walls belong to.
  */
-export function useMapboxWallsLayer(walls: Wall[], floor: number) {
+export function useMapboxWallsLayer(
+  walls: Wall[],
+  floor: number,
+  flat = false,
+) {
   const map = useSceneStore((s) => s.mapboxMap as MapboxMap | null);
 
   useEffect(() => {
     if (!map) return;
 
-    const base = floor * FLOOR_HEIGHT_M + SLAB_OFFSET_M;
+    // In floor-plan design mode walls sit on the ground; otherwise on
+    // the floor's slab.
+    const base = flat ? 0 : floor * FLOOR_HEIGHT_M + SLAB_OFFSET_M;
     const features: GeoJSON.Feature[] = [];
     for (const wall of walls) {
       const thickness = wall.thickness ?? 0.15;
@@ -114,5 +120,5 @@ export function useMapboxWallsLayer(walls: Wall[], floor: number) {
         /* style already torn down */
       }
     };
-  }, [map, walls, floor]);
+  }, [map, walls, floor, flat]);
 }

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -21,7 +21,14 @@ import { FloorControls, type FloorOption } from "./FloorControls";
  * touches the server bundle and stays out of the main chunk. The
  * `import type` above is erased at build, so it costs nothing.
  */
-export function MappedinViewer({ venue }: { venue: MappedinVenue }) {
+export function MappedinViewer({
+  venue,
+  focusSpaceId,
+}: {
+  venue: MappedinVenue;
+  /** A space id to select + fly to once the venue has loaded. */
+  focusSpaceId?: string;
+}) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapViewRef = useRef<MapView | null>(null);
   const mapDataRef = useRef<MapData | null>(null);
@@ -261,6 +268,15 @@ export function MappedinViewer({ venue }: { venue: MappedinVenue }) {
     },
     [highlightSpace, syncFloors],
   );
+
+  // Deep link — focus the space named by `focusSpaceId` once the
+  // venue has loaded (a news post links straight to its room).
+  const focusDoneRef = useRef(false);
+  useEffect(() => {
+    if (status !== "ready" || focusDoneRef.current || !focusSpaceId) return;
+    focusDoneRef.current = true;
+    void handleSearchSelect(focusSpaceId);
+  }, [status, focusSpaceId, handleSearchSelect]);
 
   const handleSelectFloor = useCallback(
     async (floorId: string) => {

--- a/apps/campus/lib/mappedin/spaces.ts
+++ b/apps/campus/lib/mappedin/spaces.ts
@@ -1,0 +1,35 @@
+import type { MappedinVenue } from "./config";
+import type { PlaceOption } from "@/lib/places";
+
+/**
+ * Load a MappedIn venue's named spaces as place options for the news
+ * linked-place picker. The SDK is dynamically imported so it never
+ * reaches the server bundle.
+ *
+ * Used when a campus's indoor map is MappedIn — then the rooms a post
+ * should link to are MappedIn spaces, not the workbench scene.
+ */
+export async function loadMappedinSpaces(
+  venue: MappedinVenue,
+): Promise<PlaceOption[]> {
+  const { getMapData } = await import("@mappedin/mappedin-js");
+  const mapData = await getMapData({
+    key: venue.key,
+    secret: venue.secret,
+    mapId: venue.mapId,
+  });
+  return mapData
+    .getByType("space")
+    .filter((s) => s.name)
+    .map((s) => {
+      const name = s.name as string;
+      return {
+        id: s.id,
+        kind: "room" as const,
+        name,
+        source: "mappedin" as const,
+        label: name,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/campus/lib/posts.ts
+++ b/apps/campus/lib/posts.ts
@@ -18,6 +18,12 @@ export interface PostPlace {
   id: string;
   kind: PlaceKind;
   name: string;
+  /**
+   * Which map the `id` belongs to — the workbench campus scene or the
+   * campus's MappedIn venue. Absent on legacy posts → treated as
+   * "campus".
+   */
+  source?: "campus" | "mappedin";
 }
 
 export interface CampusPost {

--- a/apps/campus/lib/workbench/floor-design-store.ts
+++ b/apps/campus/lib/workbench/floor-design-store.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+/**
+ * Floor-plan design mode.
+ *
+ * While a `designPlanId` is set, the workbench hides every building
+ * shell and flattens that floor's content to ground level — so the
+ * user designs the plan flat (placing a reference image, drawing
+ * walls), then exits and the floor lifts back to its real elevation.
+ * Only the render height changes; the geometry (lng/lat) never moves.
+ */
+interface FloorDesignStore {
+  /** The floor plan being designed, or null when not in design mode. */
+  designPlanId: string | null;
+  enter(planId: string): void;
+  exit(): void;
+}
+
+export const useFloorDesignStore = create<FloorDesignStore>((set) => ({
+  designPlanId: null,
+  enter(planId) {
+    set({ designPlanId: planId });
+  },
+  exit() {
+    set({ designPlanId: null });
+  },
+}));

--- a/apps/campus/lib/workbench/views/map.tsx
+++ b/apps/campus/lib/workbench/views/map.tsx
@@ -16,6 +16,7 @@ import { useMapboxWallsLayer } from "@/app/hooks/useMapboxWallsLayer";
 import { useCampusLabelDefaults } from "@/app/hooks/useCampusLabelDefaults";
 import { placementKind, usePlacementStore } from "../placement-store";
 import { snapWallPoint } from "../wall-snapping";
+import { useFloorDesignStore } from "../floor-design-store";
 
 const MapboxViewer = dynamic(
   () =>
@@ -56,6 +57,7 @@ function MapViewComponent({ ctx }: ViewProps) {
   );
   const selectedId = ctx.selection.focusedId;
   const placementMode = usePlacementStore((s) => s.active);
+  const designPlanId = useFloorDesignStore((s) => s.designPlanId);
 
   // Resolve the focused selection into the things the indoor layers
   // care about — which building POI is in focus, and which floor (if
@@ -166,13 +168,15 @@ function MapViewComponent({ ctx }: ViewProps) {
       ctx.setSelection({ ids: new Set([id]), focusedId: id });
     },
     // Suppress building clicks while a placement is in progress.
-    clickEnabled: !placementMode,
+    clickEnabled: !placementMode && !designPlanId,
+    // Floor-plan design mode hides every shell.
+    hidden: !!designPlanId,
   });
 
   // Floor slabs — the horizontal plates between floors. Clicking one
   // selects the matching floor plan, which becomes the new focused
   // entity and drives `activeFloor` above.
-  useMapboxFloorSlabsLayer(pois, allFloorPlans, allRooms, {
+  useMapboxFloorSlabsLayer(pois, designPlanId ? [] : allFloorPlans, allRooms, {
     activePlanId: activeFloor != null ? selectedId : null,
     selectedBuildingPoiId: selectedBuildingId,
     onSelect: (_buildingId, _floor, planId) => {
@@ -184,7 +188,7 @@ function MapViewComponent({ ctx }: ViewProps) {
   // Rooms — the 3D extruded volumes inside the building, rendered with
   // the X-ray-friendly opacity. Scoped to the selected building so we
   // don't paint every room in every building all at once.
-  useMapboxRoomsLayer(roomsForSelection, {
+  useMapboxRoomsLayer(designPlanId ? [] : roomsForSelection, {
     activeFloor,
     onSelect: (id) => {
       if (usePlacementStore.getState().active) return;
@@ -206,6 +210,7 @@ function MapViewComponent({ ctx }: ViewProps) {
   useMapboxWallsLayer(
     activeFloorPlan?.walls ?? [],
     activeFloorPlan?.floor ?? 0,
+    !!designPlanId,
   );
 
   // Force basemap labels off whenever the scene is mounted (Mapbox's
@@ -262,8 +267,23 @@ function MapViewComponent({ ctx }: ViewProps) {
           }
         },
       },
+      {
+        id: "floor.design",
+        label: designPlanId ? "Done" : "Design floor",
+        icon: DesignFloorIcon,
+        active: !!designPlanId,
+        disabled: !designPlanId && !focusedPlanId,
+        hint: "Select a floor first",
+        onSelect: () => {
+          if (designPlanId) {
+            useFloorDesignStore.getState().exit();
+          } else if (focusedPlanId) {
+            useFloorDesignStore.getState().enter(focusedPlanId);
+          }
+        },
+      },
     ];
-  }, [allFloorPlans, selectedId, placementMode, ctx]);
+  }, [allFloorPlans, selectedId, placementMode, designPlanId, ctx]);
 
   useEffect(() => {
     if (!placementMode) return;
@@ -423,6 +443,26 @@ function PlacementBanner({ mode }: { mode: string }) {
         </button>
       </div>
     </div>
+  );
+}
+
+function DesignFloorIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <rect x="3" y="3" width="18" height="18" rx="1" />
+      <path d="M3 10 L14 10 L14 21 M14 10 L14 3" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## Summary

A workbench mode for designing an indoor floor **flat on the ground**, then levelling it back up — the first slice of the floor-plan design workflow.

## Behaviour

**Enter** via the new **"Design floor"** scene tool (with a floor in focus):
- every building shell, floor slab and room is hidden — the user works on the bare Mapbox ground;
- that floor's walls flatten to ground level (z=0), so they can be drawn / traced flat.

**Exit** via **"Done"**:
- the building returns and the floor's walls lift back to their real elevation.

Only the *render height* changes — wall geometry (lng/lat) never moves, so "levelling up" is automatic and lossless.

## Changes

- `floor-design-store.ts` — a small zustand store holding `designPlanId`.
- `useMapboxWallsLayer` — a `flat` mode (base at z=0).
- `useMapboxDrawnBuildingsLayer` — a `hidden` option (visibility off).
- `map.tsx` — the scene tool, and design-mode-aware layer inputs.

## Next slice

Upload a floor-plan **image** and interactively **move / rotate / scale** it on the ground (writing `FloorPlan.coordinates`) as a tracing template — the bigger piece of the workflow.

## Testing

`tsc --noEmit` clean; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)