### PR TITLE
feat(campus): production-push — MappedIn pivot finishers + robustness + perf

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
@@ -67,8 +67,16 @@ export default function IndoorTab({ map, onConfigure }: Props) {
       if (!res.ok) throw new Error("save");
       await mutate(`/api/maps/${mapId}`);
       toast.success("Campus thumbnail updated");
-    } catch {
-      toast.error("Couldn't save the thumbnail");
+    } catch (e) {
+      // Surface what actually failed (upload error, 4xx from the
+      // PATCH, network drop) — the generic toast made all of these
+      // look identical and left nothing in the console for support.
+      console.error("Thumbnail capture failed:", e);
+      toast.error(
+        e instanceof Error
+          ? `Couldn't save the thumbnail: ${e.message}`
+          : "Couldn't save the thumbnail",
+      );
     } finally {
       setCapturing(false);
     }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
@@ -1,7 +1,15 @@
 "use client";
 
+import { useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import { toast } from "react-toastify";
+import { mutate } from "swr";
 import { Button } from "@klorad/design-system";
-import { MappedinViewer } from "@/lib/mappedin/MappedinViewer";
+import { uploadFile } from "@klorad/storage/client";
+import {
+  MappedinViewer,
+  type MappedinViewerHandle,
+} from "@/lib/mappedin/MappedinViewer";
 import { venueForIndoorMap } from "@/lib/mappedin/config";
 
 interface Props {
@@ -11,26 +19,84 @@ interface Props {
 }
 
 /**
- * The campus profile's "Indoor" tab — the indoor 3D viewer rendered
+ * The campus profile's "Indoor" tab — the MappedIn viewer rendered
  * inside Klorad's dashboard chrome.
  *
- * Reads the campus's `indoorMapId` (set on the Settings tab). If none
- * is configured, shows an empty state pointing at Settings. The
- * `data-mappedin` marker on the wrapper restores border / list
- * styling for the viewer's controls (Tailwind preflight is off
- * app-wide — see global.css).
+ * Reads the campus's `indoorMapId` (set on the Settings tab). If
+ * none is configured, shows an empty state pointing at Settings.
+ * Also hosts the **"Capture thumbnail"** action: snapshots the
+ * current view (`mapView.takeScreenshot()`), uploads it, and saves
+ * the URL as the campus's thumbnail — the image shown on the campus
+ * card and as the home page's hero fallback.
+ *
+ * The `data-mappedin` marker restores border / list styling for the
+ * viewer's controls (Tailwind preflight is off app-wide).
  */
 export default function IndoorTab({ map, onConfigure }: Props) {
+  const params = useParams<{ mapId: string }>();
+  const mapId = params?.mapId ?? "";
+
   const indoorMapId = (
     map.sceneData as { indoorMapId?: string } | undefined
   )?.indoorMapId;
 
+  const viewerRef = useRef<MappedinViewerHandle>(null);
+  const [capturing, setCapturing] = useState(false);
+
+  const handleCapture = async () => {
+    if (!mapId) return;
+    setCapturing(true);
+    try {
+      const dataUrl = await viewerRef.current?.capture();
+      if (!dataUrl) {
+        toast.error("Couldn't capture — wait for the venue to load");
+        return;
+      }
+      const blob = await (await fetch(dataUrl)).blob();
+      const file = new File([blob], `${mapId}-thumbnail.png`, {
+        type: blob.type || "image/png",
+      });
+      const { publicUrl } = await uploadFile(file, {
+        prefix: "campus-thumbnails",
+      });
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ thumbnail: publicUrl }),
+      });
+      if (!res.ok) throw new Error("save");
+      await mutate(`/api/maps/${mapId}`);
+      toast.success("Campus thumbnail updated");
+    } catch {
+      toast.error("Couldn't save the thumbnail");
+    } finally {
+      setCapturing(false);
+    }
+  };
+
   return (
-    <div data-mappedin className="pt-6">
+    <div data-mappedin className="space-y-3 pt-6">
       {indoorMapId ? (
-        <div className="h-[72vh] overflow-hidden rounded-2xl border border-line-soft">
-          <MappedinViewer venue={venueForIndoorMap(indoorMapId)} />
-        </div>
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-xs text-text-tertiary">
+              Frame the view, then capture it as the campus card image.
+            </p>
+            <Button
+              size="sm"
+              onClick={handleCapture}
+              disabled={capturing}
+            >
+              {capturing ? "Capturing…" : "Capture thumbnail"}
+            </Button>
+          </div>
+          <div className="h-[72vh] overflow-hidden rounded-2xl border border-line-soft">
+            <MappedinViewer
+              ref={viewerRef}
+              venue={venueForIndoorMap(indoorMapId)}
+            />
+          </div>
+        </>
       ) : (
         <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-line-soft py-20 text-center">
           <p className="text-sm font-medium text-text-primary">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import useSWR, { mutate } from "swr";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -57,10 +57,16 @@ export default function SettingsTab({ orgId, mapId, map }: Props) {
   const [indoorMapId, setIndoorMapId] = useState("");
   const [savingIndoor, setSavingIndoor] = useState(false);
 
+  // Initialise from the saved config exactly once. SWR revalidates
+  // `serverMap` (on window focus etc.); re-running this would clobber
+  // unsaved edits — same bug pattern as HomePagePanel.
+  const loadedRef = useRef(false);
   useEffect(() => {
-    if (serverMap?.sceneData?.branding)
+    if (loadedRef.current || !serverMap) return;
+    loadedRef.current = true;
+    if (serverMap.sceneData?.branding)
       setBranding(serverMap.sceneData.branding);
-    if (serverMap?.sceneData?.indoorMapId !== undefined)
+    if (serverMap.sceneData?.indoorMapId !== undefined)
       setIndoorMapId(serverMap.sceneData.indoorMapId);
   }, [serverMap]);
 

--- a/apps/campus/app/(public)/campus/[token]/CampusEvents.tsx
+++ b/apps/campus/app/(public)/campus/[token]/CampusEvents.tsx
@@ -95,7 +95,7 @@ export function CampusEvents({
                 {event.location ? (
                   spaceId ? (
                     <Link
-                      href={`/campus/${token}/map?space=${encodeURIComponent(spaceId)}`}
+                      href={`/campus/${token}/map?lang=${locale}&space=${encodeURIComponent(spaceId)}`}
                       className="block truncate text-xs font-medium text-accent transition-opacity hover:opacity-80"
                     >
                       {event.location} →

--- a/apps/campus/app/(public)/campus/[token]/NotPublishedPlaceholder.tsx
+++ b/apps/campus/app/(public)/campus/[token]/NotPublishedPlaceholder.tsx
@@ -1,23 +1,32 @@
 import { KloradMark } from "@klorad/design-system";
+import { type Locale, translate } from "@/app/lib/i18n-core";
 
 /**
  * Friendly "coming soon" placeholder for an unpublished campus —
  * shared by the public home and map routes. No internal data leaked:
  * the visitor sees only the campus name (already known via the URL).
  */
-export default function NotPublishedPlaceholder({ name }: { name: string }) {
+export default function NotPublishedPlaceholder({
+  name,
+  locale = "en",
+}: {
+  name: string;
+  locale?: Locale;
+}) {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center">
+    <main
+      lang={locale}
+      className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center"
+    >
       <KloradMark className="h-10 w-10" />
       <h1 className="mt-6 text-2xl font-semibold tracking-tight text-text-primary">
         {name}
       </h1>
       <p className="mt-3 max-w-sm text-sm text-text-secondary">
-        This campus isn&apos;t published yet. The author is still building
-        it — check back soon.
+        {translate(locale, "published.body")}
       </p>
       <p className="mt-8 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
-        Powered by Klorad
+        {translate(locale, "home.poweredBy")}
       </p>
     </main>
   );

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -42,7 +42,8 @@ export default async function CampusMapPage({
     .catch(() => null);
 
   if (!map) notFound();
-  if (!map.isPublished) return <NotPublishedPlaceholder name={map.title} />;
+  if (!map.isPublished)
+    return <NotPublishedPlaceholder name={map.title} locale={locale} />;
 
   const indoorMapId = (map.sceneData as { indoorMapId?: string } | null)
     ?.indoorMapId;
@@ -54,6 +55,7 @@ export default async function CampusMapPage({
           venue={venueForIndoorMap(indoorMapId)}
           focusSpaceId={focusSpaceId}
           locale={locale}
+          homeHref={`/campus/${token}`}
         />
       </main>
     );

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -50,7 +50,7 @@ export default async function CampusMapPage({
           venue={venueForIndoorMap(indoorMapId)}
           focusSpaceId={focusSpaceId}
           locale={locale}
-          homeHref={`/campus/${token}`}
+          homeHref={`/campus/${token}?lang=${locale}`}
         />
       </main>
     );

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { prisma } from "@/lib/prisma";
+import { getPublicCampusByToken } from "@/lib/public-campus";
 import { venueForIndoorMap } from "@/lib/mappedin/config";
 import { MappedinViewer } from "@/lib/mappedin/MappedinViewer";
 import { detectLocale } from "@/app/lib/i18n-core";
@@ -34,12 +34,7 @@ export default async function CampusMapPage({
   const focusSpaceId = typeof sp.space === "string" ? sp.space : undefined;
   const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
-  const map = await prisma.project
-    .findUnique({
-      where: { id: token },
-      select: { id: true, title: true, isPublished: true, sceneData: true },
-    })
-    .catch(() => null);
+  const map = await getPublicCampusByToken(token);
 
   if (!map) notFound();
   if (!map.isPublished)

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -2,11 +2,15 @@ import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { venueForIndoorMap } from "@/lib/mappedin/config";
 import { MappedinViewer } from "@/lib/mappedin/MappedinViewer";
+import { detectLocale } from "@/app/lib/i18n-core";
 import PublicViewerClient from "../PublicViewerClient";
 import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
 
 type Params = Promise<{ token: string }>;
-type Search = Promise<{ space?: string | string[] }>;
+type Search = Promise<{
+  space?: string | string[];
+  lang?: string | string[];
+}>;
 
 /**
  * `/campus/[token]/map` — the campus map.
@@ -28,6 +32,7 @@ export default async function CampusMapPage({
   const { token } = await params;
   const sp = await searchParams;
   const focusSpaceId = typeof sp.space === "string" ? sp.space : undefined;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
   const map = await prisma.project
     .findUnique({
@@ -48,6 +53,7 @@ export default async function CampusMapPage({
         <MappedinViewer
           venue={venueForIndoorMap(indoorMapId)}
           focusSpaceId={focusSpaceId}
+          locale={locale}
         />
       </main>
     );

--- a/apps/campus/app/(public)/campus/[token]/not-found.tsx
+++ b/apps/campus/app/(public)/campus/[token]/not-found.tsx
@@ -1,0 +1,25 @@
+import { KloradMark } from "@klorad/design-system";
+
+/**
+ * Branded 404 for a campus that doesn't exist — replaces Next's
+ * generic page when `notFound()` is called from `/campus/[token]/*`
+ * (the home, the map, the redirect). No locale context here — Next's
+ * not-found segment is static — so it renders in English.
+ */
+export default function CampusNotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center">
+      <KloradMark className="h-10 w-10" />
+      <h1 className="mt-6 text-2xl font-semibold tracking-tight text-text-primary">
+        Campus not found
+      </h1>
+      <p className="mt-3 max-w-sm text-sm text-text-secondary">
+        The link you followed may be wrong, or this campus no longer
+        exists.
+      </p>
+      <p className="mt-8 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
+        Powered by Klorad
+      </p>
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -25,6 +25,16 @@ function isValidHex(value: string | undefined): value is string {
   return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
 }
 
+/** Whether `next/image` can optimise this URL — only Spaces hosts. */
+function isOptimisableImage(url: string): boolean {
+  if (url.startsWith("data:")) return false;
+  try {
+    return new URL(url).hostname.endsWith(".digitaloceanspaces.com");
+  } catch {
+    return false;
+  }
+}
+
 /** Location-pin glyph for a post's linked place. */
 function PinIcon({ className }: { className?: string }) {
   return (
@@ -106,7 +116,9 @@ export default async function CampusHomePage({
     : "#158ca3";
   const posts = readPosts(map.sceneData);
   const events = await fetchCampusEvents(readEventFeeds(map.sceneData));
-  const mapHref = `/campus/${token}/map`;
+  // Always carries `?lang=` so downstream links append with `&`
+  // (and so the locale survives navigation off the home page).
+  const mapHref = `/campus/${token}/map?lang=${locale}`;
 
   // Home page builder config — bilingual fields resolved to the
   // visitor's locale, each falling back to a sensible default.
@@ -167,6 +179,9 @@ export default async function CampusHomePage({
               priority
               sizes="100vw"
               className="object-cover"
+              // Legacy thumbnails / pasted URLs may not be on Spaces;
+              // bypass the optimiser rather than 500 the page.
+              unoptimized={!isOptimisableImage(heroBg)}
             />
             <div
               aria-hidden
@@ -234,8 +249,8 @@ export default async function CampusHomePage({
                   <Link
                     href={
                       post.place.source === "mappedin"
-                        ? `${mapHref}?space=${encodeURIComponent(post.place.id)}`
-                        : `${mapHref}?place=${encodeURIComponent(post.place.id)}`
+                        ? `${mapHref}&space=${encodeURIComponent(post.place.id)}`
+                        : `${mapHref}&place=${encodeURIComponent(post.place.id)}`
                     }
                     className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition-opacity hover:opacity-80"
                   >

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -113,7 +113,8 @@ export default async function CampusHomePage({
     .catch(() => null);
 
   if (!map) notFound();
-  if (!map.isPublished) return <NotPublishedPlaceholder name={map.title} />;
+  if (!map.isPublished)
+    return <NotPublishedPlaceholder name={map.title} locale={locale} />;
 
   const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
   const branding = scene.branding ?? {};

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { KloradMark } from "@klorad/design-system";
@@ -151,17 +152,33 @@ export default async function CampusHomePage({
         className="relative flex min-h-[56vh] items-end overflow-hidden px-6 py-12 md:px-10 md:py-16"
         style={
           heroBg
-            ? {
-                backgroundImage: `linear-gradient(to top, rgba(11,17,22,0.9), rgba(11,17,22,0.35)), url("${heroBg}")`,
-                backgroundSize: "cover",
-                backgroundPosition: "center",
-              }
+            ? undefined
             : {
                 background: `linear-gradient(155deg, ${accent} 0%, #0b1116 100%)`,
               }
         }
       >
-        <div className="max-w-3xl">
+        {heroBg ? (
+          <>
+            <Image
+              src={heroBg}
+              alt=""
+              fill
+              priority
+              sizes="100vw"
+              className="object-cover"
+            />
+            <div
+              aria-hidden
+              className="absolute inset-0"
+              style={{
+                background:
+                  "linear-gradient(to top, rgba(11,17,22,0.9), rgba(11,17,22,0.35))",
+              }}
+            />
+          </>
+        ) : null}
+        <div className="relative z-10 max-w-3xl">
           <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl md:text-5xl">
             {headline}
           </h1>

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { KloradMark } from "@klorad/design-system";
-import { prisma } from "@/lib/prisma";
+import { getPublicCampusByToken } from "@/lib/public-campus";
 import { formatPostDate, readPosts } from "@/lib/posts";
 import { readEventFeeds } from "@/lib/events";
 import { fetchCampusEvents } from "@/lib/events-server";
@@ -45,12 +45,7 @@ export async function generateMetadata({
   params: Params;
 }): Promise<Metadata> {
   const { token } = await params;
-  const map = await prisma.project
-    .findUnique({
-      where: { id: token },
-      select: { title: true, sceneData: true },
-    })
-    .catch(() => null);
+  const map = await getPublicCampusByToken(token);
 
   const scene = (map?.sceneData ?? null) as {
     branding?: { name?: string };
@@ -96,21 +91,7 @@ export default async function CampusHomePage({
   const sp = await searchParams;
   const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
-  const map = await prisma.project
-    .findUnique({
-      where: {
-        id: token,
-      },
-      select: {
-        id: true,
-        title: true,
-        description: true,
-        isPublished: true,
-        thumbnail: true,
-        sceneData: true,
-      },
-    })
-    .catch(() => null);
+  const map = await getPublicCampusByToken(token);
 
   if (!map) notFound();
   if (!map.isPublished)

--- a/apps/campus/app/api/maps/[mapId]/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess, requireOrgAccess } from "@/lib/authz";
-import { CAMPUS_CACHE_TAG } from "@/lib/public-campus";
+import { publicCampusTag } from "@/lib/public-campus";
 
 export async function GET(
   _req: Request,
@@ -69,9 +69,10 @@ export async function PATCH(
     },
   });
 
-  // The public home / map cache this campus's read; invalidate it so
-  // an owner's save shows up on the public side promptly.
-  revalidateTag(CAMPUS_CACHE_TAG);
+  // The public home / map cache this campus's read; invalidate just
+  // this campus's entry so an owner's save shows up promptly (and one
+  // tenant's edits don't thrash every other campus's cache).
+  revalidateTag(publicCampusTag(mapId));
 
   return NextResponse.json({ ...map, name: map.title });
 }
@@ -87,6 +88,10 @@ export async function DELETE(
   if (denied) return denied;
 
   await prisma.project.delete({ where: { id: mapId } });
+
+  // Without this the public cache would keep serving the deleted
+  // campus for up to 60s.
+  revalidateTag(publicCampusTag(mapId));
 
   return new NextResponse(null, { status: 204 });
 }

--- a/apps/campus/app/api/maps/[mapId]/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess, requireOrgAccess } from "@/lib/authz";
+import { CAMPUS_CACHE_TAG } from "@/lib/public-campus";
 
 export async function GET(
   _req: Request,
@@ -66,6 +68,10 @@ export async function PATCH(
       isPublished: true,
     },
   });
+
+  // The public home / map cache this campus's read; invalidate it so
+  // an owner's save shows up on the public side promptly.
+  revalidateTag(CAMPUS_CACHE_TAG);
 
   return NextResponse.json({ ...map, name: map.title });
 }

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -68,6 +68,27 @@ const MESSAGES = {
     "home.news": "News",
     "home.noNews": "No news yet — check back soon.",
     "home.poweredBy": "Powered by Klorad",
+
+    // MappedIn indoor / campus viewer
+    "mappedin.loading": "Loading the campus map…",
+    "mappedin.errorTitle": "We couldn’t load the campus map",
+    "mappedin.errorBody": "Please refresh the page or try again later.",
+    "mappedin.searchPlaceholder": "Find a room or space…",
+    "mappedin.searchClear": "Clear search",
+    "mappedin.searchNoMatch": "Nothing matches “{query}”.",
+    "mappedin.wayfindTitle": "Indoor directions",
+    "mappedin.wayfindFrom": "From",
+    "mappedin.wayfindTo": "To",
+    "mappedin.wayfindPick": "Choose a space…",
+    "mappedin.wayfindStepFree": "Step-free route",
+    "mappedin.wayfindGo": "Get directions",
+    "mappedin.wayfindRouting": "Routing…",
+    "mappedin.wayfindClear": "Clear",
+    "mappedin.wayfindNoRoute": "No route between those spaces.",
+    "mappedin.wayfindNoStepFree":
+      "No step-free route between those spaces.",
+    "mappedin.clearSelection": "Clear selection",
+    "mappedin.building": "Building",
   },
   el: {
     // Generic
@@ -126,6 +147,28 @@ const MESSAGES = {
     "home.news": "Νέα",
     "home.noNews": "Δεν υπάρχουν νέα ακόμη — ελάτε σύντομα ξανά.",
     "home.poweredBy": "Με την υποστήριξη του Klorad",
+
+    // MappedIn indoor / campus viewer
+    "mappedin.loading": "Φόρτωση του χάρτη…",
+    "mappedin.errorTitle": "Δεν φορτώθηκε ο χάρτης",
+    "mappedin.errorBody":
+      "Παρακαλώ ανανεώστε τη σελίδα ή δοκιμάστε ξανά αργότερα.",
+    "mappedin.searchPlaceholder": "Βρείτε αίθουσα ή χώρο…",
+    "mappedin.searchClear": "Καθαρισμός αναζήτησης",
+    "mappedin.searchNoMatch": "Δεν βρέθηκε «{query}».",
+    "mappedin.wayfindTitle": "Οδηγίες εσωτερικά",
+    "mappedin.wayfindFrom": "Από",
+    "mappedin.wayfindTo": "Προς",
+    "mappedin.wayfindPick": "Επιλέξτε χώρο…",
+    "mappedin.wayfindStepFree": "Προσβάσιμη διαδρομή",
+    "mappedin.wayfindGo": "Οδηγίες",
+    "mappedin.wayfindRouting": "Υπολογισμός…",
+    "mappedin.wayfindClear": "Καθαρισμός",
+    "mappedin.wayfindNoRoute": "Δεν υπάρχει διαδρομή ανάμεσα στους χώρους.",
+    "mappedin.wayfindNoStepFree":
+      "Δεν υπάρχει προσβάσιμη διαδρομή ανάμεσα στους χώρους.",
+    "mappedin.clearSelection": "Καθαρισμός επιλογής",
+    "mappedin.building": "Κτίριο",
   },
 } as const;
 

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -87,6 +87,7 @@ const MESSAGES = {
     "mappedin.wayfindNoRoute": "No route between those spaces.",
     "mappedin.wayfindNoStepFree":
       "No step-free route between those spaces.",
+    "mappedin.wayfindFailed": "We couldn’t compute that route.",
     "mappedin.clearSelection": "Clear selection",
     "mappedin.building": "Building",
     "mappedin.errorBack": "Back to home",
@@ -175,6 +176,7 @@ const MESSAGES = {
     "mappedin.wayfindNoRoute": "Δεν υπάρχει διαδρομή ανάμεσα στους χώρους.",
     "mappedin.wayfindNoStepFree":
       "Δεν υπάρχει προσβάσιμη διαδρομή ανάμεσα στους χώρους.",
+    "mappedin.wayfindFailed": "Δεν υπολογίστηκε η διαδρομή.",
     "mappedin.clearSelection": "Καθαρισμός επιλογής",
     "mappedin.building": "Κτίριο",
     "mappedin.errorBack": "Πίσω στην αρχική",
@@ -209,8 +211,12 @@ export function translate(
 ): string {
   const raw = MESSAGES[locale]?.[key] ?? MESSAGES[DEFAULT_LOCALE][key] ?? key;
   if (!vars) return raw;
+  // Function form — replacement strings with `$&` / `$1` / `$$`
+  // (e.g. user-typed text in a search query) would otherwise be
+  // interpreted by String.prototype.replace as regex backreferences.
   return Object.entries(vars).reduce(
-    (acc, [k, v]) => acc.replace(new RegExp(`\\{${k}\\}`, "g"), String(v)),
+    (acc, [k, v]) =>
+      acc.replace(new RegExp(`\\{${k}\\}`, "g"), () => String(v)),
     raw,
   );
 }

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -89,6 +89,14 @@ const MESSAGES = {
       "No step-free route between those spaces.",
     "mappedin.clearSelection": "Clear selection",
     "mappedin.building": "Building",
+    "mappedin.errorBack": "Back to home",
+
+    // Unpublished / not-found states
+    "published.body":
+      "This campus isn’t published yet. The author is still building it — check back soon.",
+    "notFound.title": "Campus not found",
+    "notFound.body":
+      "The link you followed may be wrong, or this campus no longer exists.",
   },
   el: {
     // Generic
@@ -169,6 +177,14 @@ const MESSAGES = {
       "Δεν υπάρχει προσβάσιμη διαδρομή ανάμεσα στους χώρους.",
     "mappedin.clearSelection": "Καθαρισμός επιλογής",
     "mappedin.building": "Κτίριο",
+    "mappedin.errorBack": "Πίσω στην αρχική",
+
+    // Unpublished / not-found states
+    "published.body":
+      "Η σελίδα της πανεπιστημιούπολης δεν έχει δημοσιευτεί ακόμη — επιστρέψτε σύντομα.",
+    "notFound.title": "Δεν βρέθηκε η πανεπιστημιούπολη",
+    "notFound.body":
+      "Ο σύνδεσμος μπορεί να είναι λανθασμένος ή η πανεπιστημιούπολη να μην υπάρχει πια.",
   },
 } as const;
 

--- a/apps/campus/lib/mappedin/FloorControls.tsx
+++ b/apps/campus/lib/mappedin/FloorControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Select, cn } from "@klorad/design-system";
+import { translate, type Locale } from "@/app/lib/i18n-core";
 
 /** A switchable level — a floor or a building. Just `{ id, name }`. */
 export interface FloorOption {
@@ -18,6 +19,8 @@ export interface FloorControlsProps {
   onSelectFloor: (floorId: string) => void;
   onSelectBuilding: (buildingId: string) => void;
   className?: string;
+  /** UI locale — defaults to English. */
+  locale?: Locale;
 }
 
 /**
@@ -33,6 +36,7 @@ export function FloorControls({
   onSelectFloor,
   onSelectBuilding,
   className,
+  locale = "en",
 }: FloorControlsProps) {
   const multiBuilding = buildings.length > 1;
   // Nothing to switch — don't render an empty control.
@@ -49,7 +53,7 @@ export function FloorControls({
         <Select
           value={currentBuildingId}
           onChange={(e) => onSelectBuilding(e.target.value)}
-          aria-label="Building"
+          aria-label={translate(locale, "mappedin.building")}
         >
           {buildings.map((b) => (
             <option key={b.id} value={b.id}>

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -11,6 +11,7 @@ import {
 import { Spinner } from "@klorad/design-system";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
+import { translate, type Locale } from "@/app/lib/i18n-core";
 import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
 import { SearchControls } from "./SearchControls";
 import { FloorControls, type FloorOption } from "./FloorControls";
@@ -41,12 +42,15 @@ interface MappedinViewerProps {
   venue: MappedinVenue;
   /** A space id to select + fly to once the venue has loaded. */
   focusSpaceId?: string;
+  /** UI locale — defaults to English. */
+  locale?: Locale;
 }
 
 export const MappedinViewer = forwardRef<
   MappedinViewerHandle,
   MappedinViewerProps
->(function MappedinViewer({ venue, focusSpaceId }, ref) {
+>(function MappedinViewer({ venue, focusSpaceId, locale = "en" }, ref) {
+  const t = (key: Parameters<typeof translate>[1]) => translate(locale, key);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapViewRef = useRef<MapView | null>(null);
   const mapDataRef = useRef<MapData | null>(null);
@@ -257,8 +261,8 @@ export const MappedinViewer = forwardRef<
         if (!directions) {
           setRouteError(
             accessible
-              ? "No step-free route between those spaces."
-              : "No route between those spaces.",
+              ? t("mappedin.wayfindNoStepFree")
+              : t("mappedin.wayfindNoRoute"),
           );
           return;
         }
@@ -371,7 +375,7 @@ export const MappedinViewer = forwardRef<
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <span className="flex items-center gap-3 text-sm text-text-secondary">
             <Spinner />
-            Loading indoor map…
+            {t("mappedin.loading")}
           </span>
         </div>
       ) : null}
@@ -380,10 +384,10 @@ export const MappedinViewer = forwardRef<
         <div className="absolute inset-0 flex items-center justify-center p-8">
           <div className="max-w-sm rounded-2xl border border-solid border-line-soft bg-surface-1 p-5 text-center shadow-glass">
             <p className="text-sm font-medium text-text-primary">
-              We couldn’t load the campus map
+              {t("mappedin.errorTitle")}
             </p>
             <p className="mt-1 text-xs text-text-tertiary">
-              Please refresh the page or try again later.
+              {t("mappedin.errorBody")}
             </p>
             {error ? (
               <p className="mt-2 text-[0.65rem] text-text-tertiary opacity-60">
@@ -399,6 +403,7 @@ export const MappedinViewer = forwardRef<
           <SearchControls
             spaces={spaces}
             onSelect={(id) => void handleSearchSelect(id)}
+            locale={locale}
           />
           {spaces.length >= 2 ? (
             <WayfindingControls
@@ -409,6 +414,7 @@ export const MappedinViewer = forwardRef<
                 void handleRoute(from, to, accessible)
               }
               onClear={handleClear}
+              locale={locale}
             />
           ) : null}
         </div>
@@ -422,6 +428,7 @@ export const MappedinViewer = forwardRef<
           currentBuildingId={currentBuildingId}
           onSelectFloor={(id) => void handleSelectFloor(id)}
           onSelectBuilding={(id) => void handleSelectBuilding(id)}
+          locale={locale}
           // Top-right — clear of MappedIn's own zoom / nav controls,
           // which sit centred on the right edge.
           className="absolute right-4 top-4 z-10"
@@ -436,7 +443,7 @@ export const MappedinViewer = forwardRef<
           <button
             type="button"
             onClick={clearSelection}
-            aria-label="Clear selection"
+            aria-label={t("mappedin.clearSelection")}
             className="text-sm leading-none text-text-tertiary transition-colors hover:text-text-primary"
           >
             ✕

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import Link from "next/link";
 import { Spinner } from "@klorad/design-system";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
@@ -44,12 +45,20 @@ interface MappedinViewerProps {
   focusSpaceId?: string;
   /** UI locale — defaults to English. */
   locale?: Locale;
+  /**
+   * If set, the error state renders a "Back" link to this URL so the
+   * visitor isn't stranded — e.g. the campus home for the public map.
+   */
+  homeHref?: string;
 }
 
 export const MappedinViewer = forwardRef<
   MappedinViewerHandle,
   MappedinViewerProps
->(function MappedinViewer({ venue, focusSpaceId, locale = "en" }, ref) {
+>(function MappedinViewer(
+  { venue, focusSpaceId, locale = "en", homeHref },
+  ref,
+) {
   const t = (key: Parameters<typeof translate>[1]) => translate(locale, key);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapViewRef = useRef<MapView | null>(null);
@@ -393,6 +402,14 @@ export const MappedinViewer = forwardRef<
               <p className="mt-2 text-[0.65rem] text-text-tertiary opacity-60">
                 {error}
               </p>
+            ) : null}
+            {homeHref ? (
+              <Link
+                href={homeHref}
+                className="mt-4 inline-block text-xs font-medium text-accent transition-opacity hover:opacity-80"
+              >
+                ← {t("mappedin.errorBack")}
+              </Link>
             ) : null}
           </div>
         </div>

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -270,19 +270,19 @@ export const MappedinViewer = forwardRef<
         if (!directions) {
           setRouteError(
             accessible
-              ? t("mappedin.wayfindNoStepFree")
-              : t("mappedin.wayfindNoRoute"),
+              ? translate(locale, "mappedin.wayfindNoStepFree")
+              : translate(locale, "mappedin.wayfindNoRoute"),
           );
           return;
         }
         await mapView.Navigation.draw(directions);
-      } catch (e) {
-        setRouteError(e instanceof Error ? e.message : "Routing failed");
+      } catch {
+        setRouteError(translate(locale, "mappedin.wayfindFailed"));
       } finally {
         setRouting(false);
       }
     },
-    [],
+    [locale],
   );
 
   const handleClear = useCallback(() => {
@@ -312,11 +312,10 @@ export const MappedinViewer = forwardRef<
   );
 
   // Deep link — focus the space named by `focusSpaceId` once the
-  // venue has loaded (a news post links straight to its room).
-  const focusDoneRef = useRef(false);
+  // venue has loaded. Re-fires when `focusSpaceId` changes so a
+  // soft-nav between rooms (news post → news post) refocuses.
   useEffect(() => {
-    if (status !== "ready" || focusDoneRef.current || !focusSpaceId) return;
-    focusDoneRef.current = true;
+    if (status !== "ready" || !focusSpaceId) return;
     void handleSearchSelect(focusSpaceId);
   }, [status, focusSpaceId, handleSearchSelect]);
 

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { Spinner } from "@klorad/design-system";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
@@ -21,14 +28,25 @@ import { FloorControls, type FloorOption } from "./FloorControls";
  * touches the server bundle and stays out of the main chunk. The
  * `import type` above is erased at build, so it costs nothing.
  */
-export function MappedinViewer({
-  venue,
-  focusSpaceId,
-}: {
+/**
+ * Imperative handle exposed via `ref` — the parent can take a
+ * screenshot of the current view to use as the campus thumbnail.
+ */
+export interface MappedinViewerHandle {
+  /** Take a screenshot of the current scene; returns a PNG data URL. */
+  capture(): Promise<string | null>;
+}
+
+interface MappedinViewerProps {
   venue: MappedinVenue;
   /** A space id to select + fly to once the venue has loaded. */
   focusSpaceId?: string;
-}) {
+}
+
+export const MappedinViewer = forwardRef<
+  MappedinViewerHandle,
+  MappedinViewerProps
+>(function MappedinViewer({ venue, focusSpaceId }, ref) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapViewRef = useRef<MapView | null>(null);
   const mapDataRef = useRef<MapData | null>(null);
@@ -306,6 +324,34 @@ export function MappedinViewer({
     [syncFloors],
   );
 
+  // Imperative handle — capture the current view as a PNG data URL.
+  // Used by the dashboard's Indoor tab to set the campus thumbnail.
+  useImperativeHandle(
+    ref,
+    () => ({
+      async capture(): Promise<string | null> {
+        const mv = mapViewRef.current as
+          | (MapView & {
+              takeScreenshot?: (opts?: {
+                withOutdoorContext?: boolean;
+                withLabels?: boolean;
+              }) => Promise<string>;
+            })
+          | null;
+        if (!mv?.takeScreenshot) return null;
+        try {
+          return await mv.takeScreenshot({
+            withOutdoorContext: true,
+            withLabels: true,
+          });
+        } catch {
+          return null;
+        }
+      },
+    }),
+    [],
+  );
+
   return (
     <div className="relative h-full w-full bg-bg">
       <div ref={containerRef} className="h-full w-full" />
@@ -379,4 +425,4 @@ export function MappedinViewer({
       ) : null}
     </div>
   );
-}
+});

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -236,30 +236,41 @@ export const MappedinViewer = forwardRef<
     clearSelection,
   ]);
 
-  const handleRoute = useCallback(async (fromId: string, toId: string) => {
-    const mapData = mapDataRef.current;
-    const mapView = mapViewRef.current;
-    if (!mapData || !mapView) return;
-    const from = spacesRef.current.get(fromId);
-    const to = spacesRef.current.get(toId);
-    if (!from || !to) return;
+  const handleRoute = useCallback(
+    async (fromId: string, toId: string, accessible: boolean) => {
+      const mapData = mapDataRef.current;
+      const mapView = mapViewRef.current;
+      if (!mapData || !mapView) return;
+      const from = spacesRef.current.get(fromId);
+      const to = spacesRef.current.get(toId);
+      if (!from || !to) return;
 
-    setRouting(true);
-    setRouteError(null);
-    try {
-      mapView.Navigation.clear();
-      const directions = await mapData.getDirections(from, to);
-      if (!directions) {
-        setRouteError("No route between those spaces.");
-        return;
+      setRouting(true);
+      setRouteError(null);
+      try {
+        mapView.Navigation.clear();
+        const directions = await mapData.getDirections(
+          from,
+          to,
+          accessible ? { accessible: true } : undefined,
+        );
+        if (!directions) {
+          setRouteError(
+            accessible
+              ? "No step-free route between those spaces."
+              : "No route between those spaces.",
+          );
+          return;
+        }
+        await mapView.Navigation.draw(directions);
+      } catch (e) {
+        setRouteError(e instanceof Error ? e.message : "Routing failed");
+      } finally {
+        setRouting(false);
       }
-      await mapView.Navigation.draw(directions);
-    } catch (e) {
-      setRouteError(e instanceof Error ? e.message : "Routing failed");
-    } finally {
-      setRouting(false);
-    }
-  }, []);
+    },
+    [],
+  );
 
   const handleClear = useCallback(() => {
     mapViewRef.current?.Navigation.clear();
@@ -367,11 +378,18 @@ export const MappedinViewer = forwardRef<
 
       {status === "error" ? (
         <div className="absolute inset-0 flex items-center justify-center p-8">
-          <div className="max-w-sm rounded-2xl border border-line-soft bg-surface-1 p-5 text-center shadow-glass">
+          <div className="max-w-sm rounded-2xl border border-solid border-line-soft bg-surface-1 p-5 text-center shadow-glass">
             <p className="text-sm font-medium text-text-primary">
-              Indoor map unavailable
+              We couldn’t load the campus map
             </p>
-            <p className="mt-1 text-xs text-text-tertiary">{error}</p>
+            <p className="mt-1 text-xs text-text-tertiary">
+              Please refresh the page or try again later.
+            </p>
+            {error ? (
+              <p className="mt-2 text-[0.65rem] text-text-tertiary opacity-60">
+                {error}
+              </p>
+            ) : null}
           </div>
         </div>
       ) : null}
@@ -387,7 +405,9 @@ export const MappedinViewer = forwardRef<
               spaces={spaces}
               routing={routing}
               error={routeError}
-              onRoute={(from, to) => void handleRoute(from, to)}
+              onRoute={(from, to, accessible) =>
+                void handleRoute(from, to, accessible)
+              }
               onClear={handleClear}
             />
           ) : null}

--- a/apps/campus/lib/mappedin/SearchControls.tsx
+++ b/apps/campus/lib/mappedin/SearchControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { translate, type Locale } from "@/app/lib/i18n-core";
 import type { SpaceOption } from "./WayfindingControls";
 
 export interface SearchControlsProps {
@@ -8,6 +9,8 @@ export interface SearchControlsProps {
   spaces: SpaceOption[];
   /** Fired when a result is picked — the viewer flies there. */
   onSelect: (spaceId: string) => void;
+  /** UI locale — defaults to English. */
+  locale?: Locale;
 }
 
 const MAX_RESULTS = 8;
@@ -18,7 +21,11 @@ const MAX_RESULTS = 8;
  * floor and flies the camera to it. Presentational: it only filters
  * the space list and emits `onSelect`.
  */
-export function SearchControls({ spaces, onSelect }: SearchControlsProps) {
+export function SearchControls({
+  spaces,
+  onSelect,
+  locale = "en",
+}: SearchControlsProps) {
   const [query, setQuery] = useState("");
   const q = query.trim().toLowerCase();
   const matches = q
@@ -33,14 +40,14 @@ export function SearchControls({ spaces, onSelect }: SearchControlsProps) {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Find a room or space…"
+          placeholder={translate(locale, "mappedin.searchPlaceholder")}
           className="w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary"
         />
         {query ? (
           <button
             type="button"
             onClick={() => setQuery("")}
-            aria-label="Clear search"
+            aria-label={translate(locale, "mappedin.searchClear")}
             className="shrink-0 text-text-tertiary transition-colors hover:text-text-primary"
           >
             <CloseIcon className="h-3.5 w-3.5" />
@@ -67,7 +74,7 @@ export function SearchControls({ spaces, onSelect }: SearchControlsProps) {
         </ul>
       ) : q ? (
         <p className="mt-2 px-2 text-xs text-text-tertiary">
-          Nothing matches “{query}”.
+          {translate(locale, "mappedin.searchNoMatch", { query })}
         </p>
       ) : null}
     </div>

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Button, Select } from "@klorad/design-system";
+import { translate, type Locale } from "@/app/lib/i18n-core";
 
 /** A selectable destination — a named space in the venue. */
 export interface SpaceOption {
@@ -23,6 +24,8 @@ export interface WayfindingControlsProps {
   onRoute: (fromId: string, toId: string, accessible: boolean) => void;
   /** Clear the drawn route. */
   onClear: () => void;
+  /** UI locale — defaults to English. */
+  locale?: Locale;
 }
 
 /**
@@ -38,7 +41,9 @@ export function WayfindingControls({
   error,
   onRoute,
   onClear,
+  locale = "en",
 }: WayfindingControlsProps) {
+  const t = (key: Parameters<typeof translate>[1]) => translate(locale, key);
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
   const [accessible, setAccessible] = useState(false);
@@ -47,13 +52,13 @@ export function WayfindingControls({
   return (
     <div className="flex w-full flex-col gap-3 rounded-2xl border border-line-soft bg-surface-1/95 p-4 shadow-glass backdrop-blur">
       <h2 className="text-sm font-semibold text-text-primary">
-        Indoor directions
+        {t("mappedin.wayfindTitle")}
       </h2>
 
       <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
-        From
+        {t("mappedin.wayfindFrom")}
         <Select value={from} onChange={(e) => setFrom(e.target.value)}>
-          <option value="">Choose a space…</option>
+          <option value="">{t("mappedin.wayfindPick")}</option>
           {spaces.map((s) => (
             <option key={s.id} value={s.id}>
               {s.name}
@@ -63,9 +68,9 @@ export function WayfindingControls({
       </label>
 
       <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
-        To
+        {t("mappedin.wayfindTo")}
         <Select value={to} onChange={(e) => setTo(e.target.value)}>
-          <option value="">Choose a space…</option>
+          <option value="">{t("mappedin.wayfindPick")}</option>
           {spaces.map((s) => (
             <option key={s.id} value={s.id}>
               {s.name}
@@ -81,21 +86,23 @@ export function WayfindingControls({
           onChange={(e) => setAccessible(e.target.checked)}
           className="h-4 w-4 rounded accent-accent"
         />
-        Step-free route
+        {t("mappedin.wayfindStepFree")}
       </label>
 
       {error ? <p className="text-xs text-red-600">{error}</p> : null}
 
       <div className="flex justify-end gap-2">
         <Button size="sm" variant="secondary" onClick={onClear}>
-          Clear
+          {t("mappedin.wayfindClear")}
         </Button>
         <Button
           size="sm"
           disabled={!canRoute}
           onClick={() => onRoute(from, to, accessible)}
         >
-          {routing ? "Routing…" : "Get directions"}
+          {routing
+            ? t("mappedin.wayfindRouting")
+            : t("mappedin.wayfindGo")}
         </Button>
       </div>
     </div>

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -16,8 +16,11 @@ export interface WayfindingControlsProps {
   routing: boolean;
   /** Inline error (no route, routing failed). */
   error: string | null;
-  /** Compute + draw a route between two spaces. */
-  onRoute: (fromId: string, toId: string) => void;
+  /**
+   * Compute + draw a route between two spaces. `accessible` requests
+   * MappedIn's step-free route — stairs avoided where alternatives exist.
+   */
+  onRoute: (fromId: string, toId: string, accessible: boolean) => void;
   /** Clear the drawn route. */
   onClear: () => void;
 }
@@ -38,6 +41,7 @@ export function WayfindingControls({
 }: WayfindingControlsProps) {
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
+  const [accessible, setAccessible] = useState(false);
   const canRoute = from !== "" && to !== "" && from !== to && !routing;
 
   return (
@@ -70,6 +74,16 @@ export function WayfindingControls({
         </Select>
       </label>
 
+      <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-text-secondary">
+        <input
+          type="checkbox"
+          checked={accessible}
+          onChange={(e) => setAccessible(e.target.checked)}
+          className="h-4 w-4 rounded accent-accent"
+        />
+        Step-free route
+      </label>
+
       {error ? <p className="text-xs text-red-600">{error}</p> : null}
 
       <div className="flex justify-end gap-2">
@@ -79,7 +93,7 @@ export function WayfindingControls({
         <Button
           size="sm"
           disabled={!canRoute}
-          onClick={() => onRoute(from, to)}
+          onClick={() => onRoute(from, to, accessible)}
         >
           {routing ? "Routing…" : "Get directions"}
         </Button>

--- a/apps/campus/lib/public-campus.ts
+++ b/apps/campus/lib/public-campus.ts
@@ -1,0 +1,38 @@
+import "server-only";
+import { unstable_cache } from "next/cache";
+import { prisma } from "@/lib/prisma";
+
+/** Tag used to invalidate every cached public-campus lookup on edits. */
+export const CAMPUS_CACHE_TAG = "public-campus";
+
+/**
+ * Cached campus lookup for the public routes (home, map).
+ *
+ * Public pages would otherwise hit the database on every request —
+ * fine for a quiet site, painful under traffic. We cache the lookup
+ * for 60 seconds and invalidate it on every campus PATCH via
+ * {@link CAMPUS_CACHE_TAG}, so owner edits appear quickly.
+ *
+ * The selection is a superset that satisfies both the home and the
+ * map pages (and the home's `generateMetadata`) so they share one
+ * cache entry per token.
+ */
+export const getPublicCampusByToken = unstable_cache(
+  async (token: string) => {
+    return prisma.project
+      .findUnique({
+        where: { id: token },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          isPublished: true,
+          thumbnail: true,
+          sceneData: true,
+        },
+      })
+      .catch(() => null);
+  },
+  ["public-campus-by-token"],
+  { revalidate: 60, tags: [CAMPUS_CACHE_TAG] },
+);

--- a/apps/campus/lib/public-campus.ts
+++ b/apps/campus/lib/public-campus.ts
@@ -2,26 +2,30 @@ import "server-only";
 import { unstable_cache } from "next/cache";
 import { prisma } from "@/lib/prisma";
 
-/** Tag used to invalidate every cached public-campus lookup on edits. */
-export const CAMPUS_CACHE_TAG = "public-campus";
+/** Tag for a single campus's cached public lookup. */
+export const publicCampusTag = (token: string) => `public-campus:${token}`;
 
 /**
  * Cached campus lookup for the public routes (home, map).
  *
  * Public pages would otherwise hit the database on every request —
- * fine for a quiet site, painful under traffic. We cache the lookup
- * for 60 seconds and invalidate it on every campus PATCH via
- * {@link CAMPUS_CACHE_TAG}, so owner edits appear quickly.
+ * fine for a quiet site, painful under traffic. We cache per token
+ * for 60s and invalidate just that token on its PATCH / DELETE via
+ * {@link publicCampusTag} — one tenant's edits don't thrash every
+ * other campus's cache entry.
+ *
+ * The `.catch(() => null)` sits *outside* the cached function so a
+ * transient Prisma failure doesn't get cached as a permanent 404
+ * for 60s — only real, settled results are cached.
  *
  * The selection is a superset that satisfies both the home and the
- * map pages (and the home's `generateMetadata`) so they share one
- * cache entry per token.
+ * map pages (and the home's `generateMetadata`).
  */
-export const getPublicCampusByToken = unstable_cache(
-  async (token: string) => {
-    return prisma.project
-      .findUnique({
-        where: { id: token },
+export async function getPublicCampusByToken(token: string) {
+  const cached = unstable_cache(
+    async (t: string) => {
+      return prisma.project.findUnique({
+        where: { id: t },
         select: {
           id: true,
           title: true,
@@ -30,9 +34,14 @@ export const getPublicCampusByToken = unstable_cache(
           thumbnail: true,
           sceneData: true,
         },
-      })
-      .catch(() => null);
-  },
-  ["public-campus-by-token"],
-  { revalidate: 60, tags: [CAMPUS_CACHE_TAG] },
-);
+      });
+    },
+    ["public-campus-by-token", token],
+    { revalidate: 60, tags: [publicCampusTag(token)] },
+  );
+  try {
+    return await cached(token);
+  } catch {
+    return null;
+  }
+}

--- a/apps/campus/next.config.mjs
+++ b/apps/campus/next.config.mjs
@@ -12,6 +12,17 @@ const nextConfig = {
   // survive webpack bundling — load it at runtime instead of bundling
   // it into the server output.
   serverExternalPackages: ["node-ical"],
+  images: {
+    // Uploaded campus assets (hero, thumbnails, branding, floor
+    // plans) live on DigitalOcean Spaces — `<bucket>.<region>.
+    // digitaloceanspaces.com`. The wildcard covers any region.
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.digitaloceanspaces.com",
+      },
+    ],
+  },
   webpack(config) {
     config.resolve.alias = {
       ...config.resolve.alias,


### PR DESCRIPTION
## Why

The campus product is going **all-in on MappedIn** as its underlying map — public viewer, exploration, thumbnails ([memory: campus-indoor-mappedin-decision](#)). This branch is the production-push: finish the pivot, harden the public surfaces, fix what a real-world deploy would trip over.

One long-running branch by design (per directive): commit progressively, audit, sweep — open the PR only when it's worth merging.

## The eight commits, by theme

### MappedIn pivot finishers (4)

- **`5bd97e47`** — **MappedIn thumbnail capture.** `MappedinViewer` is now `forwardRef`-d with a `capture()` imperative handle (calls `mapView.takeScreenshot()`). The dashboard's **Indoor tab** has a "Capture thumbnail" button; the PNG uploads to `campus-thumbnails` and saves as the campus's `thumbnail`.
- **`0de0d56b`** — **Step-free routing toggle + friendlier MappedIn error state.** The wayfinding panel gets a "Step-free route" checkbox → `getDirections({ accessible: true })`. The viewer's error card got friendlier copy and the raw error pushed to a tiny detail line.
- **`92e38925`** — **MappedIn viewer translated (EN / EL).** Threaded `locale` through `MappedinViewer` and its sub-controls; added a `mappedin.*` key namespace in both languages (~18 keys). Greek visitors now get the wayfinding panel / search / step-free / loading / error in Greek.
- **`50127a16`** — **Hero image via `next/image`.** Replaced the CSS `background-image` with `<Image fill priority sizes=\"100vw\">` — automatic WebP/AVIF + responsive sizes. Added `images.remotePatterns` for `**.digitaloceanspaces.com`.

### Robustness / edge states (1)

- **`90f32e76`** — **Empty / 404 / error edge polish.** Translated `NotPublishedPlaceholder` (EN/EL). Branded **`not-found.tsx`** for `/campus/[token]/*` (replaces Next's generic 404). MappedIn viewer's error state gets an optional `homeHref` → public visitors aren't stranded if the map fails.

### Performance (1)

- **`1780bd59`** — **Cache the public campus DB lookup.** `getPublicCampusByToken` in `lib/public-campus.ts`, wrapped in `unstable_cache`, 60s TTL, per-token tag. Home (page + `generateMetadata`) and map share one cache entry per campus. The maps `PATCH`/`DELETE` `revalidateTag(publicCampusTag(mapId))` so owner edits show up immediately.

### Bug sweeps (2)

- **`872248e8`** — **Code-review sweep (8 real bugs).** Ran the `code-review` skill across the branch diff at high effort (5 angles, dedup, verify, sweep). Confirmed + fixed:
  1. DELETE handler didn't invalidate the cache → deleted campus served stale for 60s
  2. Single global cache tag → one tenant's edit wiped every campus
  3. `.catch(() => null)` inside the cache → DB blip cached null for 60s
  4. Hero `<Image>` rejected legacy / non-Spaces thumbnails → 500s on the public home
  5. `translate()` `str.replace` interpreted `$&` / `$1` in user input → corrupted search no-match message
  6. `mapHref` / `homeHref` / news + event pills dropped `?lang=` → Greek visitors lost locale on navigation
  7. `focusDoneRef` only fired once → soft-nav between rooms didn't refocus
  8. `handleRoute` `useCallback([])` closed over `locale` via `t()` → error language pinned to first render
- **`139942cc`** — **Dashboard audit.** Caught the same SWR-revalidation form-wipe bug in `SettingsTab` (the one I'd already fixed once in `HomePagePanel` — different file, same class) and replaced `IndoorTab`'s bare `catch {}` with a real error message + `console.error` so support can diagnose.

## Not in this PR (deliberately)

These are each a separate session/arc, sized to deserve their own PR:

- **Push notifications** ("event starting now in Building X" — Web Push + service worker + a scheduler)
- **Analytics dashboard** (rector-facing — visits, popular places, searches, event engagement)
- **Onboarding** (first-run experience for new campus owners)
- **Mapbox workbench's map-authoring path** — *parked* per the MappedIn pivot; lives in the tree but isn't the promoted product

## Testing

- `tsc --noEmit` clean throughout the branch.
- Pre-commit green on every commit.
- I didn't run a full `next build` (disk constraints) — the changes don't introduce new client/server boundary risks, but verify on your end before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)