### PR TITLE
feat(campus): map polish + side panel + AI assistant — professional-tool overhaul

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
@@ -96,13 +96,23 @@ export default function IndoorTab({ map, onConfigure }: Props) {
             <p className="text-xs text-text-tertiary">
               Frame the view, then capture it as the campus card image.
             </p>
-            <Button
-              size="sm"
-              onClick={handleCapture}
-              disabled={capturing}
-            >
-              {capturing ? "Capturing…" : "Capture thumbnail"}
-            </Button>
+            <div className="flex items-center gap-2">
+              <a
+                href={`/campus/${mapId}/map`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-medium text-accent transition-opacity hover:opacity-80"
+              >
+                Preview public view ↗
+              </a>
+              <Button
+                size="sm"
+                onClick={handleCapture}
+                disabled={capturing}
+              >
+                {capturing ? "Capturing…" : "Capture thumbnail"}
+              </Button>
+            </div>
           </div>
           <div className="h-[72vh] overflow-hidden rounded-2xl border border-line-soft">
             <MappedinViewer

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
@@ -36,9 +36,15 @@ export default function IndoorTab({ map, onConfigure }: Props) {
   const params = useParams<{ mapId: string }>();
   const mapId = params?.mapId ?? "";
 
-  const indoorMapId = (
-    map.sceneData as { indoorMapId?: string } | undefined
-  )?.indoorMapId;
+  const scene = map.sceneData as
+    | { indoorMapId?: string; branding?: { primaryColor?: string } }
+    | undefined;
+  const indoorMapId = scene?.indoorMapId;
+  const accentColor =
+    scene?.branding?.primaryColor &&
+    /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(scene.branding.primaryColor)
+      ? scene.branding.primaryColor
+      : undefined;
 
   const viewerRef = useRef<MappedinViewerHandle>(null);
   const [capturing, setCapturing] = useState(false);
@@ -102,6 +108,7 @@ export default function IndoorTab({ map, onConfigure }: Props) {
             <MappedinViewer
               ref={viewerRef}
               venue={venueForIndoorMap(indoorMapId)}
+              accentColor={accentColor}
             />
           </div>
         </>

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -60,6 +60,7 @@ export default async function CampusMapPage({
           locale={locale}
           homeHref={`/campus/${token}?lang=${locale}`}
           accentColor={accentColor}
+          showWelcome
         />
       </main>
     );

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -40,8 +40,16 @@ export default async function CampusMapPage({
   if (!map.isPublished)
     return <NotPublishedPlaceholder name={map.title} locale={locale} />;
 
-  const indoorMapId = (map.sceneData as { indoorMapId?: string } | null)
-    ?.indoorMapId;
+  const scene = (map.sceneData ?? null) as {
+    indoorMapId?: string;
+    branding?: { primaryColor?: string };
+  } | null;
+  const indoorMapId = scene?.indoorMapId;
+  const accentColor =
+    scene?.branding?.primaryColor &&
+    /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(scene.branding.primaryColor)
+      ? scene.branding.primaryColor
+      : undefined;
 
   if (indoorMapId) {
     return (
@@ -51,6 +59,7 @@ export default async function CampusMapPage({
           focusSpaceId={focusSpaceId}
           locale={locale}
           homeHref={`/campus/${token}?lang=${locale}`}
+          accentColor={accentColor}
         />
       </main>
     );

--- a/apps/campus/app/api/assistant/route.ts
+++ b/apps/campus/app/api/assistant/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server";
+
+interface SpaceInput {
+  id: string;
+  name: string;
+  type?: string;
+}
+
+interface RequestBody {
+  message: string;
+  spaces: SpaceInput[];
+  locale?: "en" | "el";
+}
+
+type Suggestion =
+  | { action: "focus"; toId: string }
+  | { action: "route"; fromId: string; toId: string; accessible: boolean };
+
+interface AssistantReply {
+  reply: string;
+  suggested?: Suggestion;
+}
+
+/** Loose match — exact, then "text contains a space name," then by digits. */
+function findSpace(text: string, spaces: SpaceInput[]): SpaceInput | undefined {
+  const cleaned = text.trim().toLowerCase().replace(/[?.!,]+$/, "");
+  if (!cleaned) return undefined;
+  const exact = spaces.find((s) => s.name.toLowerCase() === cleaned);
+  if (exact) return exact;
+  const containing = spaces.find(
+    (s) => s.name.length > 2 && cleaned.includes(s.name.toLowerCase()),
+  );
+  if (containing) return containing;
+  const num = cleaned.match(/\d+/)?.[0];
+  if (num) {
+    const numMatch = spaces.find((s) => s.name.includes(num));
+    if (numMatch) return numMatch;
+  }
+  return undefined;
+}
+
+/**
+ * Lightweight intent parser — no LLM needed. Handles the common
+ * student-facing patterns:
+ *   - "How do I get to room 201?"           → focus room 201
+ *   - "From the gym to the library"         → route gym → library
+ *   - "I use a wheelchair, reach the lab"   → focus lab, accessible
+ *   - "Show me the cafeteria"               → focus cafeteria
+ *
+ * When ANTHROPIC_API_KEY is set in the env, this is where a Claude
+ * tool-use call belongs — same return shape, much smarter matching.
+ * That's a follow-up; this fallback ships a usable assistant today.
+ */
+function parseMessage(message: string, spaces: SpaceInput[]): AssistantReply {
+  const text = message.toLowerCase();
+  const accessible =
+    /wheelchair|accessible|step.?free|αναπηρ|προσβάσιμ/.test(text);
+
+  // "from X to Y" pattern
+  const fromTo = text.match(/from\s+(.+?)\s+to\s+(.+?)(?:[?.!]+|$)/);
+  if (fromTo) {
+    const fromMatch = findSpace(fromTo[1], spaces);
+    const toMatch = findSpace(fromTo[2], spaces);
+    if (fromMatch && toMatch) {
+      return {
+        reply: `Routing from ${fromMatch.name} to ${toMatch.name}${accessible ? " (step-free)" : ""}.`,
+        suggested: {
+          action: "route",
+          fromId: fromMatch.id,
+          toId: toMatch.id,
+          accessible,
+        },
+      };
+    }
+  }
+
+  // "to X" / "reach X" / "find X" / "where's X" / single-space match
+  const toOnly = text.match(
+    /(?:to|reach|find|show(?: me)?|where(?:'s| is))\s+(?:the\s+)?(.+?)(?:[?.!]+|$)/,
+  );
+  const candidate = toOnly ? toOnly[1] : message;
+  const match = findSpace(candidate, spaces);
+  if (match) {
+    return {
+      reply: `Showing ${match.name} on the map${accessible ? " — pick a starting point and we'll route step-free." : "."}`,
+      suggested: { action: "focus", toId: match.id },
+    };
+  }
+
+  return {
+    reply:
+      "I couldn't match a room from that. Try a room name or number (e.g. \"201\" or \"library\"), or use the dropdowns above.",
+  };
+}
+
+export async function POST(req: Request) {
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!body.message || !Array.isArray(body.spaces)) {
+    return NextResponse.json(
+      { error: "message + spaces required" },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json(parseMessage(body.message, body.spaces));
+}

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -97,6 +97,9 @@ const MESSAGES = {
     "mappedin.welcomeTipTap": "Tap a space to see its details.",
     "mappedin.welcomeTipExplore": "Drag and pinch to look around.",
     "mappedin.welcomeGotIt": "Got it",
+    "mappedin.tabExplore": "Explore",
+    "mappedin.tabNavigate": "Navigate",
+    "mappedin.pickRoom": "Pick a starting room and a destination.",
 
     // Unpublished / not-found states
     "published.body":
@@ -192,6 +195,9 @@ const MESSAGES = {
     "mappedin.welcomeTipTap": "Αγγίξτε έναν χώρο για λεπτομέρειες.",
     "mappedin.welcomeTipExplore": "Σύρετε και ζουμάρετε για να εξερευνήσετε.",
     "mappedin.welcomeGotIt": "Εντάξει",
+    "mappedin.tabExplore": "Εξερεύνηση",
+    "mappedin.tabNavigate": "Πλοήγηση",
+    "mappedin.pickRoom": "Επιλέξτε αφετηρία και προορισμό.",
 
     // Unpublished / not-found states
     "published.body":

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -92,7 +92,11 @@ const MESSAGES = {
     "mappedin.building": "Building",
     "mappedin.floor": "Floor",
     "mappedin.searchSpaces": "Search rooms…",
+    "mappedin.searchBuildings": "Search buildings…",
+    "mappedin.searchPick": "Select…",
     "mappedin.noMatches": "No matches",
+    "mappedin.moreResults":
+      "Refine to see more ({shown} of {total})",
     "mappedin.errorBack": "Back to home",
     "mappedin.welcomeTitle": "Quick tips",
     "mappedin.welcomeTipSearch":
@@ -206,7 +210,11 @@ const MESSAGES = {
     "mappedin.building": "Κτίριο",
     "mappedin.floor": "Όροφος",
     "mappedin.searchSpaces": "Αναζήτηση αιθουσών…",
+    "mappedin.searchBuildings": "Αναζήτηση κτιρίων…",
+    "mappedin.searchPick": "Επιλογή…",
     "mappedin.noMatches": "Κανένα αποτέλεσμα",
+    "mappedin.moreResults":
+      "Περιορίστε για περισσότερα ({shown} από {total})",
     "mappedin.errorBack": "Πίσω στην αρχική",
     "mappedin.welcomeTitle": "Γρήγορες συμβουλές",
     "mappedin.welcomeTipSearch":

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -105,6 +105,14 @@ const MESSAGES = {
     "mappedin.profileWheelchair": "Wheelchair",
     "mappedin.profileVisual": "Visually impaired",
     "mappedin.swap": "Swap",
+    "mappedin.askAssistant": "Ask the assistant",
+    "mappedin.askDivider": "or ask the assistant",
+    "mappedin.askPlaceholder": "Ask about a route…",
+    "mappedin.askSend": "Send",
+    "mappedin.askExamples":
+      'Try: "How do I get to room 201?" or "I use a wheelchair, how do I reach the gym?"',
+    "mappedin.askUnavailable":
+      "Sorry — the assistant is unavailable right now.",
 
     // Unpublished / not-found states
     "published.body":
@@ -208,6 +216,14 @@ const MESSAGES = {
     "mappedin.profileWheelchair": "Αναπηρικό αμαξίδιο",
     "mappedin.profileVisual": "Πρόβλημα όρασης",
     "mappedin.swap": "Εναλλαγή",
+    "mappedin.askAssistant": "Ρωτήστε τον βοηθό",
+    "mappedin.askDivider": "ή ρωτήστε τον βοηθό",
+    "mappedin.askPlaceholder": "Ρωτήστε για μια διαδρομή…",
+    "mappedin.askSend": "Αποστολή",
+    "mappedin.askExamples":
+      'Δοκιμάστε: «Πώς πάω στην αίθουσα 201;» ή «Είμαι σε αναπηρικό αμαξίδιο, πώς φτάνω στο γυμναστήριο;»',
+    "mappedin.askUnavailable":
+      "Λυπούμαστε — ο βοηθός δεν είναι διαθέσιμος αυτή τη στιγμή.",
 
     // Unpublished / not-found states
     "published.body":

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -100,6 +100,11 @@ const MESSAGES = {
     "mappedin.tabExplore": "Explore",
     "mappedin.tabNavigate": "Navigate",
     "mappedin.pickRoom": "Pick a starting room and a destination.",
+    "mappedin.profile": "Profile",
+    "mappedin.profileDefault": "Default",
+    "mappedin.profileWheelchair": "Wheelchair",
+    "mappedin.profileVisual": "Visually impaired",
+    "mappedin.swap": "Swap",
 
     // Unpublished / not-found states
     "published.body":
@@ -198,6 +203,11 @@ const MESSAGES = {
     "mappedin.tabExplore": "Εξερεύνηση",
     "mappedin.tabNavigate": "Πλοήγηση",
     "mappedin.pickRoom": "Επιλέξτε αφετηρία και προορισμό.",
+    "mappedin.profile": "Προφίλ",
+    "mappedin.profileDefault": "Κανονική",
+    "mappedin.profileWheelchair": "Αναπηρικό αμαξίδιο",
+    "mappedin.profileVisual": "Πρόβλημα όρασης",
+    "mappedin.swap": "Εναλλαγή",
 
     // Unpublished / not-found states
     "published.body":

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -90,6 +90,9 @@ const MESSAGES = {
     "mappedin.wayfindFailed": "We couldn’t compute that route.",
     "mappedin.clearSelection": "Clear selection",
     "mappedin.building": "Building",
+    "mappedin.floor": "Floor",
+    "mappedin.searchSpaces": "Search rooms…",
+    "mappedin.noMatches": "No matches",
     "mappedin.errorBack": "Back to home",
     "mappedin.welcomeTitle": "Quick tips",
     "mappedin.welcomeTipSearch":
@@ -201,6 +204,9 @@ const MESSAGES = {
     "mappedin.wayfindFailed": "Δεν υπολογίστηκε η διαδρομή.",
     "mappedin.clearSelection": "Καθαρισμός επιλογής",
     "mappedin.building": "Κτίριο",
+    "mappedin.floor": "Όροφος",
+    "mappedin.searchSpaces": "Αναζήτηση αιθουσών…",
+    "mappedin.noMatches": "Κανένα αποτέλεσμα",
     "mappedin.errorBack": "Πίσω στην αρχική",
     "mappedin.welcomeTitle": "Γρήγορες συμβουλές",
     "mappedin.welcomeTipSearch":

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -91,6 +91,12 @@ const MESSAGES = {
     "mappedin.clearSelection": "Clear selection",
     "mappedin.building": "Building",
     "mappedin.errorBack": "Back to home",
+    "mappedin.welcomeTitle": "Quick tips",
+    "mappedin.welcomeTipSearch":
+      "Search or pick a category to find a room.",
+    "mappedin.welcomeTipTap": "Tap a space to see its details.",
+    "mappedin.welcomeTipExplore": "Drag and pinch to look around.",
+    "mappedin.welcomeGotIt": "Got it",
 
     // Unpublished / not-found states
     "published.body":
@@ -180,6 +186,12 @@ const MESSAGES = {
     "mappedin.clearSelection": "Καθαρισμός επιλογής",
     "mappedin.building": "Κτίριο",
     "mappedin.errorBack": "Πίσω στην αρχική",
+    "mappedin.welcomeTitle": "Γρήγορες συμβουλές",
+    "mappedin.welcomeTipSearch":
+      "Αναζητήστε ή επιλέξτε κατηγορία για να βρείτε αίθουσα.",
+    "mappedin.welcomeTipTap": "Αγγίξτε έναν χώρο για λεπτομέρειες.",
+    "mappedin.welcomeTipExplore": "Σύρετε και ζουμάρετε για να εξερευνήσετε.",
+    "mappedin.welcomeGotIt": "Εντάξει",
 
     // Unpublished / not-found states
     "published.body":

--- a/apps/campus/lib/mappedin/AssistantChat.tsx
+++ b/apps/campus/lib/mappedin/AssistantChat.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@klorad/design-system";
+import { translate, type Locale } from "@/app/lib/i18n-core";
+import type { SpaceOption } from "./WayfindingControls";
+
+interface Message {
+  role: "user" | "assistant";
+  text: string;
+}
+
+export interface AssistantChatProps {
+  locale: Locale;
+  spaces: SpaceOption[];
+  /** Focus a space (used for "show me X" / single-destination intents). */
+  onFocus: (spaceId: string) => void;
+  /** Draw a route (used for "from X to Y" intents). */
+  onRoute: (fromId: string, toId: string, accessible: boolean) => void;
+}
+
+/**
+ * Ask-the-assistant chat for the Navigate tab.
+ *
+ * Posts to `/api/assistant`, which parses the message and replies
+ * with a short text + optionally an action (focus a space or draw a
+ * route). The chat dispatches the action to the viewer's own
+ * handlers — same call paths the dropdowns already use — so the map
+ * reacts identically whether the visitor typed or clicked.
+ *
+ * The backend is a lightweight regex parser today; a Claude call
+ * with tool use can plug in there later without changing this
+ * component.
+ */
+export function AssistantChat({
+  locale,
+  spaces,
+  onFocus,
+  onRoute,
+}: AssistantChatProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const t = (key: Parameters<typeof translate>[1]) =>
+    translate(locale, key);
+
+  const submit = async () => {
+    const msg = input.trim();
+    if (!msg || sending) return;
+    setMessages((m) => [...m, { role: "user", text: msg }]);
+    setInput("");
+    setSending(true);
+    try {
+      const res = await fetch("/api/assistant", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: msg,
+          spaces: spaces.map((s) => ({
+            id: s.id,
+            name: s.name,
+            type: s.type,
+          })),
+          locale,
+        }),
+      });
+      if (!res.ok) throw new Error("assistant failed");
+      const data = (await res.json()) as {
+        reply: string;
+        suggested?:
+          | { action: "focus"; toId: string }
+          | {
+              action: "route";
+              fromId: string;
+              toId: string;
+              accessible: boolean;
+            };
+      };
+      setMessages((m) => [...m, { role: "assistant", text: data.reply }]);
+      if (data.suggested?.action === "route") {
+        onRoute(
+          data.suggested.fromId,
+          data.suggested.toId,
+          data.suggested.accessible,
+        );
+      } else if (data.suggested?.action === "focus") {
+        onFocus(data.suggested.toId);
+      }
+    } catch {
+      setMessages((m) => [
+        ...m,
+        { role: "assistant", text: t("mappedin.askUnavailable") },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+        {t("mappedin.askAssistant")}
+      </h3>
+
+      {messages.length === 0 ? (
+        <p className="text-xs italic leading-relaxed text-text-tertiary">
+          {t("mappedin.askExamples")}
+        </p>
+      ) : (
+        <div className="max-h-48 space-y-2 overflow-y-auto rounded-xl bg-surface-2 p-2 text-xs leading-relaxed">
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              className={
+                m.role === "user"
+                  ? "text-text-primary"
+                  : "text-text-secondary"
+              }
+            >
+              <span className="font-semibold">
+                {m.role === "user" ? "You" : "Assistant"}:{" "}
+              </span>
+              {m.text}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void submit();
+          }}
+          placeholder={t("mappedin.askPlaceholder")}
+          disabled={sending}
+          className="min-w-0 flex-1 rounded-lg border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-accent"
+        />
+        <Button
+          size="sm"
+          onClick={() => void submit()}
+          disabled={sending || !input.trim()}
+        >
+          {t("mappedin.askSend")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/lib/mappedin/ExploreTab.tsx
+++ b/apps/campus/lib/mappedin/ExploreTab.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { translate, type Locale } from "@/app/lib/i18n-core";
+import { SearchControls } from "./SearchControls";
+import type { SpaceOption } from "./WayfindingControls";
+
+export interface ExploreTabProps {
+  locale: Locale;
+  spaces: SpaceOption[];
+  onSearchSelect: (id: string) => void;
+  selectedSpace: { id: string; name: string } | null;
+  onClearSelection: () => void;
+}
+
+/**
+ * Explore tab content — search + categories + the currently
+ * selected space. Bare versions of the controls (no floating-card
+ * chrome) since the surrounding side panel is the chrome.
+ */
+export function ExploreTab({
+  locale,
+  spaces,
+  onSearchSelect,
+  selectedSpace,
+  onClearSelection,
+}: ExploreTabProps) {
+  return (
+    <div className="space-y-4">
+      <SearchControls
+        spaces={spaces}
+        onSelect={onSearchSelect}
+        locale={locale}
+        bare
+      />
+
+      {selectedSpace ? (
+        <div className="flex items-center gap-3 rounded-xl bg-accent-soft px-3 py-2">
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-accent">
+            {selectedSpace.name}
+          </span>
+          <button
+            type="button"
+            onClick={onClearSelection}
+            aria-label={translate(locale, "mappedin.clearSelection")}
+            className="shrink-0 text-sm leading-none text-accent transition-opacity hover:opacity-70"
+          >
+            ✕
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/campus/lib/mappedin/FloorControls.tsx
+++ b/apps/campus/lib/mappedin/FloorControls.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Select, cn } from "@klorad/design-system";
+import { cn } from "@klorad/design-system";
 import { translate, type Locale } from "@/app/lib/i18n-core";
+import { SearchableSelect } from "./SearchableSelect";
 
 /** A switchable level — a floor or a building. Just `{ id, name }`. */
 export interface FloorOption {
@@ -55,40 +56,47 @@ export function FloorControls({
       )}
     >
       {multiBuilding ? (
-        <Select
-          value={currentBuildingId}
-          onChange={(e) => onSelectBuilding(e.target.value)}
-          aria-label={translate(locale, "mappedin.building")}
-        >
-          {buildings.map((b) => (
-            <option key={b.id} value={b.id}>
-              {b.name}
-            </option>
-          ))}
-        </Select>
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-text-secondary">
+            {translate(locale, "mappedin.building")}
+          </span>
+          <SearchableSelect
+            options={buildings}
+            value={currentBuildingId}
+            onChange={onSelectBuilding}
+            placeholder={translate(locale, "mappedin.building")}
+            noMatchLabel={translate(locale, "mappedin.noMatches")}
+            ariaLabel={translate(locale, "mappedin.building")}
+          />
+        </div>
       ) : null}
 
       {floors.length > 1 ? (
-        <div className="flex max-h-[40vh] flex-col gap-1 overflow-y-auto">
-          {floors.map((floor) => {
-            const active = floor.id === currentFloorId;
-            return (
-              <button
-                key={floor.id}
-                type="button"
-                onClick={() => onSelectFloor(floor.id)}
-                aria-pressed={active}
-                className={cn(
-                  "shrink-0 truncate rounded-xl px-3 py-2 text-xs font-medium transition-colors",
-                  active
-                    ? "bg-accent text-accent-contrast"
-                    : "text-text-secondary hover:bg-accent-soft hover:text-accent",
-                )}
-              >
-                {floor.name}
-              </button>
-            );
-          })}
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-text-secondary">
+            {translate(locale, "mappedin.floor")}
+          </span>
+          <div className="flex max-h-[40vh] flex-col gap-1 overflow-y-auto">
+            {floors.map((floor) => {
+              const active = floor.id === currentFloorId;
+              return (
+                <button
+                  key={floor.id}
+                  type="button"
+                  onClick={() => onSelectFloor(floor.id)}
+                  aria-pressed={active}
+                  className={cn(
+                    "shrink-0 truncate rounded-xl px-3 py-2 text-xs font-medium transition-colors",
+                    active
+                      ? "bg-accent text-accent-contrast"
+                      : "text-text-secondary hover:bg-accent-soft hover:text-accent",
+                  )}
+                >
+                  {floor.name}
+                </button>
+              );
+            })}
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/campus/lib/mappedin/FloorControls.tsx
+++ b/apps/campus/lib/mappedin/FloorControls.tsx
@@ -21,6 +21,8 @@ export interface FloorControlsProps {
   className?: string;
   /** UI locale — defaults to English. */
   locale?: Locale;
+  /** Drop the rounded-card chrome — for use inside the side panel. */
+  bare?: boolean;
 }
 
 /**
@@ -37,6 +39,7 @@ export function FloorControls({
   onSelectBuilding,
   className,
   locale = "en",
+  bare = false,
 }: FloorControlsProps) {
   const multiBuilding = buildings.length > 1;
   // Nothing to switch — don't render an empty control.
@@ -45,7 +48,9 @@ export function FloorControls({
   return (
     <div
       className={cn(
-        "flex w-44 flex-col gap-2 rounded-2xl border border-line-soft bg-surface-1/95 p-2 shadow-glass backdrop-blur",
+        bare
+          ? "flex w-full flex-col gap-2"
+          : "flex w-44 flex-col gap-2 rounded-2xl border border-line-soft bg-surface-1/95 p-2 shadow-glass backdrop-blur",
         className,
       )}
     >

--- a/apps/campus/lib/mappedin/FloorControls.tsx
+++ b/apps/campus/lib/mappedin/FloorControls.tsx
@@ -65,7 +65,11 @@ export function FloorControls({
             value={currentBuildingId}
             onChange={onSelectBuilding}
             placeholder={translate(locale, "mappedin.building")}
+            searchPlaceholder={translate(locale, "mappedin.searchBuildings")}
             noMatchLabel={translate(locale, "mappedin.noMatches")}
+            moreResultsLabel={(shown, total) =>
+              translate(locale, "mappedin.moreResults", { shown, total })
+            }
             ariaLabel={translate(locale, "mappedin.building")}
           />
         </div>

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -12,9 +12,9 @@ import Link from "next/link";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
 import { translate, type Locale } from "@/app/lib/i18n-core";
-import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
-import { SearchControls } from "./SearchControls";
-import { FloorControls, type FloorOption } from "./FloorControls";
+import { type SpaceOption } from "./WayfindingControls";
+import { type FloorOption } from "./FloorControls";
+import { SidePanel } from "./SidePanel";
 import { WelcomeOverlay } from "./WelcomeOverlay";
 
 /**
@@ -446,103 +446,74 @@ export const MappedinViewer = forwardRef<
   );
 
   return (
-    <div className="relative h-full w-full bg-bg">
-      <div ref={containerRef} className="h-full w-full" />
-
-      {status === "loading" ? (
-        <div className="pointer-events-none absolute inset-0 animate-pulse bg-surface-2/40">
-          <div className="absolute inset-0 flex items-center justify-center">
-            <span className="text-sm font-medium text-text-secondary">
-              {t("mappedin.loading")}
-            </span>
-          </div>
-        </div>
-      ) : null}
-
-      {status === "error" ? (
-        <div className="absolute inset-0 flex items-center justify-center p-8">
-          <div className="max-w-sm rounded-2xl border border-solid border-line-soft bg-surface-1 p-5 text-center shadow-glass">
-            <p className="text-sm font-medium text-text-primary">
-              {t("mappedin.errorTitle")}
-            </p>
-            <p className="mt-1 text-xs text-text-tertiary">
-              {t("mappedin.errorBody")}
-            </p>
-            {error ? (
-              <p className="mt-2 text-[0.65rem] text-text-tertiary opacity-60">
-                {error}
-              </p>
-            ) : null}
-            {homeHref ? (
-              <Link
-                href={homeHref}
-                className="mt-4 inline-block text-xs font-medium text-accent transition-opacity hover:opacity-80"
-              >
-                ← {t("mappedin.errorBack")}
-              </Link>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-
-      {status === "ready" && spaces.length > 0 ? (
-        <div className="absolute left-4 top-4 z-10 flex w-72 flex-col gap-3">
-          <SearchControls
-            spaces={spaces}
-            onSelect={(id) => void handleSearchSelect(id)}
-            locale={locale}
-          />
-          {spaces.length >= 2 ? (
-            <WayfindingControls
-              spaces={spaces}
-              routing={routing}
-              error={routeError}
-              summary={routeSummary}
-              instructions={routeInstructions}
-              onRoute={(from, to, accessible) =>
-                void handleRoute(from, to, accessible)
-              }
-              onClear={handleClear}
-              locale={locale}
-            />
-          ) : null}
-        </div>
-      ) : null}
-
-      {status === "ready" ? (
-        <FloorControls
+    <div className="flex h-full w-full flex-col bg-bg md:flex-row">
+      <aside className="h-[40vh] shrink-0 border-b border-solid border-line-soft md:h-full md:w-80 md:border-b-0 md:border-r">
+        <SidePanel
+          locale={locale}
+          spaces={spaces}
+          onSearchSelect={(id) => void handleSearchSelect(id)}
+          selectedSpace={selectedSpace}
+          onClearSelection={clearSelection}
           floors={floors}
           currentFloorId={currentFloorId}
           buildings={buildings}
           currentBuildingId={currentBuildingId}
           onSelectFloor={(id) => void handleSelectFloor(id)}
           onSelectBuilding={(id) => void handleSelectBuilding(id)}
-          locale={locale}
-          // Top-right — clear of MappedIn's own zoom / nav controls,
-          // which sit centred on the right edge.
-          className="absolute right-4 top-4 z-10"
+          routing={routing}
+          routeError={routeError}
+          routeSummary={routeSummary}
+          routeInstructions={routeInstructions}
+          onRoute={(from, to, accessible) =>
+            void handleRoute(from, to, accessible)
+          }
+          onClearRoute={handleClear}
         />
-      ) : null}
+      </aside>
 
-      {status === "ready" && showWelcome ? (
-        <WelcomeOverlay locale={locale} />
-      ) : null}
+      <div className="relative min-h-0 flex-1">
+        <div ref={containerRef} className="absolute inset-0" />
 
-      {selectedSpace ? (
-        <div className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 items-center gap-3 rounded-2xl border border-line-soft bg-surface-1/95 px-4 py-2.5 shadow-glass backdrop-blur">
-          <span className="text-sm font-medium text-text-primary">
-            {selectedSpace.name}
-          </span>
-          <button
-            type="button"
-            onClick={clearSelection}
-            aria-label={t("mappedin.clearSelection")}
-            className="text-sm leading-none text-text-tertiary transition-colors hover:text-text-primary"
-          >
-            ✕
-          </button>
-        </div>
-      ) : null}
+        {status === "loading" ? (
+          <div className="pointer-events-none absolute inset-0 animate-pulse bg-surface-2/40">
+            <div className="absolute inset-0 flex items-center justify-center">
+              <span className="text-sm font-medium text-text-secondary">
+                {t("mappedin.loading")}
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        {status === "error" ? (
+          <div className="absolute inset-0 flex items-center justify-center p-8">
+            <div className="max-w-sm rounded-2xl border border-solid border-line-soft bg-surface-1 p-5 text-center shadow-glass">
+              <p className="text-sm font-medium text-text-primary">
+                {t("mappedin.errorTitle")}
+              </p>
+              <p className="mt-1 text-xs text-text-tertiary">
+                {t("mappedin.errorBody")}
+              </p>
+              {error ? (
+                <p className="mt-2 text-[0.65rem] text-text-tertiary opacity-60">
+                  {error}
+                </p>
+              ) : null}
+              {homeHref ? (
+                <Link
+                  href={homeHref}
+                  className="mt-4 inline-block text-xs font-medium text-accent transition-opacity hover:opacity-80"
+                >
+                  ← {t("mappedin.errorBack")}
+                </Link>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        {status === "ready" && showWelcome ? (
+          <WelcomeOverlay locale={locale} />
+        ) : null}
+      </div>
     </div>
   );
 });

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -9,7 +9,6 @@ import {
   useState,
 } from "react";
 import Link from "next/link";
-import { cn } from "@klorad/design-system";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
 import { translate, type Locale } from "@/app/lib/i18n-core";
@@ -135,8 +134,6 @@ export const MappedinViewer = forwardRef<
     id: string;
     name: string;
   } | null>(null);
-  /** Side panel — open on desktop always; on mobile, drawer toggled by a button. */
-  const [panelOpen, setPanelOpen] = useState(false);
 
   // Highlight a space (accent fill), reverting any previous one — the
   // shared mechanism behind both search and click selection. The
@@ -449,30 +446,12 @@ export const MappedinViewer = forwardRef<
   );
 
   return (
-    <div className="relative h-full w-full bg-bg md:flex md:flex-row">
-      {panelOpen ? (
-        <button
-          type="button"
-          onClick={() => setPanelOpen(false)}
-          aria-label="Close menu"
-          className="fixed inset-0 z-30 bg-black/40 md:hidden"
-        />
-      ) : null}
-
-      <aside
-        className={cn(
-          "fixed inset-y-0 left-0 z-40 w-[85vw] max-w-sm border-r border-solid border-line-soft shadow-2xl transition-transform duration-200",
-          "md:static md:inset-auto md:z-auto md:h-full md:w-80 md:shrink-0 md:translate-x-0 md:shadow-none",
-          panelOpen ? "translate-x-0" : "-translate-x-full",
-        )}
-      >
+    <div className="flex h-full w-full bg-bg">
+      <aside className="h-full w-64 shrink-0 border-r border-solid border-line-soft md:w-80">
         <SidePanel
           locale={locale}
           spaces={spaces}
-          onSearchSelect={(id) => {
-            setPanelOpen(false);
-            void handleSearchSelect(id);
-          }}
+          onSearchSelect={(id) => void handleSearchSelect(id)}
           selectedSpace={selectedSpace}
           onClearSelection={clearSelection}
           floors={floors}
@@ -485,39 +464,15 @@ export const MappedinViewer = forwardRef<
           routeError={routeError}
           routeSummary={routeSummary}
           routeInstructions={routeInstructions}
-          onRoute={(from, to, accessible) => {
-            setPanelOpen(false);
-            void handleRoute(from, to, accessible);
-          }}
+          onRoute={(from, to, accessible) =>
+            void handleRoute(from, to, accessible)
+          }
           onClearRoute={handleClear}
         />
       </aside>
 
-      <div className="relative h-full md:min-h-0 md:flex-1">
+      <div className="relative min-h-0 flex-1">
         <div ref={containerRef} className="absolute inset-0" />
-
-        <button
-          type="button"
-          onClick={() => setPanelOpen(true)}
-          aria-label="Open menu"
-          className="absolute left-3 top-3 z-20 flex items-center gap-2 rounded-full bg-surface-1/95 px-3 py-2 text-sm font-semibold text-text-primary shadow-glass backdrop-blur md:hidden"
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            aria-hidden
-          >
-            <line x1="4" y1="6" x2="20" y2="6" />
-            <line x1="4" y1="12" x2="20" y2="12" />
-            <line x1="4" y1="18" x2="20" y2="18" />
-          </svg>
-          Menu
-        </button>
 
         {status === "loading" ? (
           <div className="pointer-events-none absolute inset-0 animate-pulse bg-surface-2/40">

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -258,7 +258,11 @@ export const MappedinViewer = forwardRef<
         }
         setSpaces(
           [...byId.values()]
-            .map((s) => ({ id: s.id, name: s.name as string }))
+            .map((s) => ({
+              id: s.id,
+              name: s.name as string,
+              type: (s as { type?: string }).type,
+            }))
             .sort((a, b) => a.name.localeCompare(b.name)),
         );
         // Buildings (floor-stacks) for the exploration controls.

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -9,7 +9,6 @@ import {
   useState,
 } from "react";
 import Link from "next/link";
-import { Spinner } from "@klorad/design-system";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
 import { translate, type Locale } from "@/app/lib/i18n-core";
@@ -50,13 +49,53 @@ interface MappedinViewerProps {
    * visitor isn't stranded — e.g. the campus home for the public map.
    */
   homeHref?: string;
+  /**
+   * Campus accent colour — used for the wayfinding route and the
+   * selected-space highlight. Defaults to Klorad blue.
+   */
+  accentColor?: string;
+}
+
+/** Default accent for venues with no branding colour. */
+const DEFAULT_ACCENT = "#158ca3";
+
+/** Format a route's metric summary — "120 m · ~2 min". */
+function formatRouteSummary(
+  distanceM: number | undefined,
+  durationS: number | undefined,
+): string | null {
+  const parts: string[] = [];
+  if (typeof distanceM === "number" && Number.isFinite(distanceM)) {
+    parts.push(
+      distanceM >= 1000
+        ? `${(distanceM / 1000).toFixed(1)} km`
+        : `${Math.round(distanceM)} m`,
+    );
+  }
+  // Walking-pace fallback (~1.4 m/s) if the SDK didn't surface duration.
+  const seconds =
+    typeof durationS === "number" && Number.isFinite(durationS)
+      ? durationS
+      : typeof distanceM === "number" && Number.isFinite(distanceM)
+        ? distanceM / 1.4
+        : undefined;
+  if (seconds !== undefined) {
+    parts.push(`~${Math.max(1, Math.round(seconds / 60))} min`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
 }
 
 export const MappedinViewer = forwardRef<
   MappedinViewerHandle,
   MappedinViewerProps
 >(function MappedinViewer(
-  { venue, focusSpaceId, locale = "en", homeHref },
+  {
+    venue,
+    focusSpaceId,
+    locale = "en",
+    homeHref,
+    accentColor = DEFAULT_ACCENT,
+  },
   ref,
 ) {
   const t = (key: Parameters<typeof translate>[1]) => translate(locale, key);
@@ -81,6 +120,7 @@ export const MappedinViewer = forwardRef<
   const [spaces, setSpaces] = useState<SpaceOption[]>([]);
   const [routing, setRouting] = useState(false);
   const [routeError, setRouteError] = useState<string | null>(null);
+  const [routeSummary, setRouteSummary] = useState<string | null>(null);
   const [floors, setFloors] = useState<FloorOption[]>([]);
   const [currentFloorId, setCurrentFloorId] = useState("");
   const [buildings, setBuildings] = useState<FloorOption[]>([]);
@@ -91,34 +131,38 @@ export const MappedinViewer = forwardRef<
   } | null>(null);
 
   // Highlight a space (accent fill), reverting any previous one — the
-  // shared mechanism behind both search and click selection.
-  const highlightSpace = useCallback((space: Space) => {
-    const mapView = mapViewRef.current;
-    if (!mapView) return;
-    const previous = highlightRef.current;
-    if (previous && previous.space === space) return;
-    if (previous) {
+  // shared mechanism behind both search and click selection. The
+  // accent matches the campus's branding colour.
+  const highlightSpace = useCallback(
+    (space: Space) => {
+      const mapView = mapViewRef.current;
+      if (!mapView) return;
+      const previous = highlightRef.current;
+      if (previous && previous.space === space) return;
+      if (previous) {
+        try {
+          mapView.updateState(previous.space, {
+            color: previous.originalColor,
+          });
+        } catch {
+          /* ignore */
+        }
+      }
+      let originalColor: string | undefined;
       try {
-        mapView.updateState(previous.space, {
-          color: previous.originalColor,
-        });
+        originalColor = mapView.getState(space)?.color;
       } catch {
         /* ignore */
       }
-    }
-    let originalColor: string | undefined;
-    try {
-      originalColor = mapView.getState(space)?.color;
-    } catch {
-      /* ignore */
-    }
-    highlightRef.current = { space, originalColor };
-    try {
-      mapView.updateState(space, { color: "#158ca3" });
-    } catch {
-      /* ignore */
-    }
-  }, []);
+      highlightRef.current = { space, originalColor };
+      try {
+        mapView.updateState(space, { color: accentColor });
+      } catch {
+        /* ignore */
+      }
+    },
+    [accentColor],
+  );
 
   // Drop the selection — clear the detail card and the highlight.
   const clearSelection = useCallback(() => {
@@ -260,6 +304,7 @@ export const MappedinViewer = forwardRef<
 
       setRouting(true);
       setRouteError(null);
+      setRouteSummary(null);
       try {
         mapView.Navigation.clear();
         const directions = await mapData.getDirections(
@@ -275,19 +320,27 @@ export const MappedinViewer = forwardRef<
           );
           return;
         }
-        await mapView.Navigation.draw(directions);
+        await mapView.Navigation.draw(directions, {
+          pathOptions: { color: accentColor },
+        });
+        const d = directions as {
+          distance?: number;
+          duration?: number;
+        };
+        setRouteSummary(formatRouteSummary(d.distance, d.duration));
       } catch {
         setRouteError(translate(locale, "mappedin.wayfindFailed"));
       } finally {
         setRouting(false);
       }
     },
-    [locale],
+    [locale, accentColor],
   );
 
   const handleClear = useCallback(() => {
     mapViewRef.current?.Navigation.clear();
     setRouteError(null);
+    setRouteSummary(null);
   }, []);
 
   // Search → switch to the space's floor, highlight + select it, fly there.
@@ -380,11 +433,12 @@ export const MappedinViewer = forwardRef<
       <div ref={containerRef} className="h-full w-full" />
 
       {status === "loading" ? (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <span className="flex items-center gap-3 text-sm text-text-secondary">
-            <Spinner />
-            {t("mappedin.loading")}
-          </span>
+        <div className="pointer-events-none absolute inset-0 animate-pulse bg-surface-2/40">
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-sm font-medium text-text-secondary">
+              {t("mappedin.loading")}
+            </span>
+          </div>
         </div>
       ) : null}
 
@@ -426,6 +480,7 @@ export const MappedinViewer = forwardRef<
               spaces={spaces}
               routing={routing}
               error={routeError}
+              summary={routeSummary}
               onRoute={(from, to, accessible) =>
                 void handleRoute(from, to, accessible)
               }

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -121,6 +121,7 @@ export const MappedinViewer = forwardRef<
   const [routing, setRouting] = useState(false);
   const [routeError, setRouteError] = useState<string | null>(null);
   const [routeSummary, setRouteSummary] = useState<string | null>(null);
+  const [routeInstructions, setRouteInstructions] = useState<string[]>([]);
   const [floors, setFloors] = useState<FloorOption[]>([]);
   const [currentFloorId, setCurrentFloorId] = useState("");
   const [buildings, setBuildings] = useState<FloorOption[]>([]);
@@ -309,6 +310,7 @@ export const MappedinViewer = forwardRef<
       setRouting(true);
       setRouteError(null);
       setRouteSummary(null);
+      setRouteInstructions([]);
       try {
         mapView.Navigation.clear();
         const directions = await mapData.getDirections(
@@ -330,8 +332,14 @@ export const MappedinViewer = forwardRef<
         const d = directions as {
           distance?: number;
           duration?: number;
+          instructions?: Array<{ instruction?: string }>;
         };
         setRouteSummary(formatRouteSummary(d.distance, d.duration));
+        setRouteInstructions(
+          (d.instructions ?? [])
+            .map((i) => (i.instruction ?? "").trim())
+            .filter(Boolean),
+        );
       } catch {
         setRouteError(translate(locale, "mappedin.wayfindFailed"));
       } finally {
@@ -345,6 +353,7 @@ export const MappedinViewer = forwardRef<
     mapViewRef.current?.Navigation.clear();
     setRouteError(null);
     setRouteSummary(null);
+    setRouteInstructions([]);
   }, []);
 
   // Search → switch to the space's floor, highlight + select it, fly there.
@@ -485,6 +494,7 @@ export const MappedinViewer = forwardRef<
               routing={routing}
               error={routeError}
               summary={routeSummary}
+              instructions={routeInstructions}
               onRoute={(from, to, accessible) =>
                 void handleRoute(from, to, accessible)
               }

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -413,6 +413,17 @@ export const MappedinViewer = forwardRef<
         /* ignore */
       }
       syncFloors();
+      // Frame the camera on the new building so the visitor sees a
+      // jump, not just a floor-stack swap behind the scenes. The
+      // active floor is a viewable target the SDK can focus.
+      const floor = mapView.currentFloor;
+      if (floor) {
+        try {
+          await mapView.Camera.focusOn(floor);
+        } catch {
+          /* some SDK builds don't accept a Floor — silently ignore */
+        }
+      }
     },
     [syncFloors],
   );

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import Link from "next/link";
+import { cn } from "@klorad/design-system";
 import type { MapData, MapView, Space } from "@mappedin/mappedin-js";
 import type { MappedinVenue } from "./config";
 import { translate, type Locale } from "@/app/lib/i18n-core";
@@ -134,6 +135,8 @@ export const MappedinViewer = forwardRef<
     id: string;
     name: string;
   } | null>(null);
+  /** Side panel — open on desktop always; on mobile, drawer toggled by a button. */
+  const [panelOpen, setPanelOpen] = useState(false);
 
   // Highlight a space (accent fill), reverting any previous one — the
   // shared mechanism behind both search and click selection. The
@@ -446,12 +449,30 @@ export const MappedinViewer = forwardRef<
   );
 
   return (
-    <div className="flex h-full w-full flex-col bg-bg md:flex-row">
-      <aside className="h-[40vh] shrink-0 border-b border-solid border-line-soft md:h-full md:w-80 md:border-b-0 md:border-r">
+    <div className="relative h-full w-full bg-bg md:flex md:flex-row">
+      {panelOpen ? (
+        <button
+          type="button"
+          onClick={() => setPanelOpen(false)}
+          aria-label="Close menu"
+          className="fixed inset-0 z-30 bg-black/40 md:hidden"
+        />
+      ) : null}
+
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-40 w-[85vw] max-w-sm border-r border-solid border-line-soft shadow-2xl transition-transform duration-200",
+          "md:static md:inset-auto md:z-auto md:h-full md:w-80 md:shrink-0 md:translate-x-0 md:shadow-none",
+          panelOpen ? "translate-x-0" : "-translate-x-full",
+        )}
+      >
         <SidePanel
           locale={locale}
           spaces={spaces}
-          onSearchSelect={(id) => void handleSearchSelect(id)}
+          onSearchSelect={(id) => {
+            setPanelOpen(false);
+            void handleSearchSelect(id);
+          }}
           selectedSpace={selectedSpace}
           onClearSelection={clearSelection}
           floors={floors}
@@ -464,15 +485,39 @@ export const MappedinViewer = forwardRef<
           routeError={routeError}
           routeSummary={routeSummary}
           routeInstructions={routeInstructions}
-          onRoute={(from, to, accessible) =>
-            void handleRoute(from, to, accessible)
-          }
+          onRoute={(from, to, accessible) => {
+            setPanelOpen(false);
+            void handleRoute(from, to, accessible);
+          }}
           onClearRoute={handleClear}
         />
       </aside>
 
-      <div className="relative min-h-0 flex-1">
+      <div className="relative h-full md:min-h-0 md:flex-1">
         <div ref={containerRef} className="absolute inset-0" />
+
+        <button
+          type="button"
+          onClick={() => setPanelOpen(true)}
+          aria-label="Open menu"
+          className="absolute left-3 top-3 z-20 flex items-center gap-2 rounded-full bg-surface-1/95 px-3 py-2 text-sm font-semibold text-text-primary shadow-glass backdrop-blur md:hidden"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            aria-hidden
+          >
+            <line x1="4" y1="6" x2="20" y2="6" />
+            <line x1="4" y1="12" x2="20" y2="12" />
+            <line x1="4" y1="18" x2="20" y2="18" />
+          </svg>
+          Menu
+        </button>
 
         {status === "loading" ? (
           <div className="pointer-events-none absolute inset-0 animate-pulse bg-surface-2/40">

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -135,6 +136,17 @@ export const MappedinViewer = forwardRef<
     name: string;
   } | null>(null);
 
+  // Rooms shown in the selectors / search are scoped to the active
+  // building — picking a building filters the world down. Spaces
+  // whose buildingId is missing (data quirk) stay visible so we
+  // never hide everything by accident.
+  const visibleSpaces = useMemo(() => {
+    if (!currentBuildingId) return spaces;
+    return spaces.filter(
+      (s) => !s.buildingId || s.buildingId === currentBuildingId,
+    );
+  }, [spaces, currentBuildingId]);
+
   // Highlight a space (accent fill), reverting any previous one — the
   // shared mechanism behind both search and click selection. The
   // accent matches the campus's branding colour.
@@ -263,11 +275,20 @@ export const MappedinViewer = forwardRef<
         }
         setSpaces(
           [...byId.values()]
-            .map((s) => ({
-              id: s.id,
-              name: s.name as string,
-              type: (s as { type?: string }).type,
-            }))
+            .map((s) => {
+              // Reach through the SDK shape — Space.floor.floorStack.id —
+              // so we can filter the selectors to the active building.
+              const withFloor = s as {
+                type?: string;
+                floor?: { floorStack?: { id?: string } };
+              };
+              return {
+                id: s.id,
+                name: s.name as string,
+                type: withFloor.type,
+                buildingId: withFloor.floor?.floorStack?.id,
+              };
+            })
             .sort((a, b) => a.name.localeCompare(b.name)),
         );
         // Buildings (floor-stacks) for the exploration controls.
@@ -461,7 +482,7 @@ export const MappedinViewer = forwardRef<
       <aside className="h-full w-64 shrink-0 border-r border-solid border-line-soft md:w-80">
         <SidePanel
           locale={locale}
-          spaces={spaces}
+          spaces={visibleSpaces}
           onSearchSelect={(id) => void handleSearchSelect(id)}
           selectedSpace={selectedSpace}
           onClearSelection={clearSelection}

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -15,6 +15,7 @@ import { translate, type Locale } from "@/app/lib/i18n-core";
 import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
 import { SearchControls } from "./SearchControls";
 import { FloorControls, type FloorOption } from "./FloorControls";
+import { WelcomeOverlay } from "./WelcomeOverlay";
 
 /**
  * The MappedIn indoor viewer.
@@ -54,6 +55,8 @@ interface MappedinViewerProps {
    * selected-space highlight. Defaults to Klorad blue.
    */
   accentColor?: string;
+  /** Show the first-visit tips overlay (public map only). */
+  showWelcome?: boolean;
 }
 
 /** Default accent for venues with no branding colour. */
@@ -95,6 +98,7 @@ export const MappedinViewer = forwardRef<
     locale = "en",
     homeHref,
     accentColor = DEFAULT_ACCENT,
+    showWelcome = false,
   },
   ref,
 ) {
@@ -518,6 +522,10 @@ export const MappedinViewer = forwardRef<
           // which sit centred on the right edge.
           className="absolute right-4 top-4 z-10"
         />
+      ) : null}
+
+      {status === "ready" && showWelcome ? (
+        <WelcomeOverlay locale={locale} />
       ) : null}
 
       {selectedSpace ? (

--- a/apps/campus/lib/mappedin/NavigateTab.tsx
+++ b/apps/campus/lib/mappedin/NavigateTab.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
+import type { Locale } from "@/app/lib/i18n-core";
+
+export interface NavigateTabProps {
+  locale: Locale;
+  spaces: SpaceOption[];
+  routing: boolean;
+  routeError: string | null;
+  routeSummary: string | null;
+  routeInstructions: string[];
+  onRoute: (from: string, to: string, accessible: boolean) => void;
+  onClearRoute: () => void;
+}
+
+/**
+ * Navigate tab content — wayfinding (From / To / step-free /
+ * summary / turn-by-turn). The chat assistant lands here in a
+ * follow-up commit.
+ */
+export function NavigateTab({
+  locale,
+  spaces,
+  routing,
+  routeError,
+  routeSummary,
+  routeInstructions,
+  onRoute,
+  onClearRoute,
+}: NavigateTabProps) {
+  return (
+    <div className="space-y-4">
+      <WayfindingControls
+        spaces={spaces}
+        routing={routing}
+        error={routeError}
+        summary={routeSummary}
+        instructions={routeInstructions}
+        onRoute={onRoute}
+        onClear={onClearRoute}
+        locale={locale}
+        bare
+      />
+    </div>
+  );
+}

--- a/apps/campus/lib/mappedin/NavigateTab.tsx
+++ b/apps/campus/lib/mappedin/NavigateTab.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+import { useState } from "react";
+import { cn } from "@klorad/design-system";
 import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
-import type { Locale } from "@/app/lib/i18n-core";
+import { translate, type Locale } from "@/app/lib/i18n-core";
+
+type Profile = "default" | "wheelchair" | "visual";
+
+const PROFILE_LABEL_KEY = {
+  default: "mappedin.profileDefault",
+  wheelchair: "mappedin.profileWheelchair",
+  visual: "mappedin.profileVisual",
+} as const;
 
 export interface NavigateTabProps {
   locale: Locale;
@@ -15,9 +25,11 @@ export interface NavigateTabProps {
 }
 
 /**
- * Navigate tab content — wayfinding (From / To / step-free /
- * summary / turn-by-turn). The chat assistant lands here in a
- * follow-up commit.
+ * Navigate tab — routing profile (Default / Wheelchair / Visually
+ * impaired), From / To with Swap + Clear, and the route summary /
+ * turn-by-turn instructions. The profile maps to MappedIn's
+ * step-free routing (wheelchair + visual both request accessible).
+ * The AI chat assistant lands here in a follow-up commit.
  */
 export function NavigateTab({
   locale,
@@ -29,8 +41,40 @@ export function NavigateTab({
   onRoute,
   onClearRoute,
 }: NavigateTabProps) {
+  const [profile, setProfile] = useState<Profile>("default");
+  const accessible = profile !== "default";
+  const t = (key: Parameters<typeof translate>[1]) =>
+    translate(locale, key);
+
   return (
     <div className="space-y-4">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+          {t("mappedin.profile")}
+        </p>
+        <div className="mt-2 grid gap-1">
+          {(["default", "wheelchair", "visual"] as const).map((p) => {
+            const active = profile === p;
+            return (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setProfile(p)}
+                aria-pressed={active}
+                className={cn(
+                  "rounded-xl px-3 py-2 text-left text-sm font-medium transition-colors",
+                  active
+                    ? "bg-accent-soft text-accent"
+                    : "bg-surface-2 text-text-secondary hover:bg-accent-soft hover:text-accent",
+                )}
+              >
+                {translate(locale, PROFILE_LABEL_KEY[p])}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
       <WayfindingControls
         spaces={spaces}
         routing={routing}
@@ -40,6 +84,7 @@ export function NavigateTab({
         onRoute={onRoute}
         onClear={onClearRoute}
         locale={locale}
+        accessible={accessible}
         bare
       />
     </div>

--- a/apps/campus/lib/mappedin/NavigateTab.tsx
+++ b/apps/campus/lib/mappedin/NavigateTab.tsx
@@ -1,18 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import { cn } from "@klorad/design-system";
 import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
 import { AssistantChat } from "./AssistantChat";
 import { translate, type Locale } from "@/app/lib/i18n-core";
-
-type Profile = "default" | "wheelchair" | "visual";
-
-const PROFILE_LABEL_KEY = {
-  default: "mappedin.profileDefault",
-  wheelchair: "mappedin.profileWheelchair",
-  visual: "mappedin.profileVisual",
-} as const;
 
 export interface NavigateTabProps {
   locale: Locale;
@@ -28,11 +18,14 @@ export interface NavigateTabProps {
 }
 
 /**
- * Navigate tab — routing profile (Default / Wheelchair / Visually
- * impaired), From / To with Swap + Clear, and the route summary /
- * turn-by-turn instructions. The profile maps to MappedIn's
- * step-free routing (wheelchair + visual both request accessible).
- * The AI chat assistant lands here in a follow-up commit.
+ * Navigate tab — From / To pickers with Swap + Clear, the route
+ * summary / turn-by-turn instructions, and the ask-the-assistant
+ * chat below a divider.
+ *
+ * Accessibility routing isn't a top-level UI control here: the chat
+ * detects it from the user's wording ("I use a wheelchair…") and
+ * forwards `accessible: true` on the route call. Adding a dedicated
+ * toggle is one prop away if a deployment wants it back.
  */
 export function NavigateTab({
   locale,
@@ -45,40 +38,11 @@ export function NavigateTab({
   onClearRoute,
   onFocus,
 }: NavigateTabProps) {
-  const [profile, setProfile] = useState<Profile>("default");
-  const accessible = profile !== "default";
   const t = (key: Parameters<typeof translate>[1]) =>
     translate(locale, key);
 
   return (
     <div className="space-y-4">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
-          {t("mappedin.profile")}
-        </p>
-        <div className="mt-2 grid gap-1">
-          {(["default", "wheelchair", "visual"] as const).map((p) => {
-            const active = profile === p;
-            return (
-              <button
-                key={p}
-                type="button"
-                onClick={() => setProfile(p)}
-                aria-pressed={active}
-                className={cn(
-                  "rounded-xl px-3 py-2 text-left text-sm font-medium transition-colors",
-                  active
-                    ? "bg-accent-soft text-accent"
-                    : "bg-surface-2 text-text-secondary hover:bg-accent-soft hover:text-accent",
-                )}
-              >
-                {translate(locale, PROFILE_LABEL_KEY[p])}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
       <WayfindingControls
         spaces={spaces}
         routing={routing}
@@ -88,7 +52,6 @@ export function NavigateTab({
         onRoute={onRoute}
         onClear={onClearRoute}
         locale={locale}
-        accessible={accessible}
         bare
       />
 

--- a/apps/campus/lib/mappedin/NavigateTab.tsx
+++ b/apps/campus/lib/mappedin/NavigateTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { cn } from "@klorad/design-system";
 import { WayfindingControls, type SpaceOption } from "./WayfindingControls";
+import { AssistantChat } from "./AssistantChat";
 import { translate, type Locale } from "@/app/lib/i18n-core";
 
 type Profile = "default" | "wheelchair" | "visual";
@@ -22,6 +23,8 @@ export interface NavigateTabProps {
   routeInstructions: string[];
   onRoute: (from: string, to: string, accessible: boolean) => void;
   onClearRoute: () => void;
+  /** Focus a single space — used by the assistant for "show me X" intents. */
+  onFocus: (spaceId: string) => void;
 }
 
 /**
@@ -40,6 +43,7 @@ export function NavigateTab({
   routeInstructions,
   onRoute,
   onClearRoute,
+  onFocus,
 }: NavigateTabProps) {
   const [profile, setProfile] = useState<Profile>("default");
   const accessible = profile !== "default";
@@ -86,6 +90,24 @@ export function NavigateTab({
         locale={locale}
         accessible={accessible}
         bare
+      />
+
+      <div className="relative py-2">
+        <div className="absolute inset-0 flex items-center" aria-hidden>
+          <div className="w-full border-t border-solid border-line-soft" />
+        </div>
+        <div className="relative flex justify-center">
+          <span className="bg-surface-1 px-2 text-[0.65rem] uppercase tracking-wide text-text-tertiary">
+            {t("mappedin.askDivider")}
+          </span>
+        </div>
+      </div>
+
+      <AssistantChat
+        locale={locale}
+        spaces={spaces}
+        onFocus={onFocus}
+        onRoute={onRoute}
       />
     </div>
   );

--- a/apps/campus/lib/mappedin/SearchControls.tsx
+++ b/apps/campus/lib/mappedin/SearchControls.tsx
@@ -1,8 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { cn } from "@klorad/design-system";
 import { translate, type Locale } from "@/app/lib/i18n-core";
 import type { SpaceOption } from "./WayfindingControls";
+
+/** Display labels for common MappedIn space types; falls back to titlecase. */
+const PRETTY_TYPE: Record<string, string> = {
+  wc: "WC",
+  cafe: "Café",
+};
+
+function prettyType(t: string): string {
+  if (PRETTY_TYPE[t]) return PRETTY_TYPE[t];
+  return t
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 export interface SearchControlsProps {
   /** Named spaces in the venue, searched by name. */
@@ -27,13 +41,60 @@ export function SearchControls({
   locale = "en",
 }: SearchControlsProps) {
   const [query, setQuery] = useState("");
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const q = query.trim().toLowerCase();
-  const matches = q
-    ? spaces.filter((s) => s.name.toLowerCase().includes(q)).slice(0, MAX_RESULTS)
-    : [];
+
+  // Categories — derived from the venue's space types, sorted by
+  // count so the most useful chips lead. Hidden when no space carries
+  // a type.
+  const categories = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of spaces) {
+      if (!s.type) continue;
+      counts.set(s.type, (counts.get(s.type) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([type, count]) => ({ type, count, label: prettyType(type) }));
+  }, [spaces]);
+
+  const matches = useMemo(() => {
+    let pool = spaces;
+    if (activeCategory) pool = pool.filter((s) => s.type === activeCategory);
+    if (q) pool = pool.filter((s) => s.name.toLowerCase().includes(q));
+    return pool.slice(0, MAX_RESULTS);
+  }, [spaces, activeCategory, q]);
+
+  const showResults = q !== "" || activeCategory !== null;
 
   return (
-    <div className="rounded-2xl border border-line-soft bg-surface-1/95 p-3 shadow-glass backdrop-blur">
+    <div className="space-y-2 rounded-2xl border border-line-soft bg-surface-1/95 p-3 shadow-glass backdrop-blur">
+      {categories.length > 0 ? (
+        <div className="-mx-1 flex gap-1 overflow-x-auto px-1 pb-1">
+          {categories.map((cat) => {
+            const active = activeCategory === cat.type;
+            return (
+              <button
+                key={cat.type}
+                type="button"
+                onClick={() =>
+                  setActiveCategory(active ? null : cat.type)
+                }
+                aria-pressed={active}
+                className={cn(
+                  "shrink-0 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
+                  active
+                    ? "bg-accent text-accent-contrast"
+                    : "bg-surface-2 text-text-secondary hover:bg-accent-soft hover:text-accent",
+                )}
+              >
+                {cat.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
       <div className="flex items-center gap-2">
         <SearchIcon className="h-4 w-4 shrink-0 text-text-tertiary" />
         <input
@@ -55,8 +116,8 @@ export function SearchControls({
         ) : null}
       </div>
 
-      {q && matches.length > 0 ? (
-        <ul className="mt-2 max-h-56 space-y-0.5 overflow-y-auto">
+      {showResults && matches.length > 0 ? (
+        <ul className="max-h-56 space-y-0.5 overflow-y-auto">
           {matches.map((s) => (
             <li key={s.id}>
               <button
@@ -64,6 +125,7 @@ export function SearchControls({
                 onClick={() => {
                   onSelect(s.id);
                   setQuery("");
+                  setActiveCategory(null);
                 }}
                 className="block w-full truncate rounded-lg px-2 py-1.5 text-left text-sm text-text-secondary transition-colors hover:bg-accent-soft hover:text-accent"
               >
@@ -72,8 +134,8 @@ export function SearchControls({
             </li>
           ))}
         </ul>
-      ) : q ? (
-        <p className="mt-2 px-2 text-xs text-text-tertiary">
+      ) : showResults && q ? (
+        <p className="px-2 text-xs text-text-tertiary">
           {translate(locale, "mappedin.searchNoMatch", { query })}
         </p>
       ) : null}

--- a/apps/campus/lib/mappedin/SearchControls.tsx
+++ b/apps/campus/lib/mappedin/SearchControls.tsx
@@ -25,6 +25,8 @@ export interface SearchControlsProps {
   onSelect: (spaceId: string) => void;
   /** UI locale — defaults to English. */
   locale?: Locale;
+  /** Drop the rounded-card chrome — for use inside the side panel. */
+  bare?: boolean;
 }
 
 const MAX_RESULTS = 8;
@@ -39,6 +41,7 @@ export function SearchControls({
   spaces,
   onSelect,
   locale = "en",
+  bare = false,
 }: SearchControlsProps) {
   const [query, setQuery] = useState("");
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
@@ -68,7 +71,13 @@ export function SearchControls({
   const showResults = q !== "" || activeCategory !== null;
 
   return (
-    <div className="space-y-2 rounded-2xl border border-line-soft bg-surface-1/95 p-3 shadow-glass backdrop-blur">
+    <div
+      className={cn(
+        "space-y-2",
+        !bare &&
+          "rounded-2xl border border-line-soft bg-surface-1/95 p-3 shadow-glass backdrop-blur",
+      )}
+    >
       {categories.length > 0 ? (
         <div className="-mx-1 flex gap-1 overflow-x-auto px-1 pb-1">
           {categories.map((cat) => {

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -165,51 +165,58 @@ export function SearchableSelect({
               className="w-full rounded-lg border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors placeholder:text-text-tertiary focus:border-accent"
             />
           </div>
-          <ul
+          {/*
+            div / div (not ul / li) on purpose — apps/campus has
+            Tailwind preflight off, so <ul> default bullets +
+            <button> default borders render through. The list
+            container + per-option `border: none` inline style
+            keep this clean without depending on a global reset.
+          */}
+          <div
             role="listbox"
-            className="min-h-0 flex-1 space-y-0.5 overflow-y-auto p-4 pt-2"
+            className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-4 pt-2"
           >
             {visible.length === 0 ? (
-              <li className="px-3 py-2 text-xs text-text-tertiary">
+              <div className="px-3 py-2 text-xs text-text-tertiary">
                 {noMatchLabel ?? "No matches"}
-              </li>
+              </div>
             ) : (
               visible.map((o, i) => (
-                <li key={o.id}>
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={o.id === value}
-                    onMouseDown={(e) => {
-                      // mousedown fires before any pending blur — so
-                      // the click registers before Radix's outside-
-                      // click logic closes the popover.
-                      e.preventDefault();
-                      choose(o.id);
-                    }}
-                    onMouseEnter={() => setFocusIndex(i)}
-                    className={cn(
-                      "w-full rounded-lg px-3 py-2 text-left text-sm transition-colors",
-                      o.id === value
-                        ? "bg-accent-soft text-accent"
-                        : i === focusIndex
-                          ? "bg-surface-2 text-text-primary"
-                          : "text-text-primary hover:bg-surface-2",
-                    )}
-                  >
-                    {o.name}
-                  </button>
-                </li>
+                <button
+                  key={o.id}
+                  type="button"
+                  role="option"
+                  aria-selected={o.id === value}
+                  onMouseDown={(e) => {
+                    // mousedown fires before any pending blur — so
+                    // the click registers before Radix's outside-
+                    // click logic closes the popover.
+                    e.preventDefault();
+                    choose(o.id);
+                  }}
+                  onMouseEnter={() => setFocusIndex(i)}
+                  style={{ border: "none" }}
+                  className={cn(
+                    "block w-full cursor-pointer rounded-lg bg-transparent px-3 py-2 text-left text-sm transition-colors",
+                    o.id === value
+                      ? "bg-accent-soft text-accent"
+                      : i === focusIndex
+                        ? "bg-surface-2 text-text-primary"
+                        : "text-text-primary hover:bg-surface-2",
+                  )}
+                >
+                  {o.name}
+                </button>
               ))
             )}
             {truncated ? (
-              <li className="mt-1 px-3 py-1 text-[0.7rem] italic text-text-tertiary">
+              <div className="mt-1 px-3 py-1 text-[0.7rem] italic text-text-tertiary">
                 {moreResultsLabel
                   ? moreResultsLabel(MAX_RESULTS, filtered.length)
                   : `Showing ${MAX_RESULTS} of ${filtered.length}`}
-              </li>
+              </div>
             ) : null}
-          </ul>
+          </div>
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -108,7 +108,7 @@ export function SearchableSelect({
           type="button"
           aria-label={ariaLabel}
           className={cn(
-            "flex w-full items-center justify-between gap-2 rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-left text-sm outline-none transition-colors hover:border-accent focus:border-accent",
+            "flex w-full items-center justify-between gap-2 rounded-lg border border-solid border-line-soft bg-surface-1 px-3 py-2 text-left text-sm outline-none transition-colors hover:border-accent focus:border-accent",
             selectedOption ? "text-text-primary" : "text-text-tertiary",
           )}
         >
@@ -143,7 +143,7 @@ export function SearchableSelect({
             width: "var(--radix-popover-trigger-width)",
             maxHeight: "var(--radix-popover-content-available-height)",
           }}
-          className="z-50 flex flex-col overflow-hidden rounded-lg border border-solid border-line-soft bg-surface-1 shadow-glass"
+          className="z-50 flex flex-col overflow-hidden rounded-2xl border border-solid border-line-soft bg-surface-1/95 shadow-glass backdrop-blur"
           // We focus the search input ourselves; otherwise Radix
           // would focus the Content wrapper.
           onOpenAutoFocus={(e) => {
@@ -151,7 +151,7 @@ export function SearchableSelect({
             searchRef.current?.focus();
           }}
         >
-          <div className="border-b border-solid border-line-soft p-2">
+          <div className="p-2 pb-1">
             <input
               ref={searchRef}
               type="text"
@@ -162,12 +162,12 @@ export function SearchableSelect({
                 setFocusIndex(0);
               }}
               onKeyDown={onSearchKey}
-              className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-2 py-1.5 text-sm text-text-primary outline-none transition-colors focus:border-accent"
+              className="w-full rounded-lg bg-surface-2 px-3 py-2 text-sm text-text-primary outline-none transition-colors placeholder:text-text-tertiary focus:bg-surface-1 focus:ring-2 focus:ring-accent-soft"
             />
           </div>
           <ul
             role="listbox"
-            className="min-h-0 flex-1 overflow-y-auto py-1"
+            className="min-h-0 flex-1 space-y-0.5 overflow-y-auto p-2 pt-1"
           >
             {visible.length === 0 ? (
               <li className="px-3 py-2 text-xs text-text-tertiary">
@@ -189,7 +189,7 @@ export function SearchableSelect({
                     }}
                     onMouseEnter={() => setFocusIndex(i)}
                     className={cn(
-                      "w-full px-3 py-2 text-left text-sm transition-colors",
+                      "w-full rounded-lg px-3 py-2 text-left text-sm transition-colors",
                       o.id === value
                         ? "bg-accent-soft text-accent"
                         : i === focusIndex
@@ -203,7 +203,7 @@ export function SearchableSelect({
               ))
             )}
             {truncated ? (
-              <li className="border-t border-solid border-line-soft px-3 py-2 text-[0.7rem] italic text-text-tertiary">
+              <li className="mt-1 px-3 py-1 text-[0.7rem] italic text-text-tertiary">
                 {moreResultsLabel
                   ? moreResultsLabel(MAX_RESULTS, filtered.length)
                   : `Showing ${MAX_RESULTS} of ${filtered.length}`}

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-} from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useRef, useState, type KeyboardEvent } from "react";
+import * as Popover from "@radix-ui/react-popover";
 import { cn } from "@klorad/design-system";
 
 export interface SearchableOption {
@@ -24,53 +18,32 @@ export interface SearchableSelectProps {
   /** Placeholder inside the popup's search input. */
   searchPlaceholder?: string;
   noMatchLabel?: string;
-  /**
-   * Footer shown when the filtered list is capped. Receives the
-   * shown / total counts so it can render its own message.
-   */
+  /** Footer when the filtered list is capped. */
   moreResultsLabel?: (shown: number, total: number) => string;
   /** Optional `aria-label` for the trigger. */
   ariaLabel?: string;
 }
 
-/**
- * Anchor geometry for the floating popover. Stored in state so the
- * popover positions itself relative to the trigger's actual screen
- * box — viewport-aware so it always fits, scrolls when it can't.
- */
-interface PopoverGeom {
-  left: number;
-  width: number;
-  maxHeight: number;
-  openUp: boolean;
-  /** If `openUp`, distance from viewport bottom; else from viewport top. */
-  vOffset: number;
-}
-
-/**
- * Trim the list before render so the popover stays bounded even
- * when nobody has typed yet — a venue with 400 rooms shouldn't
- * pour 400 buttons into the DOM. A footer prompts the user to
- * type once the cap kicks in.
- */
 const MAX_RESULTS = 50;
-const MIN_POPUP_HEIGHT = 200;
-const VIEWPORT_MARGIN = 8;
 
 /**
- * Searchable select with a "search-in-popup" pattern.
+ * Searchable select built on Radix Popover.
  *
  * Closed: a button-like trigger shows the selected option's name
  *   (or a placeholder) + a caret.
- * Open : a popover floats off the trigger holding a search input
- *   and a scrollable list of matches; capped at 50 with a footer
- *   when more exist so the user knows to refine.
+ * Open : a popover anchored off the trigger holds a search input
+ *   on top + a scrollable list of matches below.
  *
- * The popover is portaled to `document.body` with `position: fixed`
- * so the side panel's `overflow-y-auto` can't clip it and no sibling
- * outranks its stacking. `maxHeight` = the actual room left in the
- * viewport (above or below, whichever is larger), so on a phone
- * screen the inner list scrolls instead of overflowing the page.
+ * Radix owns the hard parts — portal to body, viewport collision
+ * (auto-flips up when there's no room below), focus + outside-click
+ * + escape, and the `--radix-popover-content-available-height` CSS
+ * var that caps the popover to whatever room the viewport has left,
+ * so the inner list scrolls inside the popup even on a phone. The
+ * width matches the trigger via `--radix-popover-trigger-width`.
+ *
+ * Results are capped at 50 with a "refine to see more" footer so a
+ * 400-room venue doesn't push 400 buttons through the DOM the
+ * moment the popover opens.
  */
 export function SearchableSelect({
   options,
@@ -85,16 +58,7 @@ export function SearchableSelect({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [focusIndex, setFocusIndex] = useState(0);
-  const [geom, setGeom] = useState<PopoverGeom | null>(null);
-  const [mounted, setMounted] = useState(false);
-
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const selectedOption = useMemo(
     () => options.find((o) => o.id === value),
@@ -110,79 +74,10 @@ export function SearchableSelect({
   const visible = filtered.slice(0, MAX_RESULTS);
   const truncated = filtered.length > MAX_RESULTS;
 
-  /** Read the trigger's screen rect and choose up/down + max height. */
-  const recompute = () => {
-    const el = triggerRef.current;
-    if (!el) return;
-    const r = el.getBoundingClientRect();
-    const viewportH = window.innerHeight;
-    const below = viewportH - r.bottom - VIEWPORT_MARGIN;
-    const above = r.top - VIEWPORT_MARGIN;
-    const openUp = below < MIN_POPUP_HEIGHT && above > below;
-    setGeom({
-      left: r.left,
-      width: r.width,
-      maxHeight: Math.max(MIN_POPUP_HEIGHT, openUp ? above : below),
-      openUp,
-      vOffset: openUp ? viewportH - r.top + 4 : r.bottom + 4,
-    });
-  };
-
-  // Re-anchor on scroll / resize while open so the popover tracks
-  // the trigger when the side panel scrolls or the window changes.
-  useEffect(() => {
-    if (!open) return;
-    window.addEventListener("resize", recompute);
-    window.addEventListener("scroll", recompute, true);
-    return () => {
-      window.removeEventListener("resize", recompute);
-      window.removeEventListener("scroll", recompute, true);
-    };
-  }, [open]);
-
-  // Autofocus the search input once the popover paints.
-  useEffect(() => {
-    if (!open) return;
-    const t = setTimeout(() => searchRef.current?.focus(), 0);
-    return () => clearTimeout(t);
-  }, [open]);
-
-  // Close on outside-click (neither the trigger nor the popover).
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      const t = e.target as Node;
-      if (
-        triggerRef.current?.contains(t) ||
-        popoverRef.current?.contains(t)
-      ) {
-        return;
-      }
-      setOpen(false);
-      setQuery("");
-    };
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, [open]);
-
   const choose = (id: string) => {
     onChange(id);
     setOpen(false);
     setQuery("");
-  };
-
-  const toggleOpen = () => {
-    if (open) {
-      setOpen(false);
-      setQuery("");
-    } else {
-      // Compute geometry synchronously so the popover paints in the
-      // right place on its first render — no first-frame flicker.
-      recompute();
-      setQuery("");
-      setFocusIndex(0);
-      setOpen(true);
-    }
   };
 
   const onSearchKey = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -196,123 +91,127 @@ export function SearchableSelect({
       e.preventDefault();
       const opt = visible[focusIndex];
       if (opt) choose(opt.id);
-    } else if (e.key === "Escape") {
-      setOpen(false);
-      setQuery("");
     }
   };
 
-  const popover =
-    open && geom ? (
-      <div
-        ref={popoverRef}
-        style={{
-          position: "fixed",
-          left: geom.left,
-          width: geom.width,
-          maxHeight: geom.maxHeight,
-          ...(geom.openUp
-            ? { bottom: geom.vOffset }
-            : { top: geom.vOffset }),
-        }}
-        className="z-[60] flex flex-col overflow-hidden rounded-lg border border-solid border-line-soft bg-surface-1 shadow-glass"
-      >
-        <div className="border-b border-solid border-line-soft p-2">
-          <input
-            ref={searchRef}
-            type="text"
-            value={query}
-            placeholder={searchPlaceholder ?? "Search…"}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setFocusIndex(0);
-            }}
-            onKeyDown={onSearchKey}
-            className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-2 py-1.5 text-sm text-text-primary outline-none transition-colors focus:border-accent"
-          />
-        </div>
-        <ul role="listbox" className="min-h-0 flex-1 overflow-y-auto py-1">
-          {visible.length === 0 ? (
-            <li className="px-3 py-2 text-xs text-text-tertiary">
-              {noMatchLabel ?? "No matches"}
-            </li>
-          ) : (
-            visible.map((o, i) => (
-              <li key={o.id}>
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={o.id === value}
-                  // mousedown fires before any pending blur — the
-                  // click registers before the outside-click effect
-                  // tries to close the popover.
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    choose(o.id);
-                  }}
-                  onMouseEnter={() => setFocusIndex(i)}
-                  className={cn(
-                    "w-full px-3 py-2 text-left text-sm transition-colors",
-                    o.id === value
-                      ? "bg-accent-soft text-accent"
-                      : i === focusIndex
-                        ? "bg-surface-2 text-text-primary"
-                        : "text-text-primary hover:bg-surface-2",
-                  )}
-                >
-                  {o.name}
-                </button>
-              </li>
-            ))
-          )}
-          {truncated ? (
-            <li className="border-t border-solid border-line-soft px-3 py-2 text-[0.7rem] italic text-text-tertiary">
-              {moreResultsLabel
-                ? moreResultsLabel(MAX_RESULTS, filtered.length)
-                : `Refine to see more (${MAX_RESULTS} of ${filtered.length})`}
-            </li>
-          ) : null}
-        </ul>
-      </div>
-    ) : null;
-
   return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        role="combobox"
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-label={ariaLabel}
-        onClick={toggleOpen}
-        className={cn(
-          "flex w-full items-center justify-between gap-2 rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-left text-sm outline-none transition-colors hover:border-accent focus:border-accent",
-          selectedOption ? "text-text-primary" : "text-text-tertiary",
-        )}
-      >
-        <span className="truncate">
-          {selectedOption?.name ?? placeholder ?? "Select…"}
-        </span>
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
+    <Popover.Root
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setQuery("");
+        if (o) setFocusIndex(0);
+      }}
+    >
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
           className={cn(
-            "shrink-0 text-text-tertiary transition-transform",
-            open && "rotate-180",
+            "flex w-full items-center justify-between gap-2 rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-left text-sm outline-none transition-colors hover:border-accent focus:border-accent",
+            selectedOption ? "text-text-primary" : "text-text-tertiary",
           )}
         >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </button>
-      {mounted && popover ? createPortal(popover, document.body) : null}
-    </>
+          <span className="truncate">
+            {selectedOption?.name ?? placeholder ?? "Select…"}
+          </span>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+            className={cn(
+              "shrink-0 text-text-tertiary transition-transform",
+              open && "rotate-180",
+            )}
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          collisionPadding={8}
+          style={{
+            width: "var(--radix-popover-trigger-width)",
+            maxHeight: "var(--radix-popover-content-available-height)",
+          }}
+          className="z-50 flex flex-col overflow-hidden rounded-lg border border-solid border-line-soft bg-surface-1 shadow-glass"
+          // We focus the search input ourselves; otherwise Radix
+          // would focus the Content wrapper.
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            searchRef.current?.focus();
+          }}
+        >
+          <div className="border-b border-solid border-line-soft p-2">
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              placeholder={searchPlaceholder ?? "Search…"}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setFocusIndex(0);
+              }}
+              onKeyDown={onSearchKey}
+              className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-2 py-1.5 text-sm text-text-primary outline-none transition-colors focus:border-accent"
+            />
+          </div>
+          <ul
+            role="listbox"
+            className="min-h-0 flex-1 overflow-y-auto py-1"
+          >
+            {visible.length === 0 ? (
+              <li className="px-3 py-2 text-xs text-text-tertiary">
+                {noMatchLabel ?? "No matches"}
+              </li>
+            ) : (
+              visible.map((o, i) => (
+                <li key={o.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={o.id === value}
+                    onMouseDown={(e) => {
+                      // mousedown fires before any pending blur — so
+                      // the click registers before Radix's outside-
+                      // click logic closes the popover.
+                      e.preventDefault();
+                      choose(o.id);
+                    }}
+                    onMouseEnter={() => setFocusIndex(i)}
+                    className={cn(
+                      "w-full px-3 py-2 text-left text-sm transition-colors",
+                      o.id === value
+                        ? "bg-accent-soft text-accent"
+                        : i === focusIndex
+                          ? "bg-surface-2 text-text-primary"
+                          : "text-text-primary hover:bg-surface-2",
+                    )}
+                  >
+                    {o.name}
+                  </button>
+                </li>
+              ))
+            )}
+            {truncated ? (
+              <li className="border-t border-solid border-line-soft px-3 py-2 text-[0.7rem] italic text-text-tertiary">
+                {moreResultsLabel
+                  ? moreResultsLabel(MAX_RESULTS, filtered.length)
+                  : `Showing ${MAX_RESULTS} of ${filtered.length}`}
+              </li>
+            ) : null}
+          </ul>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -143,7 +143,7 @@ export function SearchableSelect({
             width: "var(--radix-popover-trigger-width)",
             maxHeight: "var(--radix-popover-content-available-height)",
           }}
-          className="z-50 flex flex-col overflow-hidden rounded-2xl border border-solid border-line-soft bg-surface-1/95 shadow-glass backdrop-blur"
+          className="z-50 flex flex-col overflow-hidden rounded-2xl border border-solid border-line-soft bg-surface-1 shadow-glass"
           // We focus the search input ourselves; otherwise Radix
           // would focus the Content wrapper.
           onOpenAutoFocus={(e) => {
@@ -151,7 +151,7 @@ export function SearchableSelect({
             searchRef.current?.focus();
           }}
         >
-          <div className="p-2 pb-1">
+          <div className="p-4 pb-2">
             <input
               ref={searchRef}
               type="text"
@@ -162,12 +162,12 @@ export function SearchableSelect({
                 setFocusIndex(0);
               }}
               onKeyDown={onSearchKey}
-              className="w-full rounded-lg bg-surface-2 px-3 py-2 text-sm text-text-primary outline-none transition-colors placeholder:text-text-tertiary focus:bg-surface-1 focus:ring-2 focus:ring-accent-soft"
+              className="w-full rounded-lg border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors placeholder:text-text-tertiary focus:border-accent"
             />
           </div>
           <ul
             role="listbox"
-            className="min-h-0 flex-1 space-y-0.5 overflow-y-auto p-2 pt-1"
+            className="min-h-0 flex-1 space-y-0.5 overflow-y-auto p-4 pt-2"
           >
             {visible.length === 0 ? (
               <li className="px-3 py-2 text-xs text-text-tertiary">

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { cn } from "@klorad/design-system";
+
+export interface SearchableOption {
+  id: string;
+  name: string;
+}
+
+export interface SearchableSelectProps {
+  options: SearchableOption[];
+  value: string;
+  onChange: (id: string) => void;
+  placeholder?: string;
+  noMatchLabel?: string;
+  /** Optional `aria-label` — useful when no visible label sits above. */
+  ariaLabel?: string;
+}
+
+/**
+ * A small searchable combobox — type to filter, click to pick.
+ *
+ * Native `<select>` is unusable once a venue has hundreds of spaces;
+ * the user scrolls through 200 options to find "Lecture Hall 3."
+ * This input filters as the user types, keeps keyboard nav, and
+ * stays inside the campus's existing surface / accent tokens so it
+ * matches the rest of the panel without pulling in a dependency.
+ */
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder,
+  noMatchLabel,
+  ariaLabel,
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [focusIndex, setFocusIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedOption = useMemo(
+    () => options.find((o) => o.id === value),
+    [options, value],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => o.name.toLowerCase().includes(q));
+  }, [options, query]);
+
+  // When the dropdown is open, the input shows the live query;
+  // when closed, it shows the selected name (or empty placeholder).
+  const displayValue = open ? query : (selectedOption?.name ?? "");
+
+  // Close when the user clicks anywhere outside.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const choose = (id: string) => {
+    onChange(id);
+    setOpen(false);
+    setQuery("");
+    inputRef.current?.blur();
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setFocusIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const opt = filtered[focusIndex];
+      if (opt) choose(opt.id);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setQuery("");
+      inputRef.current?.blur();
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        value={displayValue}
+        placeholder={placeholder}
+        onFocus={() => {
+          setOpen(true);
+          setQuery("");
+          setFocusIndex(0);
+        }}
+        onChange={(e) => {
+          setOpen(true);
+          setQuery(e.target.value);
+          setFocusIndex(0);
+        }}
+        onKeyDown={onKeyDown}
+        className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-accent"
+      />
+      {open ? (
+        <ul
+          role="listbox"
+          className="absolute left-0 right-0 z-30 mt-1 max-h-64 overflow-y-auto rounded-lg border border-solid border-line-soft bg-surface-1 py-1 shadow-glass"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-text-tertiary">
+              {noMatchLabel ?? "No matches"}
+            </li>
+          ) : (
+            filtered.map((o, i) => (
+              <li key={o.id}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={o.id === value}
+                  // mousedown fires before input blur — so the click registers
+                  // before the outside-click effect tries to close the dropdown.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    choose(o.id);
+                  }}
+                  onMouseEnter={() => setFocusIndex(i)}
+                  className={cn(
+                    "w-full px-3 py-2 text-left text-sm transition-colors",
+                    o.id === value
+                      ? "bg-accent-soft text-accent"
+                      : i === focusIndex
+                        ? "bg-surface-2 text-text-primary"
+                        : "text-text-primary hover:bg-surface-2",
+                  )}
+                >
+                  {o.name}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type KeyboardEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@klorad/design-system";
 
 export interface SearchableOption {
@@ -32,6 +33,12 @@ export interface SearchableSelectProps {
  * This input filters as the user types, keeps keyboard nav, and
  * stays inside the campus's existing surface / accent tokens so it
  * matches the rest of the panel without pulling in a dependency.
+ *
+ * The dropdown is rendered through a portal on `document.body` with
+ * `position: fixed`, so it escapes the side panel's
+ * `overflow-y-auto` clipping and outranks any sibling's stacking.
+ * Position is the input's `getBoundingClientRect()`, recomputed on
+ * scroll + resize so the menu tracks the input.
  */
 export function SearchableSelect({
   options,
@@ -44,8 +51,16 @@ export function SearchableSelect({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [focusIndex, setFocusIndex] = useState(0);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [mounted, setMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // SSR-safe portal — only render once the client has mounted.
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const selectedOption = useMemo(
     () => options.find((o) => o.id === value),
@@ -62,17 +77,38 @@ export function SearchableSelect({
   // when closed, it shows the selected name (or empty placeholder).
   const displayValue = open ? query : (selectedOption?.name ?? "");
 
-  // Close when the user clicks anywhere outside.
+  // Track the input's screen rect while the dropdown is open so the
+  // portaled menu stays glued to it during scroll / resize.
+  useEffect(() => {
+    if (!open) return;
+    const el = inputRef.current;
+    if (!el) return;
+    const update = () => setRect(el.getBoundingClientRect());
+    update();
+    window.addEventListener("resize", update);
+    // Capture phase catches scroll inside any ancestor (the side
+    // panel's overflow-y-auto in particular).
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open]);
+
+  // Close when the user clicks anywhere outside both the input
+  // wrapper and the portaled list (which lives on document.body).
   useEffect(() => {
     if (!open) return;
     const onDoc = (e: MouseEvent) => {
+      const target = e.target as Node;
       if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
+        containerRef.current?.contains(target) ||
+        listRef.current?.contains(target)
       ) {
-        setOpen(false);
-        setQuery("");
+        return;
       }
+      setOpen(false);
+      setQuery("");
     };
     document.addEventListener("mousedown", onDoc);
     return () => document.removeEventListener("mousedown", onDoc);
@@ -104,6 +140,55 @@ export function SearchableSelect({
     }
   };
 
+  const dropdown =
+    open && rect ? (
+      <ul
+        ref={listRef}
+        role="listbox"
+        style={{
+          position: "fixed",
+          top: rect.bottom + 4,
+          left: rect.left,
+          width: rect.width,
+        }}
+        className="z-[60] max-h-64 overflow-y-auto rounded-lg border border-solid border-line-soft bg-surface-1 py-1 shadow-glass"
+      >
+        {filtered.length === 0 ? (
+          <li className="px-3 py-2 text-xs text-text-tertiary">
+            {noMatchLabel ?? "No matches"}
+          </li>
+        ) : (
+          filtered.map((o, i) => (
+            <li key={o.id}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={o.id === value}
+                // mousedown fires before input blur — so the click
+                // registers before the outside-click effect closes
+                // the dropdown.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  choose(o.id);
+                }}
+                onMouseEnter={() => setFocusIndex(i)}
+                className={cn(
+                  "w-full px-3 py-2 text-left text-sm transition-colors",
+                  o.id === value
+                    ? "bg-accent-soft text-accent"
+                    : i === focusIndex
+                      ? "bg-surface-2 text-text-primary"
+                      : "text-text-primary hover:bg-surface-2",
+                )}
+              >
+                {o.name}
+              </button>
+            </li>
+          ))
+        )}
+      </ul>
+    ) : null;
+
   return (
     <div ref={containerRef} className="relative">
       <input
@@ -127,45 +212,7 @@ export function SearchableSelect({
         onKeyDown={onKeyDown}
         className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-accent"
       />
-      {open ? (
-        <ul
-          role="listbox"
-          className="absolute left-0 right-0 z-30 mt-1 max-h-64 overflow-y-auto rounded-lg border border-solid border-line-soft bg-surface-1 py-1 shadow-glass"
-        >
-          {filtered.length === 0 ? (
-            <li className="px-3 py-2 text-xs text-text-tertiary">
-              {noMatchLabel ?? "No matches"}
-            </li>
-          ) : (
-            filtered.map((o, i) => (
-              <li key={o.id}>
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={o.id === value}
-                  // mousedown fires before input blur — so the click registers
-                  // before the outside-click effect tries to close the dropdown.
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    choose(o.id);
-                  }}
-                  onMouseEnter={() => setFocusIndex(i)}
-                  className={cn(
-                    "w-full px-3 py-2 text-left text-sm transition-colors",
-                    o.id === value
-                      ? "bg-accent-soft text-accent"
-                      : i === focusIndex
-                        ? "bg-surface-2 text-text-primary"
-                        : "text-text-primary hover:bg-surface-2",
-                  )}
-                >
-                  {o.name}
-                </button>
-              </li>
-            ))
-          )}
-        </ul>
-      ) : null}
+      {mounted && dropdown ? createPortal(dropdown, document.body) : null}
     </div>
   );
 }

--- a/apps/campus/lib/mappedin/SearchableSelect.tsx
+++ b/apps/campus/lib/mappedin/SearchableSelect.tsx
@@ -19,45 +19,79 @@ export interface SearchableSelectProps {
   options: SearchableOption[];
   value: string;
   onChange: (id: string) => void;
+  /** Text in the closed trigger when nothing is selected. */
   placeholder?: string;
+  /** Placeholder inside the popup's search input. */
+  searchPlaceholder?: string;
   noMatchLabel?: string;
-  /** Optional `aria-label` — useful when no visible label sits above. */
+  /**
+   * Footer shown when the filtered list is capped. Receives the
+   * shown / total counts so it can render its own message.
+   */
+  moreResultsLabel?: (shown: number, total: number) => string;
+  /** Optional `aria-label` for the trigger. */
   ariaLabel?: string;
 }
 
 /**
- * A small searchable combobox — type to filter, click to pick.
+ * Anchor geometry for the floating popover. Stored in state so the
+ * popover positions itself relative to the trigger's actual screen
+ * box — viewport-aware so it always fits, scrolls when it can't.
+ */
+interface PopoverGeom {
+  left: number;
+  width: number;
+  maxHeight: number;
+  openUp: boolean;
+  /** If `openUp`, distance from viewport bottom; else from viewport top. */
+  vOffset: number;
+}
+
+/**
+ * Trim the list before render so the popover stays bounded even
+ * when nobody has typed yet — a venue with 400 rooms shouldn't
+ * pour 400 buttons into the DOM. A footer prompts the user to
+ * type once the cap kicks in.
+ */
+const MAX_RESULTS = 50;
+const MIN_POPUP_HEIGHT = 200;
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * Searchable select with a "search-in-popup" pattern.
  *
- * Native `<select>` is unusable once a venue has hundreds of spaces;
- * the user scrolls through 200 options to find "Lecture Hall 3."
- * This input filters as the user types, keeps keyboard nav, and
- * stays inside the campus's existing surface / accent tokens so it
- * matches the rest of the panel without pulling in a dependency.
+ * Closed: a button-like trigger shows the selected option's name
+ *   (or a placeholder) + a caret.
+ * Open : a popover floats off the trigger holding a search input
+ *   and a scrollable list of matches; capped at 50 with a footer
+ *   when more exist so the user knows to refine.
  *
- * The dropdown is rendered through a portal on `document.body` with
- * `position: fixed`, so it escapes the side panel's
- * `overflow-y-auto` clipping and outranks any sibling's stacking.
- * Position is the input's `getBoundingClientRect()`, recomputed on
- * scroll + resize so the menu tracks the input.
+ * The popover is portaled to `document.body` with `position: fixed`
+ * so the side panel's `overflow-y-auto` can't clip it and no sibling
+ * outranks its stacking. `maxHeight` = the actual room left in the
+ * viewport (above or below, whichever is larger), so on a phone
+ * screen the inner list scrolls instead of overflowing the page.
  */
 export function SearchableSelect({
   options,
   value,
   onChange,
   placeholder,
+  searchPlaceholder,
   noMatchLabel,
+  moreResultsLabel,
   ariaLabel,
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [focusIndex, setFocusIndex] = useState(0);
-  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [geom, setGeom] = useState<PopoverGeom | null>(null);
   const [mounted, setMounted] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
 
-  // SSR-safe portal — only render once the client has mounted.
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     setMounted(true);
   }, []);
@@ -73,37 +107,54 @@ export function SearchableSelect({
     return options.filter((o) => o.name.toLowerCase().includes(q));
   }, [options, query]);
 
-  // When the dropdown is open, the input shows the live query;
-  // when closed, it shows the selected name (or empty placeholder).
-  const displayValue = open ? query : (selectedOption?.name ?? "");
+  const visible = filtered.slice(0, MAX_RESULTS);
+  const truncated = filtered.length > MAX_RESULTS;
 
-  // Track the input's screen rect while the dropdown is open so the
-  // portaled menu stays glued to it during scroll / resize.
+  /** Read the trigger's screen rect and choose up/down + max height. */
+  const recompute = () => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const viewportH = window.innerHeight;
+    const below = viewportH - r.bottom - VIEWPORT_MARGIN;
+    const above = r.top - VIEWPORT_MARGIN;
+    const openUp = below < MIN_POPUP_HEIGHT && above > below;
+    setGeom({
+      left: r.left,
+      width: r.width,
+      maxHeight: Math.max(MIN_POPUP_HEIGHT, openUp ? above : below),
+      openUp,
+      vOffset: openUp ? viewportH - r.top + 4 : r.bottom + 4,
+    });
+  };
+
+  // Re-anchor on scroll / resize while open so the popover tracks
+  // the trigger when the side panel scrolls or the window changes.
   useEffect(() => {
     if (!open) return;
-    const el = inputRef.current;
-    if (!el) return;
-    const update = () => setRect(el.getBoundingClientRect());
-    update();
-    window.addEventListener("resize", update);
-    // Capture phase catches scroll inside any ancestor (the side
-    // panel's overflow-y-auto in particular).
-    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", recompute);
+    window.addEventListener("scroll", recompute, true);
     return () => {
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", recompute);
+      window.removeEventListener("scroll", recompute, true);
     };
   }, [open]);
 
-  // Close when the user clicks anywhere outside both the input
-  // wrapper and the portaled list (which lives on document.body).
+  // Autofocus the search input once the popover paints.
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => searchRef.current?.focus(), 0);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  // Close on outside-click (neither the trigger nor the popover).
   useEffect(() => {
     if (!open) return;
     const onDoc = (e: MouseEvent) => {
-      const target = e.target as Node;
+      const t = e.target as Node;
       if (
-        containerRef.current?.contains(target) ||
-        listRef.current?.contains(target)
+        triggerRef.current?.contains(t) ||
+        popoverRef.current?.contains(t)
       ) {
         return;
       }
@@ -118,101 +169,150 @@ export function SearchableSelect({
     onChange(id);
     setOpen(false);
     setQuery("");
-    inputRef.current?.blur();
   };
 
-  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const toggleOpen = () => {
+    if (open) {
+      setOpen(false);
+      setQuery("");
+    } else {
+      // Compute geometry synchronously so the popover paints in the
+      // right place on its first render — no first-frame flicker.
+      recompute();
+      setQuery("");
+      setFocusIndex(0);
+      setOpen(true);
+    }
+  };
+
+  const onSearchKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setOpen(true);
-      setFocusIndex((i) => Math.min(i + 1, filtered.length - 1));
+      setFocusIndex((i) => Math.min(i + 1, visible.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setFocusIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const opt = filtered[focusIndex];
+      const opt = visible[focusIndex];
       if (opt) choose(opt.id);
     } else if (e.key === "Escape") {
       setOpen(false);
       setQuery("");
-      inputRef.current?.blur();
     }
   };
 
-  const dropdown =
-    open && rect ? (
-      <ul
-        ref={listRef}
-        role="listbox"
+  const popover =
+    open && geom ? (
+      <div
+        ref={popoverRef}
         style={{
           position: "fixed",
-          top: rect.bottom + 4,
-          left: rect.left,
-          width: rect.width,
+          left: geom.left,
+          width: geom.width,
+          maxHeight: geom.maxHeight,
+          ...(geom.openUp
+            ? { bottom: geom.vOffset }
+            : { top: geom.vOffset }),
         }}
-        className="z-[60] max-h-64 overflow-y-auto rounded-lg border border-solid border-line-soft bg-surface-1 py-1 shadow-glass"
+        className="z-[60] flex flex-col overflow-hidden rounded-lg border border-solid border-line-soft bg-surface-1 shadow-glass"
       >
-        {filtered.length === 0 ? (
-          <li className="px-3 py-2 text-xs text-text-tertiary">
-            {noMatchLabel ?? "No matches"}
-          </li>
-        ) : (
-          filtered.map((o, i) => (
-            <li key={o.id}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={o.id === value}
-                // mousedown fires before input blur — so the click
-                // registers before the outside-click effect closes
-                // the dropdown.
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  choose(o.id);
-                }}
-                onMouseEnter={() => setFocusIndex(i)}
-                className={cn(
-                  "w-full px-3 py-2 text-left text-sm transition-colors",
-                  o.id === value
-                    ? "bg-accent-soft text-accent"
-                    : i === focusIndex
-                      ? "bg-surface-2 text-text-primary"
-                      : "text-text-primary hover:bg-surface-2",
-                )}
-              >
-                {o.name}
-              </button>
+        <div className="border-b border-solid border-line-soft p-2">
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            placeholder={searchPlaceholder ?? "Search…"}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setFocusIndex(0);
+            }}
+            onKeyDown={onSearchKey}
+            className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-2 py-1.5 text-sm text-text-primary outline-none transition-colors focus:border-accent"
+          />
+        </div>
+        <ul role="listbox" className="min-h-0 flex-1 overflow-y-auto py-1">
+          {visible.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-text-tertiary">
+              {noMatchLabel ?? "No matches"}
             </li>
-          ))
-        )}
-      </ul>
+          ) : (
+            visible.map((o, i) => (
+              <li key={o.id}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={o.id === value}
+                  // mousedown fires before any pending blur — the
+                  // click registers before the outside-click effect
+                  // tries to close the popover.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    choose(o.id);
+                  }}
+                  onMouseEnter={() => setFocusIndex(i)}
+                  className={cn(
+                    "w-full px-3 py-2 text-left text-sm transition-colors",
+                    o.id === value
+                      ? "bg-accent-soft text-accent"
+                      : i === focusIndex
+                        ? "bg-surface-2 text-text-primary"
+                        : "text-text-primary hover:bg-surface-2",
+                  )}
+                >
+                  {o.name}
+                </button>
+              </li>
+            ))
+          )}
+          {truncated ? (
+            <li className="border-t border-solid border-line-soft px-3 py-2 text-[0.7rem] italic text-text-tertiary">
+              {moreResultsLabel
+                ? moreResultsLabel(MAX_RESULTS, filtered.length)
+                : `Refine to see more (${MAX_RESULTS} of ${filtered.length})`}
+            </li>
+          ) : null}
+        </ul>
+      </div>
     ) : null;
 
   return (
-    <div ref={containerRef} className="relative">
-      <input
-        ref={inputRef}
-        type="text"
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
         role="combobox"
         aria-expanded={open}
+        aria-haspopup="listbox"
         aria-label={ariaLabel}
-        value={displayValue}
-        placeholder={placeholder}
-        onFocus={() => {
-          setOpen(true);
-          setQuery("");
-          setFocusIndex(0);
-        }}
-        onChange={(e) => {
-          setOpen(true);
-          setQuery(e.target.value);
-          setFocusIndex(0);
-        }}
-        onKeyDown={onKeyDown}
-        className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-accent"
-      />
-      {mounted && dropdown ? createPortal(dropdown, document.body) : null}
-    </div>
+        onClick={toggleOpen}
+        className={cn(
+          "flex w-full items-center justify-between gap-2 rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-left text-sm outline-none transition-colors hover:border-accent focus:border-accent",
+          selectedOption ? "text-text-primary" : "text-text-tertiary",
+        )}
+      >
+        <span className="truncate">
+          {selectedOption?.name ?? placeholder ?? "Select…"}
+        </span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+          className={cn(
+            "shrink-0 text-text-tertiary transition-transform",
+            open && "rotate-180",
+          )}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      {mounted && popover ? createPortal(popover, document.body) : null}
+    </>
   );
 }

--- a/apps/campus/lib/mappedin/SidePanel.tsx
+++ b/apps/campus/lib/mappedin/SidePanel.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@klorad/design-system";
+import { translate, type Locale } from "@/app/lib/i18n-core";
+import { ExploreTab } from "./ExploreTab";
+import { NavigateTab } from "./NavigateTab";
+import { FloorControls, type FloorOption } from "./FloorControls";
+import type { SpaceOption } from "./WayfindingControls";
+
+type Tab = "explore" | "navigate";
+
+export interface SidePanelProps {
+  locale: Locale;
+  // Floor / building (shared, rendered in the header above the tabs)
+  floors: FloorOption[];
+  currentFloorId: string;
+  buildings: FloorOption[];
+  currentBuildingId: string;
+  onSelectFloor: (id: string) => void;
+  onSelectBuilding: (id: string) => void;
+  // Explore
+  spaces: SpaceOption[];
+  onSearchSelect: (id: string) => void;
+  selectedSpace: { id: string; name: string } | null;
+  onClearSelection: () => void;
+  // Navigate
+  routing: boolean;
+  routeError: string | null;
+  routeSummary: string | null;
+  routeInstructions: string[];
+  onRoute: (from: string, to: string, accessible: boolean) => void;
+  onClearRoute: () => void;
+}
+
+/**
+ * Left side panel for the MappedIn viewer — replaces the older
+ * stack of floating cards (search / wayfinding / floors / selection)
+ * with one top-to-bottom panel that lives outside the map area.
+ *
+ * Structure:
+ *   - Context header (building + floor pickers, only when relevant)
+ *   - Explore | Navigate tabs
+ *   - Tab content
+ */
+export function SidePanel(props: SidePanelProps) {
+  const [tab, setTab] = useState<Tab>("explore");
+  const t = (key: Parameters<typeof translate>[1]) =>
+    translate(props.locale, key);
+
+  const hasContext =
+    props.floors.length > 1 || props.buildings.length > 1;
+
+  return (
+    <div className="flex h-full flex-col bg-surface-1">
+      {hasContext ? (
+        <div className="border-b border-solid border-line-soft p-3">
+          <FloorControls
+            floors={props.floors}
+            currentFloorId={props.currentFloorId}
+            buildings={props.buildings}
+            currentBuildingId={props.currentBuildingId}
+            onSelectFloor={props.onSelectFloor}
+            onSelectBuilding={props.onSelectBuilding}
+            locale={props.locale}
+            bare
+          />
+        </div>
+      ) : null}
+
+      <div className="flex gap-1 border-b border-solid border-line-soft p-2">
+        <TabButton
+          active={tab === "explore"}
+          onClick={() => setTab("explore")}
+          label={t("mappedin.tabExplore")}
+        />
+        <TabButton
+          active={tab === "navigate"}
+          onClick={() => setTab("navigate")}
+          label={t("mappedin.tabNavigate")}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {tab === "explore" ? (
+          <ExploreTab
+            locale={props.locale}
+            spaces={props.spaces}
+            onSearchSelect={props.onSearchSelect}
+            selectedSpace={props.selectedSpace}
+            onClearSelection={props.onClearSelection}
+          />
+        ) : (
+          <NavigateTab
+            locale={props.locale}
+            spaces={props.spaces}
+            routing={props.routing}
+            routeError={props.routeError}
+            routeSummary={props.routeSummary}
+            routeInstructions={props.routeInstructions}
+            onRoute={props.onRoute}
+            onClearRoute={props.onClearRoute}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition-colors",
+        active
+          ? "bg-accent text-accent-contrast"
+          : "text-text-secondary hover:bg-accent-soft hover:text-accent",
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/campus/lib/mappedin/SidePanel.tsx
+++ b/apps/campus/lib/mappedin/SidePanel.tsx
@@ -54,7 +54,7 @@ export function SidePanel(props: SidePanelProps) {
   return (
     <div className="flex h-full flex-col bg-surface-1">
       {hasContext ? (
-        <div className="border-b border-solid border-line-soft p-3">
+        <div className="border-b border-solid border-line-soft px-4 py-3">
           <FloorControls
             floors={props.floors}
             currentFloorId={props.currentFloorId}
@@ -68,7 +68,7 @@ export function SidePanel(props: SidePanelProps) {
         </div>
       ) : null}
 
-      <div className="flex gap-1 border-b border-solid border-line-soft p-2">
+      <div className="flex gap-1 border-b border-solid border-line-soft px-4 py-2">
         <TabButton
           active={tab === "explore"}
           onClick={() => setTab("explore")}

--- a/apps/campus/lib/mappedin/SidePanel.tsx
+++ b/apps/campus/lib/mappedin/SidePanel.tsx
@@ -100,6 +100,7 @@ export function SidePanel(props: SidePanelProps) {
             routeInstructions={props.routeInstructions}
             onRoute={props.onRoute}
             onClearRoute={props.onClearRoute}
+            onFocus={props.onSearchSelect}
           />
         )}
       </div>

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -32,6 +32,8 @@ export interface WayfindingControlsProps {
   onClear: () => void;
   /** UI locale — defaults to English. */
   locale?: Locale;
+  /** Drop the rounded-card chrome — for use inside the side panel. */
+  bare?: boolean;
 }
 
 /**
@@ -50,6 +52,7 @@ export function WayfindingControls({
   onRoute,
   onClear,
   locale = "en",
+  bare = false,
 }: WayfindingControlsProps) {
   const t = (key: Parameters<typeof translate>[1]) => translate(locale, key);
   const [from, setFrom] = useState("");
@@ -58,7 +61,13 @@ export function WayfindingControls({
   const canRoute = from !== "" && to !== "" && from !== to && !routing;
 
   return (
-    <div className="flex w-full flex-col gap-3 rounded-2xl border border-line-soft bg-surface-1/95 p-4 shadow-glass backdrop-blur">
+    <div
+      className={
+        bare
+          ? "flex w-full flex-col gap-3"
+          : "flex w-full flex-col gap-3 rounded-2xl border border-line-soft bg-surface-1/95 p-4 shadow-glass backdrop-blur"
+      }
+    >
       <h2 className="text-sm font-semibold text-text-primary">
         {t("mappedin.wayfindTitle")}
       </h2>

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Select } from "@klorad/design-system";
+import { Button } from "@klorad/design-system";
 import { translate, type Locale } from "@/app/lib/i18n-core";
+import { SearchableSelect } from "./SearchableSelect";
 
 /** A selectable destination — a named space in the venue. */
 export interface SpaceOption {
@@ -88,29 +89,33 @@ export function WayfindingControls({
         {t("mappedin.wayfindTitle")}
       </h2>
 
-      <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
-        {t("mappedin.wayfindFrom")}
-        <Select value={from} onChange={(e) => setFrom(e.target.value)}>
-          <option value="">{t("mappedin.wayfindPick")}</option>
-          {spaces.map((s) => (
-            <option key={s.id} value={s.id}>
-              {s.name}
-            </option>
-          ))}
-        </Select>
-      </label>
+      <div className="flex flex-col gap-1">
+        <span className="text-xs font-medium text-text-secondary">
+          {t("mappedin.wayfindFrom")}
+        </span>
+        <SearchableSelect
+          options={spaces}
+          value={from}
+          onChange={setFrom}
+          placeholder={t("mappedin.wayfindPick")}
+          noMatchLabel={t("mappedin.noMatches")}
+          ariaLabel={t("mappedin.wayfindFrom")}
+        />
+      </div>
 
-      <label className="flex flex-col gap-1 text-xs font-medium text-text-secondary">
-        {t("mappedin.wayfindTo")}
-        <Select value={to} onChange={(e) => setTo(e.target.value)}>
-          <option value="">{t("mappedin.wayfindPick")}</option>
-          {spaces.map((s) => (
-            <option key={s.id} value={s.id}>
-              {s.name}
-            </option>
-          ))}
-        </Select>
-      </label>
+      <div className="flex flex-col gap-1">
+        <span className="text-xs font-medium text-text-secondary">
+          {t("mappedin.wayfindTo")}
+        </span>
+        <SearchableSelect
+          options={spaces}
+          value={to}
+          onChange={setTo}
+          placeholder={t("mappedin.wayfindPick")}
+          noMatchLabel={t("mappedin.noMatches")}
+          ariaLabel={t("mappedin.wayfindTo")}
+        />
+      </div>
 
       {error ? <p className="text-xs text-red-600">{error}</p> : null}
       {summary && !error ? (

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -100,7 +100,11 @@ export function WayfindingControls({
           value={from}
           onChange={setFrom}
           placeholder={t("mappedin.wayfindPick")}
+          searchPlaceholder={t("mappedin.searchSpaces")}
           noMatchLabel={t("mappedin.noMatches")}
+          moreResultsLabel={(shown, total) =>
+            translate(locale, "mappedin.moreResults", { shown, total })
+          }
           ariaLabel={t("mappedin.wayfindFrom")}
         />
       </div>
@@ -114,7 +118,11 @@ export function WayfindingControls({
           value={to}
           onChange={setTo}
           placeholder={t("mappedin.wayfindPick")}
+          searchPlaceholder={t("mappedin.searchSpaces")}
           noMatchLabel={t("mappedin.noMatches")}
+          moreResultsLabel={(shown, total) =>
+            translate(locale, "mappedin.moreResults", { shown, total })
+          }
           ariaLabel={t("mappedin.wayfindTo")}
         />
       </div>

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -17,6 +17,8 @@ export interface WayfindingControlsProps {
   routing: boolean;
   /** Inline error (no route, routing failed). */
   error: string | null;
+  /** Inline route summary — "120 m · ~2 min" — shown after a draw. */
+  summary?: string | null;
   /**
    * Compute + draw a route between two spaces. `accessible` requests
    * MappedIn's step-free route — stairs avoided where alternatives exist.
@@ -39,6 +41,7 @@ export function WayfindingControls({
   spaces,
   routing,
   error,
+  summary,
   onRoute,
   onClear,
   locale = "en",
@@ -90,6 +93,9 @@ export function WayfindingControls({
       </label>
 
       {error ? <p className="text-xs text-red-600">{error}</p> : null}
+      {summary && !error ? (
+        <p className="text-xs font-medium text-accent">{summary}</p>
+      ) : null}
 
       <div className="flex justify-end gap-2">
         <Button size="sm" variant="secondary" onClick={onClear}>

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -21,6 +21,8 @@ export interface WayfindingControlsProps {
   error: string | null;
   /** Inline route summary — "120 m · ~2 min" — shown after a draw. */
   summary?: string | null;
+  /** Turn-by-turn instructions from the SDK, shown under the summary. */
+  instructions?: string[];
   /**
    * Compute + draw a route between two spaces. `accessible` requests
    * MappedIn's step-free route — stairs avoided where alternatives exist.
@@ -44,6 +46,7 @@ export function WayfindingControls({
   routing,
   error,
   summary,
+  instructions,
   onRoute,
   onClear,
   locale = "en",
@@ -97,6 +100,18 @@ export function WayfindingControls({
       {error ? <p className="text-xs text-red-600">{error}</p> : null}
       {summary && !error ? (
         <p className="text-xs font-medium text-accent">{summary}</p>
+      ) : null}
+      {instructions && instructions.length > 0 && !error ? (
+        <ol className="max-h-44 space-y-1 overflow-y-auto rounded-lg bg-surface-2 p-2 text-xs text-text-secondary">
+          {instructions.map((step, i) => (
+            <li key={i} className="flex gap-2">
+              <span className="shrink-0 font-semibold text-accent">
+                {i + 1}.
+              </span>
+              <span>{step}</span>
+            </li>
+          ))}
+        </ol>
       ) : null}
 
       <div className="flex justify-end gap-2">

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -8,6 +8,8 @@ import { translate, type Locale } from "@/app/lib/i18n-core";
 export interface SpaceOption {
   id: string;
   name: string;
+  /** MappedIn space type (e.g. "office", "cafe") — used by the chip filter. */
+  type?: string;
 }
 
 export interface WayfindingControlsProps {

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -28,6 +28,12 @@ export interface WayfindingControlsProps {
    * MappedIn's step-free route — stairs avoided where alternatives exist.
    */
   onRoute: (fromId: string, toId: string, accessible: boolean) => void;
+  /**
+   * Whether the route should be step-free. Controlled — the parent
+   * (NavigateTab) owns the routing profile (Default / Wheelchair /
+   * Visually impaired) and maps it to this flag.
+   */
+  accessible?: boolean;
   /** Clear the drawn route. */
   onClear: () => void;
   /** UI locale — defaults to English. */
@@ -53,12 +59,22 @@ export function WayfindingControls({
   onClear,
   locale = "en",
   bare = false,
+  accessible = false,
 }: WayfindingControlsProps) {
   const t = (key: Parameters<typeof translate>[1]) => translate(locale, key);
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
-  const [accessible, setAccessible] = useState(false);
   const canRoute = from !== "" && to !== "" && from !== to && !routing;
+
+  const swap = () => {
+    setFrom(to);
+    setTo(from);
+  };
+  const clearAll = () => {
+    setFrom("");
+    setTo("");
+    onClear();
+  };
 
   return (
     <div
@@ -96,16 +112,6 @@ export function WayfindingControls({
         </Select>
       </label>
 
-      <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-text-secondary">
-        <input
-          type="checkbox"
-          checked={accessible}
-          onChange={(e) => setAccessible(e.target.checked)}
-          className="h-4 w-4 rounded accent-accent"
-        />
-        {t("mappedin.wayfindStepFree")}
-      </label>
-
       {error ? <p className="text-xs text-red-600">{error}</p> : null}
       {summary && !error ? (
         <p className="text-xs font-medium text-accent">{summary}</p>
@@ -123,10 +129,25 @@ export function WayfindingControls({
         </ol>
       ) : null}
 
-      <div className="flex justify-end gap-2">
-        <Button size="sm" variant="secondary" onClick={onClear}>
-          {t("mappedin.wayfindClear")}
-        </Button>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={swap}
+            disabled={!from && !to}
+          >
+            ↑↓ {t("mappedin.swap")}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={clearAll}
+            disabled={!from && !to}
+          >
+            ✕ {t("mappedin.wayfindClear")}
+          </Button>
+        </div>
         <Button
           size="sm"
           disabled={!canRoute}

--- a/apps/campus/lib/mappedin/WayfindingControls.tsx
+++ b/apps/campus/lib/mappedin/WayfindingControls.tsx
@@ -11,6 +11,8 @@ export interface SpaceOption {
   name: string;
   /** MappedIn space type (e.g. "office", "cafe") — used by the chip filter. */
   type?: string;
+  /** Floor-stack id this space belongs to — used to filter to the active building. */
+  buildingId?: string;
 }
 
 export interface WayfindingControlsProps {

--- a/apps/campus/lib/mappedin/WelcomeOverlay.tsx
+++ b/apps/campus/lib/mappedin/WelcomeOverlay.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { translate, type Locale } from "@/app/lib/i18n-core";
+
+const STORAGE_KEY = "mappedin:welcome-seen";
+
+/**
+ * First-visit coachmark for the public MappedIn viewer.
+ *
+ * A small overlay card with three concrete tips (search, tap,
+ * pan/zoom) so a visitor's first encounter with the map isn't a
+ * blank "what do I do." Dismissed once, never shown again (per
+ * browser, via localStorage). Opt-in: only the public map mounts
+ * it; the dashboard's Indoor tab doesn't.
+ */
+export function WelcomeOverlay({ locale }: { locale: Locale }) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.localStorage.getItem(STORAGE_KEY) === "1") return;
+    setShow(true);
+  }, []);
+
+  if (!show) return null;
+
+  const t = (key: Parameters<typeof translate>[1]) =>
+    translate(locale, key);
+  const dismiss = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, "1");
+    }
+    setShow(false);
+  };
+
+  return (
+    <div className="pointer-events-auto absolute bottom-20 left-1/2 z-20 w-[min(22rem,calc(100vw-2rem))] -translate-x-1/2 rounded-2xl border border-solid border-line-soft bg-surface-1/95 p-4 shadow-glass backdrop-blur">
+      <h3 className="text-sm font-semibold text-text-primary">
+        {t("mappedin.welcomeTitle")}
+      </h3>
+      <ul className="mt-2 space-y-1.5 text-xs text-text-secondary">
+        <li className="flex gap-2">
+          <span aria-hidden>🔍</span>
+          <span>{t("mappedin.welcomeTipSearch")}</span>
+        </li>
+        <li className="flex gap-2">
+          <span aria-hidden>👆</span>
+          <span>{t("mappedin.welcomeTipTap")}</span>
+        </li>
+        <li className="flex gap-2">
+          <span aria-hidden>🧭</span>
+          <span>{t("mappedin.welcomeTipExplore")}</span>
+        </li>
+      </ul>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="mt-3 w-full rounded-full bg-accent px-4 py-2 text-xs font-semibold text-accent-contrast transition-opacity hover:opacity-90"
+      >
+        {t("mappedin.welcomeGotIt")}
+      </button>
+    </div>
+  );
+}

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -32,6 +32,7 @@
     "@mui/material": "^6.4.1",
     "@prisma/client": "^5.22.0",
     "@prisma/extension-accelerate": "^1.0.0",
+    "@radix-ui/react-popover": "^1.1.15",
     "@types/node": "^20.11.30",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,9 @@ importers:
       '@prisma/extension-accelerate':
         specifier: ^1.0.0
         version: 1.3.0(@prisma/client@5.22.0(prisma@5.22.0))
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.24
@@ -2761,6 +2764,28 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^19.2.1
+      react-dom: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -2768,6 +2793,19 @@ packages:
       react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^19.2.1
+      react-dom: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.8':
@@ -4239,6 +4277,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -4820,6 +4862,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   detective-amd@6.0.1:
     resolution: {integrity: sha512-TtyZ3OhwUoEEIhTFoc1C9IyJIud3y+xYkSRjmvCt65+ycQuc3VcBrPRTMWoO/AnuCyOB8T5gky+xf7Igxtjd3g==}
@@ -5443,6 +5488,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
@@ -6952,6 +7001,36 @@ packages:
     peerDependencies:
       react: ^19.2.1
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-toastify@11.0.5:
     resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
     peerDependencies:
@@ -7919,6 +7998,26 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -10321,12 +10420,52 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -11938,6 +12077,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -12516,6 +12659,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  detect-node-es@1.1.0: {}
 
   detective-amd@6.0.1:
     dependencies:
@@ -13362,6 +13507,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-own-enumerable-property-symbols@3.0.2: {}
 
@@ -14923,6 +15070,33 @@ snapshots:
       react: 19.2.1
       scheduler: 0.25.0
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-style-singleton: 2.2.3(@types/react@19.2.7)(react@19.2.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  react-remove-scroll@2.7.2(@types/react@19.2.7)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.7)(react@19.2.1)
+      react-style-singleton: 2.2.3(@types/react@19.2.7)(react@19.2.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.7)(react@19.2.1)
+      use-sidecar: 1.1.3(@types/react@19.2.7)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.2.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   react-toastify@11.0.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       clsx: 2.1.1
@@ -16101,6 +16275,21 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  use-sidecar@1.1.3(@types/react@19.2.7)(react@19.2.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
 
   use-sync-external-store@1.6.0(react@19.2.1):
     dependencies:


### PR DESCRIPTION
## Summary

Seventeen commits taking the MappedIn indoor map from "we have a 3D viewer" to a clean, branded, student-usable campus tool. Started as a polish pass; the side-panel restructure, AI assistant, searchable dropdowns and the surface/style fixes all landed on the same branch on direction during the session.

## The seventeen commits

### Polish bundle (4)

- `fe03f4e4` — Branded route + selected-space highlight + distance / ETA + loading skeleton. `Navigation.draw({ pathOptions: { color } })` + `updateState({ color })` thread the campus's `branding.primaryColor` through. `directions.distance` / `.duration` render as "120 m · ~2 min."
- `17d721bc` — Category filter chips above search, sorted by count.
- `2d529866` — Turn-by-turn text directions under the drawn route.
- `53f32f0b` — Welcome coachmark (first-visit tips, localStorage-gated) + "Preview public view ↗" link in the dashboard Indoor tab.

### Side-panel restructure (3)

- `42ec1729` — Replace the stack of floating cards with a **left side panel** that holds everything top-to-bottom. Context header (building + floor) above two tabs: **Explore** (search + categories + selected space) and **Navigate** (wayfinding). `SearchControls` / `WayfindingControls` / `FloorControls` gained a `bare` prop so they render without their own card chrome inside the panel.
- `15a2236b` — Routing profile selector (Default / Wheelchair / Visually impaired) + Swap button + Clear that wipes the route. *(Removed in `72d11247` per direction — the profile UX is gone; accessibility is detected by the chat instead.)*
- `55e7306e` — **Ask-the-assistant chat** on the Navigate tab. `AssistantChat` posts to `/api/assistant`; a regex parser there turns "How do I get to room 201?" / "From the gym to the library" / "I use a wheelchair, reach the lab" into focus / route actions and dispatches them through the viewer's own handlers. `ANTHROPIC_API_KEY` upgrade path is one function swap.

### Mobile + filtering (3)

- `d15eca7f` then **`c7a13979`** — Side panel is one layout on every screen (left aside, 256 / 320 px, always visible). (`d15eca7f` had it as a mobile drawer; `c7a13979` undid that per direction.)
- `eb390c58` — Padding fixes (tabs row + context header on `px-4` so everything aligns with the content gutter), labels above the Building / Floor groups, **building selection zooms the camera in**, and the first iteration of the searchable dropdowns.
- `72d11247` — Dropped the profile chips; **rooms filter to the active building**. `SpaceOption.buildingId` populates from `Space.floor.floorStack.id`; the viewer derives `visibleSpaces` and passes that to the panel so the From / To dropdowns, the search and the chat all scope to the active building.

### Searchable dropdown (7)

- `24274c4c` then `0ca76bb4` then **`2912bec6`** — Built and rebuilt three times until it was right. Final version is on **Radix Popover** (`@radix-ui/react-popover`): trigger is a button showing the selected value + caret; popover holds a search input on top + a scrollable list of matches; Radix owns portal, viewport collision (auto-flip up), available-height (`--radix-popover-content-available-height` so the inner list scrolls inside the viewport on a phone), trigger-width matching, outside-click, escape and ARIA.
- `77aff814` then `ac540b51` then **`c6c65f4d`** — Style passes to match the Klorad visual language (glass + pills + accent-soft, never bordered grey rows). Final state: solid `bg-surface-1` popover, `p-4` gutter around options, rounded-lg pills, white search input with a soft border, results capped at 50 with a "Refine to see more (50 of N)" footer in EN + EL. `c6c65f4d` kills the browser-default `<button>` borders and `<ul>` bullets that show through because `apps/campus` has Tailwind preflight off (`div role="listbox"` + inline `border: none`).

## What this changes

Before: a 3D venue + floating overlays in Klorad blue, search + wayfinding cramped on top of each other, no real sense of "this is the campus's tool."

After: campus's brand colour everywhere on the map · category-aware search · routes with distance + ETA + turn-by-turn · single side panel with two tabs · building-scoped rooms · searchable dropdowns that handle 400-room venues · a chat that lets visitors ask in natural language.

## Mobile

Side panel is the same layout on every screen — 256 px on phones, 320 px at md+, always visible. The map fills the rest.

## New dep

`@radix-ui/react-popover` (used by `SearchableSelect`).

## Testing

`tsc --noEmit` clean throughout; pre-commit green on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)