### PR TITLE
feat(campus): new consumer home — Arc 1 of the consumer pivot

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -1,17 +1,10 @@
 import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { KloradMark } from "@klorad/design-system";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { formatPostDate, readPosts } from "@/lib/posts";
-import { readEventFeeds } from "@/lib/events";
-import { fetchCampusEvents } from "@/lib/events-server";
 import { readHomePage } from "@/lib/home-page";
-import { CampusEvents } from "./CampusEvents";
-import { detectLocale, pickText, translate } from "@/app/lib/i18n-core";
+import { detectLocale, pickText } from "@/app/lib/i18n-core";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
-import { HomeLangToggle } from "./HomeLangToggle";
+import { ConsumerHome } from "@/lib/consumer/ConsumerHome";
 
 type Params = Promise<{ token: string }>;
 
@@ -25,31 +18,7 @@ function isValidHex(value: string | undefined): value is string {
   return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
 }
 
-/** Whether `next/image` can optimise this URL — only Spaces hosts. */
-function isOptimisableImage(url: string): boolean {
-  if (url.startsWith("data:")) return false;
-  try {
-    return new URL(url).hostname.endsWith(".digitaloceanspaces.com");
-  } catch {
-    return false;
-  }
-}
-
-/** Location-pin glyph for a post's linked place. */
-function PinIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden
-    >
-      <path d="M12 2C8 2 5 5 5 9c0 5.5 7 13 7 13s7-7.5 7-13c0-4-3-7-7-7zm0 9.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" />
-    </svg>
-  );
-}
-
-/** Dynamic metadata so shared URLs preview nicely in Slack / WhatsApp / LinkedIn. */
+/** Dynamic metadata so shared URLs preview nicely. */
 export async function generateMetadata({
   params,
 }: {
@@ -57,13 +26,11 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { token } = await params;
   const map = await getPublicCampusByToken(token);
-
   const scene = (map?.sceneData ?? null) as {
     branding?: { name?: string };
   } | null;
   const name = scene?.branding?.name || map?.title || "Campus";
-  const description = `${name} — campus news, events, and an interactive 3D map with step-free indoor wayfinding.`;
-
+  const description = `${name} — news, events, clubs and an interactive campus map.`;
   return {
     title: name,
     description,
@@ -84,12 +51,14 @@ export async function generateMetadata({
 /**
  * `/campus/[token]` — the public campus home page.
  *
- * The branded landing for a campus: news, and a route into the 3D
- * map (`/campus/[token]/map`). Server-rendered so news is in the
- * HTML for SEO and link previews.
+ * Arc 1 of [[campus-consumer-pivot]]: the multi-tenant template
+ * lands here. Everything visible is now rendered by `ConsumerHome`;
+ * per-org `branding.primaryColor` flows in as `accentColor` and
+ * overrides the default purple at the `data-consumer` root.
  *
- * Gated on `isPublished`: unknown → 404, draft → "coming soon"
- * placeholder, published → the home.
+ * Real news / events / clubs land in Arcs 2 – 4. For now the rails
+ * are populated by `lib/sample-campus.ts`, shaped to the eventual
+ * schema so the markup doesn't change when data sources flip.
  */
 export default async function CampusHomePage({
   params,
@@ -103,178 +72,31 @@ export default async function CampusHomePage({
   const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
   const map = await getPublicCampusByToken(token);
-
   if (!map) notFound();
   if (!map.isPublished)
     return <NotPublishedPlaceholder name={map.title} locale={locale} />;
 
   const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
   const branding = scene.branding ?? {};
-  const displayName = branding.name || map.title;
-  const accent = isValidHex(branding.primaryColor)
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
     ? branding.primaryColor
-    : "#158ca3";
-  const posts = readPosts(map.sceneData);
-  const events = await fetchCampusEvents(readEventFeeds(map.sceneData));
-  // Always carries `?lang=` so downstream links append with `&`
-  // (and so the locale survives navigation off the home page).
-  const mapHref = `/campus/${token}/map?lang=${locale}`;
-
-  // Home page builder config — bilingual fields resolved to the
-  // visitor's locale, each falling back to a sensible default.
+    : undefined;
+  // The home-page builder lets an org override the marketing copy.
+  // When set, those win over the platform's defaults.
   const home = readHomePage(map.sceneData);
-  const heroBg = home.heroImage || map.thumbnail || null;
-  const headline = pickText(home.headline, locale) || displayName;
-  const tagline = pickText(home.tagline, locale) || map.description || "";
-  const ctaLabel =
-    pickText(home.ctaLabel, locale) || translate(locale, "home.exploreMap");
-  const showEvents = home.showEvents !== false;
-  const showNews = home.showNews !== false;
-  const indoorMapId = (map.sceneData as { indoorMapId?: string } | null)
-    ?.indoorMapId;
+  const headline = pickText(home.headline, locale) || undefined;
+  const subheading = pickText(home.tagline, locale) || undefined;
 
   return (
-    <main lang={locale} className="min-h-screen bg-bg">
-      <header className="sticky top-0 z-20 flex items-center justify-between gap-3 border-b border-solid border-line-soft bg-bg/85 px-6 py-3 backdrop-blur md:px-10 md:py-4">
-        {branding.logo ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={branding.logo}
-            alt={displayName}
-            className="h-7 max-w-[160px] object-contain sm:h-8 sm:max-w-[200px]"
-          />
-        ) : (
-          <span className="truncate text-base font-semibold text-text-primary sm:text-lg">
-            {displayName}
-          </span>
-        )}
-        <div className="flex shrink-0 items-center gap-2">
-          <HomeLangToggle token={token} current={locale} />
-          <Link
-            href={mapHref}
-            className="rounded-full px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
-            style={{ backgroundColor: accent }}
-          >
-            {translate(locale, "home.openMap")}
-          </Link>
-        </div>
-      </header>
-
-      <section
-        className="relative flex min-h-[56vh] items-end overflow-hidden px-6 py-12 md:px-10 md:py-16"
-        style={
-          heroBg
-            ? undefined
-            : {
-                background: `linear-gradient(155deg, ${accent} 0%, #0b1116 100%)`,
-              }
-        }
-      >
-        {heroBg ? (
-          <>
-            <Image
-              src={heroBg}
-              alt=""
-              fill
-              priority
-              sizes="100vw"
-              className="object-cover"
-              // Legacy thumbnails / pasted URLs may not be on Spaces;
-              // bypass the optimiser rather than 500 the page.
-              unoptimized={!isOptimisableImage(heroBg)}
-            />
-            <div
-              aria-hidden
-              className="absolute inset-0"
-              style={{
-                background:
-                  "linear-gradient(to top, rgba(11,17,22,0.9), rgba(11,17,22,0.35))",
-              }}
-            />
-          </>
-        ) : null}
-        <div className="relative z-10 max-w-3xl">
-          <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl md:text-5xl">
-            {headline}
-          </h1>
-          {tagline ? (
-            <p className="mt-3 max-w-2xl text-base leading-relaxed text-white/85">
-              {tagline}
-            </p>
-          ) : null}
-          <Link
-            href={mapHref}
-            className="mt-7 inline-flex w-full items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold shadow-sm transition-transform hover:scale-[1.02] sm:w-auto"
-            style={{ color: accent }}
-          >
-            {ctaLabel} →
-          </Link>
-        </div>
-      </section>
-
-      {showEvents ? (
-        <CampusEvents
-          events={events}
-          indoorMapId={indoorMapId}
-          token={token}
-          locale={locale}
-          accent={accent}
-        />
-      ) : null}
-
-      {showNews ? (
-      <section className="px-6 pb-20 pt-8 md:px-10">
-        <h2 className="text-xs font-medium uppercase tracking-[0.16em] text-text-tertiary">
-          {translate(locale, "home.news")}
-        </h2>
-        {posts.length > 0 ? (
-          <div className="mt-4 space-y-4">
-            {posts.map((post) => (
-              <article
-                key={post.id}
-                className="rounded-2xl bg-surface-1 p-6 shadow-glass"
-              >
-                <time className="text-xs text-text-tertiary">
-                  {formatPostDate(post.publishedAt)}
-                </time>
-                <h3 className="mt-1 text-lg font-semibold text-text-primary">
-                  {pickText(post.title, locale)}
-                </h3>
-                {pickText(post.body, locale) ? (
-                  <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-text-secondary">
-                    {pickText(post.body, locale)}
-                  </p>
-                ) : null}
-                {post.place ? (
-                  <Link
-                    href={
-                      post.place.source === "mappedin"
-                        ? `${mapHref}&space=${encodeURIComponent(post.place.id)}`
-                        : `${mapHref}&place=${encodeURIComponent(post.place.id)}`
-                    }
-                    className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition-opacity hover:opacity-80"
-                  >
-                    <PinIcon className="h-3 w-3" />
-                    {post.place.name}
-                  </Link>
-                ) : null}
-              </article>
-            ))}
-          </div>
-        ) : (
-          <p className="mt-4 text-sm text-text-tertiary">
-            {translate(locale, "home.noNews")}
-          </p>
-        )}
-      </section>
-      ) : null}
-
-      <footer className="border-t border-solid border-line-soft px-6 py-6 text-center md:px-10">
-        <span className="inline-flex items-center gap-1.5 text-[0.7rem] uppercase tracking-[0.18em] text-text-tertiary">
-          <KloradMark className="h-4 w-4" />
-          Powered by Klorad
-        </span>
-      </footer>
-    </main>
+    <ConsumerHome
+      token={token}
+      campusName={campusName}
+      accentColor={accentColor}
+      logoUrl={branding.logo}
+      locale={locale}
+      headline={headline}
+      subheading={subheading}
+    />
   );
 }

--- a/apps/campus/app/global.css
+++ b/apps/campus/app/global.css
@@ -95,15 +95,46 @@ body {
  * utilities still win. Scoped to `[data-workbench]` / `[data-mappedin]`
  * so MUI dashboard pages stay untouched.
  */
-:where([data-workbench], [data-mappedin]) *,
-:where([data-workbench], [data-mappedin]) *::before,
-:where([data-workbench], [data-mappedin]) *::after {
+:where([data-workbench], [data-mappedin], [data-consumer]) *,
+:where([data-workbench], [data-mappedin], [data-consumer]) *::before,
+:where([data-workbench], [data-mappedin], [data-consumer]) *::after {
   border-width: 0;
   border-style: solid;
   border-color: var(--line-soft);
 }
 
 /* Lists in these surfaces carry no markers — rows style themselves. */
-:where([data-workbench], [data-mappedin]) :where(ul, ol) {
+:where([data-workbench], [data-mappedin], [data-consumer]) :where(ul, ol) {
   list-style: none;
+}
+
+/*
+ * Consumer surface palette ([[campus-consumer-pivot]]). Default
+ * Klorad-purple tokens applied on every `[data-consumer]` wrapper;
+ * per-org `branding.primaryColor` overrides `--brand-primary` via an
+ * inline style on the wrapper. Coral / teal / pink stay fixed —
+ * they're the accent vocabulary, not the brand colour.
+ */
+[data-consumer] {
+  --brand-primary: #534ab7;
+  --brand-primary-bg: #eeedfe;
+  --brand-coral: #d85a30;
+  --brand-teal: #1d9e75;
+  --brand-pink: #d4537e;
+  --brand-text: #1a1a1a;
+  --brand-text-muted: #6b6b6b;
+  --brand-page: #fafafa;
+  --brand-line: rgba(26, 26, 26, 0.08);
+  background-color: var(--brand-page);
+  color: var(--brand-text);
+}
+
+/*
+ * Consumer surfaces are flat — 0.5 px hairline borders by default.
+ * Override per element with explicit `border-[1px]` where needed.
+ */
+:where([data-consumer]) *,
+:where([data-consumer]) *::before,
+:where([data-consumer]) *::after {
+  border-color: var(--brand-line);
 }

--- a/apps/campus/lib/consumer/ClubRow.tsx
+++ b/apps/campus/lib/consumer/ClubRow.tsx
@@ -1,0 +1,49 @@
+import type { ConsumerClub } from "./types";
+
+const AVATAR_BG: Record<ConsumerClub["avatarColor"], string> = {
+  purple: "var(--brand-primary)",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+export interface ClubRowProps {
+  club: ConsumerClub;
+}
+
+/**
+ * One row in the "Most active clubs" rail. Coloured square avatar
+ * with initials + name + member count + meets cadence on the left;
+ * "View" pill on the right opens the club's external link in a new
+ * tab. No identity / login involved — see [[campus-consumer-pivot]].
+ */
+export function ClubRow({ club }: ClubRowProps) {
+  return (
+    <div className="flex items-center gap-4 border-b border-[var(--brand-line)] py-3 last:border-b-0">
+      <span
+        aria-hidden
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-sm font-medium text-white"
+        style={{ backgroundColor: AVATAR_BG[club.avatarColor] }}
+      >
+        {club.initials}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-[var(--brand-text)]">
+          {club.name}
+        </div>
+        <div className="mt-0.5 text-xs text-[var(--brand-text-muted)]">
+          {club.memberCount} members · {club.meetsCadence}
+        </div>
+      </div>
+      <a
+        href={club.externalLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 rounded-full px-4 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+        style={{ backgroundColor: "var(--brand-primary)" }}
+      >
+        View
+      </a>
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/ConsumerFooter.tsx
+++ b/apps/campus/lib/consumer/ConsumerFooter.tsx
@@ -1,0 +1,20 @@
+export interface ConsumerFooterProps {
+  /** Display name of the campus — appears in the "Built for …" line. */
+  campusName: string;
+}
+
+/**
+ * Centered, low-weight footer. Per [[campus-consumer-pivot]] the
+ * line reads "Built for {Campus} · Powered by Klorad" to preserve
+ * the multi-tenant story.
+ */
+export function ConsumerFooter({ campusName }: ConsumerFooterProps) {
+  return (
+    <footer className="mx-auto mt-12 max-w-[1280px] px-4 pb-10 pt-8 text-center md:px-6">
+      <p className="text-xs text-[var(--brand-text-muted)]">
+        Built for {campusName} · Powered by Klorad · privacy ·
+        accessibility · contact
+      </p>
+    </footer>
+  );
+}

--- a/apps/campus/lib/consumer/ConsumerHero.tsx
+++ b/apps/campus/lib/consumer/ConsumerHero.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import { MapTeaser } from "./MapTeaser";
+
+export interface ConsumerHeroProps {
+  /** Primary headline — falls back to a generic line if the org hasn't set one. */
+  headline: string;
+  subheading: string;
+  /** Honest copy: where the "Get started" CTA lands. */
+  primaryHref: string;
+  primaryLabel: string;
+  /** Optional secondary CTA — "Watch the tour" in the brief. */
+  secondaryHref?: string;
+  secondaryLabel?: string;
+  /** Map link the right-column teaser opens. */
+  mapHref: string;
+}
+
+/** Four pastel avatar circles, decorative — the "joined by 8,400" social proof. */
+function AvatarStack() {
+  const colors = ["#534AB7", "#D85A30", "#1D9E75", "#D4537E"];
+  return (
+    <div className="flex -space-x-2">
+      {colors.map((c, i) => (
+        <span
+          key={i}
+          aria-hidden
+          className="inline-block h-7 w-7 rounded-full border-2 border-[var(--brand-primary-bg)]"
+          style={{ backgroundColor: c }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Two-column hero. Left column lives on the soft-purple background
+ * (`--brand-primary-bg`) with two decorative blobs — a large purple
+ * circle bottom-right, a coral circle top-right — copy stacked over
+ * the top, two CTAs, social-proof avatar stack at the bottom. Right
+ * column is the `MapTeaser`. On mobile the columns stack vertically.
+ */
+export function ConsumerHero({
+  headline,
+  subheading,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+  mapHref,
+}: ConsumerHeroProps) {
+  return (
+    <section className="mx-auto grid max-w-[1280px] grid-cols-1 gap-6 px-4 py-8 md:grid-cols-[1.1fr_0.9fr] md:gap-10 md:px-6 md:py-12">
+      <div className="relative overflow-hidden rounded-2xl bg-[var(--brand-primary-bg)] p-8 md:p-12">
+        {/* Decorative blobs */}
+        <span
+          aria-hidden
+          className="absolute -bottom-12 -right-12 h-56 w-56 rounded-full"
+          style={{ backgroundColor: "var(--brand-primary)", opacity: 0.18 }}
+        />
+        <span
+          aria-hidden
+          className="absolute -right-4 top-6 h-16 w-16 rounded-full"
+          style={{ backgroundColor: "#D85A30", opacity: 0.55 }}
+        />
+
+        <div className="relative">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-xs font-medium text-[var(--brand-text)]">
+            <Sparkles size={14} className="text-[var(--brand-primary)]" />
+            Made for students, by students
+          </span>
+
+          <h1 className="mt-6 max-w-xl text-3xl font-medium leading-tight tracking-tight text-[var(--brand-text)] md:text-4xl">
+            {headline}
+          </h1>
+
+          <p className="mt-4 max-w-lg text-base leading-relaxed text-[var(--brand-text-muted)]">
+            {subheading}
+          </p>
+
+          <div className="mt-7 flex flex-wrap items-center gap-3">
+            <Link
+              href={primaryHref}
+              className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+              style={{ backgroundColor: "var(--brand-primary)" }}
+            >
+              {primaryLabel}
+            </Link>
+            {secondaryHref && secondaryLabel ? (
+              <Link
+                href={secondaryHref}
+                className="inline-flex items-center justify-center rounded-full border border-[var(--brand-line)] bg-white px-5 py-2.5 text-sm font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
+              >
+                {secondaryLabel}
+              </Link>
+            ) : null}
+          </div>
+
+          <div className="mt-8 flex items-center gap-3">
+            <AvatarStack />
+            <span className="text-xs text-[var(--brand-text-muted)]">
+              Joined by 8,400+ students this semester.
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <MapTeaser mapHref={mapHref} />
+    </section>
+  );
+}

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -1,0 +1,156 @@
+import { Calendar, MapPin, Newspaper, Users } from "lucide-react";
+import type { Locale } from "@/app/lib/i18n-core";
+import { ConsumerNav } from "./ConsumerNav";
+import { ConsumerHero } from "./ConsumerHero";
+import { QuickTile } from "./QuickTile";
+import { EventCard } from "./EventCard";
+import { ClubRow } from "./ClubRow";
+import { NewsItem } from "./NewsItem";
+import { ConsumerFooter } from "./ConsumerFooter";
+import {
+  SAMPLE_CLUBS,
+  SAMPLE_EVENTS,
+  SAMPLE_NEWS,
+} from "../sample-campus";
+
+export interface ConsumerHomeProps {
+  token: string;
+  campusName: string;
+  /** Per-org accent — overrides `--brand-primary` for the whole page. */
+  accentColor?: string;
+  logoUrl?: string;
+  locale: Locale;
+  /** Optional org-set hero copy; defaults to the platform marketing line. */
+  headline?: string;
+  subheading?: string;
+}
+
+/**
+ * The new consumer home — top-level layout for the public-facing
+ * campus surface ([[campus-consumer-pivot]] Arc 1).
+ *
+ * Renders the spec's six bands top-to-bottom: nav · hero with map
+ * teaser · 3 quick-action tiles · events grid · two-column (clubs
+ * + news) bottom row · footer. Sample data drives the rails; Arcs
+ * 2 – 5 swap each source from constants to API without changing
+ * the markup.
+ *
+ * The whole page is wrapped in `data-consumer`, which (a) restores
+ * the border + list resets Tailwind preflight would have done and
+ * (b) makes the consumer palette CSS vars apply. Per-org
+ * `accentColor` overrides `--brand-primary` via inline style.
+ */
+export function ConsumerHome({
+  token,
+  campusName,
+  accentColor,
+  logoUrl,
+  locale,
+  headline,
+  subheading,
+}: ConsumerHomeProps) {
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+  // Per-org accent overrides the default purple at the wrapper, so
+  // every descendant that uses `var(--brand-primary)` follows suit.
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={logoUrl}
+        token={token}
+        locale={locale}
+      />
+
+      <ConsumerHero
+        headline={headline ?? "Your whole campus, one happy little app."}
+        subheading={
+          subheading ??
+          "Find any building, jump into events, and meet your people — without 12 tabs open."
+        }
+        primaryHref={mapHref}
+        primaryLabel="Get started — it's free"
+        secondaryHref={`/campus/${token}/tour${lang}`}
+        secondaryLabel="Watch the tour"
+        mapHref={mapHref}
+      />
+
+      <section className="mx-auto grid max-w-[1280px] grid-cols-1 gap-4 px-4 md:grid-cols-3 md:gap-6 md:px-6">
+        <QuickTile
+          href={mapHref}
+          icon={MapPin}
+          accent="purple"
+          label="Find a building"
+          subtitle="Walking time + indoor maps"
+        />
+        <QuickTile
+          href={`/campus/${token}/clubs${lang}`}
+          icon={Users}
+          accent="pink"
+          label="Browse clubs"
+          subtitle={`${SAMPLE_CLUBS.length}+ on campus`}
+        />
+        <QuickTile
+          href={`/campus/${token}/events${lang}`}
+          icon={Calendar}
+          accent="teal"
+          label="This week's events"
+          subtitle={`${SAMPLE_EVENTS.length} happening near you`}
+        />
+      </section>
+
+      <section className="mx-auto mt-12 max-w-[1280px] px-4 md:px-6">
+        <h2 className="text-lg font-medium text-[var(--brand-text)]">
+          Happening this week
+        </h2>
+        <div className="mt-4 grid grid-cols-1 gap-5 md:grid-cols-3">
+          {SAMPLE_EVENTS.map((e) => (
+            <EventCard
+              key={e.id}
+              event={e}
+              href={`/campus/${token}/events/${e.id}${lang}`}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto mt-12 grid max-w-[1280px] grid-cols-1 gap-6 px-4 md:grid-cols-[1.4fr_1fr] md:gap-10 md:px-6">
+        <div>
+          <h2 className="text-lg font-medium text-[var(--brand-text)]">
+            Most active clubs this week
+          </h2>
+          <p className="mt-1 text-xs text-[var(--brand-text-muted)]">
+            Sorted by activity — no tracking
+          </p>
+          <div className="mt-4">
+            {SAMPLE_CLUBS.map((c) => (
+              <ClubRow key={c.id} club={c} />
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h2 className="inline-flex items-center gap-2 text-lg font-medium text-[var(--brand-text)]">
+            <Newspaper size={18} strokeWidth={1.75} />
+            Campus news
+          </h2>
+          <div className="mt-4">
+            {SAMPLE_NEWS.map((n) => (
+              <NewsItem
+                key={n.id}
+                item={n}
+                href={`/campus/${token}/news/${n.id}${lang}`}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/lib/consumer/ConsumerNav.tsx
+++ b/apps/campus/lib/consumer/ConsumerNav.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link";
+import { KLogo } from "./KLogo";
+import { LOCALES, type Locale } from "@/app/lib/i18n-core";
+
+interface NavLink {
+  label: string;
+  href: string;
+}
+
+const LOCALE_LABEL: Record<Locale, string> = { en: "EN", el: "ΕΛ" };
+
+export interface ConsumerNavProps {
+  /** Campus display name shown next to the K. */
+  campusName: string;
+  /** Per-org logo image, used in place of the wordmark when set. */
+  logoUrl?: string;
+  /** Token in the URL — used to build the nav links. */
+  token: string;
+  /** Locale appended to every link so language survives navigation. */
+  locale: Locale;
+}
+
+/**
+ * Consumer nav: white, hairline-bottom, K logo + wordmark on the
+ * left, text links centre-right, language toggle / map CTA on the
+ * far right. On mobile every link is hidden — only the logo +
+ * wordmark stay visible so the bar never wraps to two rows.
+ */
+export function ConsumerNav({
+  campusName,
+  logoUrl,
+  token,
+  locale,
+}: ConsumerNavProps) {
+  const lang = `?lang=${locale}`;
+  const links: NavLink[] = [
+    { label: "Map", href: `/campus/${token}/map${lang}` },
+    { label: "Events", href: `/campus/${token}/events${lang}` },
+    { label: "Clubs", href: `/campus/${token}/clubs${lang}` },
+    { label: "Dining", href: `/campus/${token}/dining${lang}` },
+    { label: "News", href: `/campus/${token}/news${lang}` },
+    { label: "Help", href: `/campus/${token}/help${lang}` },
+  ];
+
+  return (
+    <header className="sticky top-0 z-20 border-b border-[var(--brand-line)] bg-white">
+      <div className="mx-auto flex h-14 max-w-[1280px] items-center justify-between gap-4 px-4 md:px-6">
+        <Link
+          href={`/campus/${token}${lang}`}
+          className="flex shrink-0 items-center gap-2"
+        >
+          {logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={logoUrl}
+              alt={campusName}
+              className="h-7 max-w-[160px] object-contain"
+            />
+          ) : (
+            <>
+              <KLogo />
+              <span className="text-base font-medium text-[var(--brand-text)]">
+                {campusName}
+              </span>
+            </>
+          )}
+        </Link>
+
+        <nav
+          aria-label="Primary"
+          className="hidden items-center gap-6 md:flex"
+        >
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="text-sm font-normal text-[var(--brand-text)] transition-colors hover:text-[var(--brand-primary)]"
+            >
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="flex shrink-0 items-center gap-1 rounded-full border border-[var(--brand-line)] bg-white p-0.5">
+          {LOCALES.map((l) => {
+            const active = l === locale;
+            return (
+              <Link
+                key={l}
+                href={`/campus/${token}?lang=${l}`}
+                aria-current={active ? "true" : undefined}
+                className="rounded-full px-2.5 py-1 text-[0.7rem] font-medium transition-colors"
+                style={
+                  active
+                    ? {
+                        backgroundColor: "var(--brand-primary)",
+                        color: "#fff",
+                      }
+                    : { color: "var(--brand-text-muted)" }
+                }
+              >
+                {LOCALE_LABEL[l]}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/campus/lib/consumer/EventCard.tsx
+++ b/apps/campus/lib/consumer/EventCard.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { Calendar, MapPin, Music, Sprout, Trophy } from "lucide-react";
+import type { ConsumerEvent } from "./types";
+
+const ICONS = {
+  music: Music,
+  trophy: Trophy,
+  sprout: Sprout,
+  calendar: Calendar,
+} as const;
+
+const BANNER_BG: Record<ConsumerEvent["bannerColor"], string> = {
+  purple: "var(--brand-primary)",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+function formatWhen(startsAt: string): string {
+  const d = new Date(startsAt);
+  if (Number.isNaN(d.getTime())) return "";
+  const day = d.toLocaleDateString(undefined, { weekday: "short" });
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: d.getMinutes() === 0 ? undefined : "2-digit",
+  });
+  return `${day} · ${time.toLowerCase()}`;
+}
+
+export interface EventCardProps {
+  event: ConsumerEvent;
+  /** Where the card links to — set up so detail page slot is ready when Arc 3 ships. */
+  href: string;
+}
+
+/**
+ * One card in the "Happening this week" grid. Colored banner with a
+ * white outline icon at the top; title, date / time, anchor chip,
+ * expected attendance under it. Whole card links to the event's
+ * detail page (placeholder route for Arc 1).
+ */
+export function EventCard({ event, href }: EventCardProps) {
+  const Icon = ICONS[event.bannerIcon];
+  const where = event.anchors[0]?.refName;
+
+  return (
+    <Link
+      href={href}
+      className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
+    >
+      <div
+        className="flex h-24 items-end justify-start p-4"
+        style={{ backgroundColor: BANNER_BG[event.bannerColor] }}
+      >
+        <Icon
+          size={28}
+          strokeWidth={1.5}
+          className="text-white"
+          aria-hidden
+        />
+      </div>
+      <div className="flex flex-col gap-2 p-5">
+        <h3 className="text-base font-medium text-[var(--brand-text)]">
+          {event.title}
+        </h3>
+        <span className="text-xs text-[var(--brand-text-muted)]">
+          {formatWhen(event.startsAt)}
+        </span>
+        <div className="mt-1 flex items-center gap-3 text-xs text-[var(--brand-text-muted)]">
+          {where ? (
+            <span className="inline-flex items-center gap-1">
+              <MapPin size={14} strokeWidth={1.75} />
+              {where}
+            </span>
+          ) : null}
+          {event.expectedAttendance ? (
+            <span>{event.expectedAttendance} going</span>
+          ) : null}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/campus/lib/consumer/KLogo.tsx
+++ b/apps/campus/lib/consumer/KLogo.tsx
@@ -1,0 +1,22 @@
+/**
+ * 28 × 28 rounded purple square with a white "K" — the brand mark
+ * the consumer nav opens with. Falls back automatically to the
+ * per-org brand colour because the bg uses `var(--brand-primary)`.
+ */
+export function KLogo({ size = 28 }: { size?: number }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex shrink-0 items-center justify-center rounded-lg font-medium text-white"
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: "var(--brand-primary)",
+        fontSize: Math.round(size * 0.5),
+        lineHeight: 1,
+      }}
+    >
+      K
+    </span>
+  );
+}

--- a/apps/campus/lib/consumer/MapTeaser.tsx
+++ b/apps/campus/lib/consumer/MapTeaser.tsx
@@ -1,0 +1,136 @@
+import Link from "next/link";
+
+const FILTER_PILLS: { label: string; active?: boolean }[] = [
+  { label: "Study spots", active: true },
+  { label: "Food" },
+  { label: "Fitness" },
+  { label: "Events" },
+];
+
+interface BuildingDot {
+  label: string;
+  x: number;
+  y: number;
+  color: string;
+}
+
+/**
+ * Six representative dots placed on a soft-teal canvas — the
+ * teaser only suggests there is a map; the real one is one tap
+ * away on `/map`.
+ */
+const BUILDINGS: BuildingDot[] = [
+  { label: "Library", x: 70, y: 50, color: "var(--brand-primary)" },
+  { label: "Sci hall", x: 290, y: 55, color: "#D85A30" },
+  { label: "Gym", x: 60, y: 145, color: "#1D9E75" },
+  { label: "Dorm A", x: 310, y: 150, color: "#D4537E" },
+  { label: "Cafeteria", x: 130, y: 200, color: "var(--brand-primary)" },
+  { label: "Quad", x: 200, y: 110, color: "#1D9E75" },
+];
+
+export interface MapTeaserProps {
+  /** URL of the real MappedIn viewer for this campus. */
+  mapHref: string;
+}
+
+/**
+ * Right-column card on the hero — a "Campus map" panel with a
+ * live indicator dot, an illustrated overview, and four filter
+ * pills underneath. Tap anywhere → drops the visitor into the
+ * real MappedIn viewer at `mapHref`. The illustration is decoration
+ * only; the pills are visual today and gain behaviour when we ship
+ * categories on the real map in a later arc.
+ */
+export function MapTeaser({ mapHref }: MapTeaserProps) {
+  return (
+    <div className="rounded-2xl border border-[var(--brand-line)] bg-white p-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="inline-block h-2 w-2 rounded-full bg-[#1D9E75]"
+          />
+          <span className="text-sm font-medium text-[var(--brand-text)]">
+            Campus map
+          </span>
+        </div>
+        <Link
+          href={mapHref}
+          className="text-xs font-medium text-[var(--brand-text-muted)] transition-colors hover:text-[var(--brand-primary)]"
+        >
+          Open ↗
+        </Link>
+      </div>
+
+      <Link
+        href={mapHref}
+        aria-label="Open campus map"
+        className="mt-4 block overflow-hidden rounded-xl"
+      >
+        <svg
+          viewBox="0 0 380 250"
+          xmlns="http://www.w3.org/2000/svg"
+          className="block h-auto w-full"
+          role="img"
+          aria-label="Illustrated campus map"
+        >
+          <rect width="380" height="250" fill="#E0F2EE" />
+          {/* Cross-shaped walking paths */}
+          <line
+            x1="0"
+            y1="125"
+            x2="380"
+            y2="125"
+            stroke="#fff"
+            strokeWidth="14"
+            strokeLinecap="round"
+            opacity="0.7"
+          />
+          <line
+            x1="190"
+            y1="0"
+            x2="190"
+            y2="250"
+            stroke="#fff"
+            strokeWidth="14"
+            strokeLinecap="round"
+            opacity="0.7"
+          />
+          {BUILDINGS.map((b) => (
+            <g key={b.label}>
+              <circle cx={b.x} cy={b.y} r="7" fill={b.color} />
+              <text
+                x={b.x}
+                y={b.y + 22}
+                textAnchor="middle"
+                fontSize="11"
+                fontWeight="500"
+                fill="#1A1A1A"
+              >
+                {b.label}
+              </text>
+            </g>
+          ))}
+        </svg>
+      </Link>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {FILTER_PILLS.map((p) => (
+          <span
+            key={p.label}
+            className={
+              p.active
+                ? "rounded-full px-3 py-1 text-xs font-medium text-white"
+                : "rounded-full border border-[var(--brand-line)] bg-white px-3 py-1 text-xs font-medium text-[var(--brand-text-muted)]"
+            }
+            style={
+              p.active ? { backgroundColor: "var(--brand-primary)" } : undefined
+            }
+          >
+            {p.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/NewsItem.tsx
+++ b/apps/campus/lib/consumer/NewsItem.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import type { ConsumerNews } from "./types";
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  const day = 1000 * 60 * 60 * 24;
+  const days = Math.floor(diffMs / day);
+  if (days < 1) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days} days ago`;
+  if (days < 14) return "a week ago";
+  if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export interface NewsItemProps {
+  item: ConsumerNews;
+  /** Where the headline links to (detail page slot for Arc 2). */
+  href: string;
+}
+
+/**
+ * One row in the "Campus news" rail. Headline + short excerpt +
+ * "X days ago" timestamp. Headline is the clickable target — the
+ * detail page lands in Arc 2.
+ */
+export function NewsItem({ item, href }: NewsItemProps) {
+  return (
+    <article className="border-b border-[var(--brand-line)] py-4 last:border-b-0">
+      <Link href={href} className="block group">
+        <h3 className="text-sm font-medium text-[var(--brand-text)] transition-colors group-hover:text-[var(--brand-primary)]">
+          {item.title}
+        </h3>
+        <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-[var(--brand-text-muted)]">
+          {item.excerpt}
+        </p>
+        <div className="mt-2 text-[0.7rem] uppercase tracking-wide text-[var(--brand-text-muted)]">
+          {relativeTime(item.publishedAt)}
+        </div>
+      </Link>
+    </article>
+  );
+}

--- a/apps/campus/lib/consumer/QuickTile.tsx
+++ b/apps/campus/lib/consumer/QuickTile.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import type { AccentName } from "./types";
+
+const ACCENT_HEX: Record<AccentName, string> = {
+  purple: "var(--brand-primary)",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+export interface QuickTileProps {
+  href: string;
+  label: string;
+  subtitle: string;
+  icon: LucideIcon;
+  accent: AccentName;
+}
+
+/**
+ * One of the three quick-action cards under the hero. White card,
+ * colored icon chip on the left, label + one-line subtitle on the
+ * right. Whole card is clickable.
+ */
+export function QuickTile({
+  href,
+  label,
+  subtitle,
+  icon: Icon,
+  accent,
+}: QuickTileProps) {
+  return (
+    <Link
+      href={href}
+      className="group flex items-start gap-4 rounded-2xl border border-[var(--brand-line)] bg-white p-5 transition-colors hover:border-[var(--brand-primary)]"
+    >
+      <span
+        aria-hidden
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-white"
+        style={{ backgroundColor: ACCENT_HEX[accent] }}
+      >
+        <Icon size={20} strokeWidth={1.75} />
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-[var(--brand-text)]">
+          {label}
+        </span>
+        <span className="mt-0.5 block text-xs text-[var(--brand-text-muted)]">
+          {subtitle}
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/apps/campus/lib/consumer/types.ts
+++ b/apps/campus/lib/consumer/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Consumer-home data shapes.
+ *
+ * Kept deliberately close to the schemas we'll persist in Arcs 2-5,
+ * so when the rails switch source from `sample-campus.ts` constants
+ * to the API they don't have to change shape. Localisation is on
+ * the per-arc roadmap — strings here are EN-only for now.
+ */
+
+export interface ConsumerAnchor {
+  kind: "building" | "room";
+  /** MappedIn space id. Empty in sample data; reconciled at deploy time. */
+  refId: string;
+  /** Denormalised display name — survives a MappedIn rename for one cycle. */
+  refName: string;
+}
+
+export type AccentName = "purple" | "coral" | "teal" | "pink";
+
+export interface ConsumerNews {
+  id: string;
+  title: string;
+  /** One-paragraph summary shown in the rail. */
+  excerpt: string;
+  category: "announcement" | "news" | "alert";
+  publishedAt: string;
+  anchors: ConsumerAnchor[];
+}
+
+export interface ConsumerEvent {
+  id: string;
+  title: string;
+  /** Short blurb shown under the title. */
+  blurb: string;
+  startsAt: string;
+  endsAt: string;
+  /** Banner accent — colour vocabulary, not branding. */
+  bannerColor: AccentName;
+  /** Lucide icon name used on the banner. */
+  bannerIcon: "music" | "trophy" | "sprout" | "calendar";
+  anchors: ConsumerAnchor[];
+  /** Vanity admin-set "expected attendance" — see [[campus-consumer-pivot]]. */
+  expectedAttendance?: number;
+}
+
+export interface ConsumerClub {
+  id: string;
+  name: string;
+  /** Two-letter avatar initials. */
+  initials: string;
+  avatarColor: AccentName;
+  memberCount: number;
+  /** Free-text frequency, e.g. "Meets Tuesdays at 6 pm". */
+  meetsCadence: string;
+  /** External link the View / Join button opens (Discord, Insta, …). */
+  externalLink: string;
+}

--- a/apps/campus/lib/sample-campus.ts
+++ b/apps/campus/lib/sample-campus.ts
@@ -1,0 +1,145 @@
+/**
+ * Sample-campus seed.
+ *
+ * Used by Arc 1 to populate the new consumer home before any CRUD
+ * exists. Shaped exactly like the eventual schema (`ConsumerNews`,
+ * `ConsumerEvent`, `ConsumerClub`), so subsequent arcs switch the
+ * rail source from constants to the API with no markup change.
+ *
+ * Also reused as the "Try with sample data" onboarding seed and
+ * the 60-second demo fixture. Keep it tight (4 news / 4 events /
+ * 4 clubs) — a venue with more isn't more believable, just slower
+ * to read.
+ *
+ * Anchors point at building names that exist in the MappedIn Cal
+ * Poly Pomona demo we've been testing on; `refId` is filled at
+ * deploy time, see [[campus-consumer-pivot]].
+ */
+
+import type {
+  ConsumerClub,
+  ConsumerEvent,
+  ConsumerNews,
+} from "./consumer/types";
+
+export const SAMPLE_NEWS: ConsumerNews[] = [
+  {
+    id: "news-library-hours",
+    title: "Library hours extended through finals",
+    excerpt:
+      "Engineering South stays open 24 / 7 until June 9. Quiet floors, free coffee on the second floor every night from 8 pm.",
+    category: "announcement",
+    publishedAt: "2026-05-23T09:00:00Z",
+    anchors: [
+      {
+        kind: "building",
+        refId: "",
+        refName: "Engineering South Building",
+      },
+    ],
+  },
+  {
+    id: "news-cafe-renovation",
+    title: "Cafe Pavilion closed for renovation",
+    excerpt:
+      "Closed May 28 — June 2 for a kitchen refit. Grab-and-go meals available at the Marketplace in the meantime.",
+    category: "alert",
+    publishedAt: "2026-05-25T11:30:00Z",
+    anchors: [
+      { kind: "building", refId: "", refName: "Cafe Pavilion" },
+    ],
+  },
+  {
+    id: "news-3d-printers",
+    title: "New 3D printers in the Graphic Arts lab",
+    excerpt:
+      "Six new printers landed last week — drop-in hours every weekday afternoon, training Tuesday at 4 pm.",
+    category: "news",
+    publishedAt: "2026-05-19T15:00:00Z",
+    anchors: [
+      { kind: "building", refId: "", refName: "Graphic Arts Building" },
+    ],
+  },
+];
+
+export const SAMPLE_EVENTS: ConsumerEvent[] = [
+  {
+    id: "evt-open-mic",
+    title: "Open mic at the quad cafe",
+    blurb:
+      "Bring a poem, a song, a stand-up bit. Sign-up at the door, sets are five minutes.",
+    startsAt: "2026-05-28T19:00:00Z",
+    endsAt: "2026-05-28T22:00:00Z",
+    bannerColor: "purple",
+    bannerIcon: "music",
+    anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
+    expectedAttendance: 84,
+  },
+  {
+    id: "evt-bball-finals",
+    title: "Intramural basketball finals",
+    blurb:
+      "The Reds vs the Greens. Free entry with student ID. Doors at 5:30 pm, tip-off at 6.",
+    startsAt: "2026-05-29T18:00:00Z",
+    endsAt: "2026-05-29T21:00:00Z",
+    bannerColor: "coral",
+    bannerIcon: "trophy",
+    anchors: [
+      { kind: "building", refId: "", refName: "Mott Athletics Center" },
+    ],
+    expectedAttendance: 212,
+  },
+  {
+    id: "evt-garden-volunteer",
+    title: "Community garden volunteer day",
+    blurb:
+      "Planting summer tomatoes, weeding, and lunch. Tools provided; bring a hat.",
+    startsAt: "2026-05-30T10:00:00Z",
+    endsAt: "2026-05-30T14:00:00Z",
+    bannerColor: "teal",
+    bannerIcon: "sprout",
+    anchors: [
+      { kind: "building", refId: "", refName: "1901 Marketplace Building" },
+    ],
+    expectedAttendance: 36,
+  },
+];
+
+export const SAMPLE_CLUBS: ConsumerClub[] = [
+  {
+    id: "club-ds-society",
+    name: "Data science society",
+    initials: "DS",
+    avatarColor: "purple",
+    memberCount: 248,
+    meetsCadence: "Meets Wednesdays at 6 pm",
+    externalLink: "https://discord.gg/example",
+  },
+  {
+    id: "club-film",
+    name: "Film club",
+    initials: "FC",
+    avatarColor: "pink",
+    memberCount: 142,
+    meetsCadence: "Screenings every Friday at 8 pm",
+    externalLink: "https://instagram.com/example",
+  },
+  {
+    id: "club-hiking",
+    name: "Hiking & outdoors",
+    initials: "HK",
+    avatarColor: "coral",
+    memberCount: 186,
+    meetsCadence: "Trips most Saturdays",
+    externalLink: "https://discord.gg/example",
+  },
+  {
+    id: "club-sustainability",
+    name: "Sustainability union",
+    initials: "SU",
+    avatarColor: "teal",
+    memberCount: 97,
+    meetsCadence: "Meets Mondays at 5 pm",
+    externalLink: "https://instagram.com/example",
+  },
+];

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^20.11.30",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "lucide-react": "^1.16.0",
     "mapbox-gl": "^3.9.4",
     "next": "^15.1.9",
     "next-auth": "5.0.0-beta.30",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.7)
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.1)
       mapbox-gl:
         specifier: ^3.9.4
         version: 3.20.0
@@ -6202,6 +6205,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^19.2.1
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -14237,6 +14245,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.16.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## What this is

Arc 1 of [[campus-consumer-pivot]] — the **visible** half of the pivot. Lands the spec'd consumer template on `/campus/[token]`:

- Flat design, 16 px corners, hairline borders, no shadows.
- Default Klorad-purple palette (#534AB7 / #EEEDFE / #D85A30 / #1D9E75 / #D4537E / Inter 400-500 / sentence case / Lucide outline icons).
- Per-org `branding.primaryColor` overrides `--brand-primary` for the whole page, so existing tenants keep their accent on day one.
- Footer reads *"Built for {Campus} · Powered by Klorad"* — multi-tenant story preserved.

## What's on the page

1. **Nav** — K logo + campus name, hide-on-mobile link rail (Map · Events · Clubs · Dining · News · Help), EN / ΕΛ toggle.
2. **Hero** — two columns on desktop, stacked on mobile. Left: pill badge ("Made for students, by students"), headline, subheading, two CTAs ("Get started — it's free" / "Watch the tour"), social-proof avatar stack. Right: `MapTeaser` card with a live indicator, illustrated 6-building map, and four filter pills.
3. **Quick tiles** — 3-column row: "Find a building," "Browse clubs," "This week's events."
4. **Events grid** — 3 event cards with colored banners + Lucide icons.
5. **Bottom row** — "Most active clubs this week" (4 rows with View buttons → external link) + "Campus news" (3 rows).
6. **Footer** — *Built for {Campus} · Powered by Klorad · privacy · accessibility · contact*.

## No new schema yet

All rails are populated by `lib/sample-campus.ts`, shaped to the eventual `ConsumerNews` / `ConsumerEvent` / `ConsumerClub` types. Arcs 2 – 4 swap each rail's source from constants to the API with **no markup change**.

## Spec contradictions resolved

| Brief said | Now |
|---|---|
| *"Picked for you · Based on your major"* | "Most active clubs this week · Sorted by activity — no tracking." |
| *"Join"* (no auth) | "View" — opens the club's external link (Discord / Insta / …) |
| *"84 going"* | Stays — admin-set "expected attendance" |

## Preflight trap (noted)

`apps/campus` runs Tailwind with preflight off. `[data-consumer]` joins the existing workbench / mappedin reset scope in `global.css` so `border-*` utilities + `<ul>` lists render correctly without depending on a workbench-only style. See [[campus-tailwind-preflight-off]].

## What's untouched

- The MappedIn 3D viewer at `/campus/[token]/map` — keeps all PR #144 polish.
- The dashboard / admin surface — still on the glass + accent-soft visual language. Two surfaces, two languages, one platform.
- The home-page builder — if a tenant has set a custom headline / tagline, that still wins over the platform default copy in the hero.

## Files

- `apps/campus/lib/consumer/` — `ConsumerHome` orchestrator + 9 presentational components (all server components, no client JS shipped on the home).
- `apps/campus/lib/sample-campus.ts` — the seed data shaped to the eventual schema.
- `apps/campus/app/(public)/campus/[token]/page.tsx` — rewritten to just resolve the campus + render `ConsumerHome`.
- `apps/campus/app/global.css` — extended reset scope + consumer palette tokens.
- Adds `lucide-react`.

`tsc --noEmit` clean. `next lint` clean. Mobile-first tested mentally at 360 × 800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)