### PR TITLE
fix(campus): consumer home layout — tailwind scan + real thumbnail

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -97,6 +97,7 @@ export default async function CampusHomePage({
       locale={locale}
       headline={headline}
       subheading={subheading}
+      mapThumbnailUrl={map.thumbnail ?? undefined}
     />
   );
 }

--- a/apps/campus/lib/consumer/ConsumerHero.tsx
+++ b/apps/campus/lib/consumer/ConsumerHero.tsx
@@ -14,6 +14,8 @@ export interface ConsumerHeroProps {
   secondaryLabel?: string;
   /** Map link the right-column teaser opens. */
   mapHref: string;
+  /** Real venue thumbnail — preferred over a fallback illustration. */
+  mapThumbnailUrl?: string;
 }
 
 /** Four pastel avatar circles, decorative — the "joined by 8,400" social proof. */
@@ -48,6 +50,7 @@ export function ConsumerHero({
   secondaryHref,
   secondaryLabel,
   mapHref,
+  mapThumbnailUrl,
 }: ConsumerHeroProps) {
   return (
     <section className="mx-auto grid max-w-[1280px] grid-cols-1 gap-6 px-4 py-8 md:grid-cols-[1.1fr_0.9fr] md:gap-10 md:px-6 md:py-12">
@@ -105,7 +108,7 @@ export function ConsumerHero({
         </div>
       </div>
 
-      <MapTeaser mapHref={mapHref} />
+      <MapTeaser mapHref={mapHref} thumbnailUrl={mapThumbnailUrl} />
     </section>
   );
 }

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -23,6 +23,8 @@ export interface ConsumerHomeProps {
   /** Optional org-set hero copy; defaults to the platform marketing line. */
   headline?: string;
   subheading?: string;
+  /** Real venue thumbnail for the hero's MapTeaser. */
+  mapThumbnailUrl?: string;
 }
 
 /**
@@ -48,6 +50,7 @@ export function ConsumerHome({
   locale,
   headline,
   subheading,
+  mapThumbnailUrl,
 }: ConsumerHomeProps) {
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
@@ -77,6 +80,7 @@ export function ConsumerHome({
         secondaryHref={`/campus/${token}/tour${lang}`}
         secondaryLabel="Watch the tour"
         mapHref={mapHref}
+        mapThumbnailUrl={mapThumbnailUrl}
       />
 
       <section className="mx-auto grid max-w-[1280px] grid-cols-1 gap-4 px-4 md:grid-cols-3 md:gap-6 md:px-6">

--- a/apps/campus/lib/consumer/MapTeaser.tsx
+++ b/apps/campus/lib/consumer/MapTeaser.tsx
@@ -7,43 +7,30 @@ const FILTER_PILLS: { label: string; active?: boolean }[] = [
   { label: "Events" },
 ];
 
-interface BuildingDot {
-  label: string;
-  x: number;
-  y: number;
-  color: string;
-}
-
-/**
- * Six representative dots placed on a soft-teal canvas — the
- * teaser only suggests there is a map; the real one is one tap
- * away on `/map`.
- */
-const BUILDINGS: BuildingDot[] = [
-  { label: "Library", x: 70, y: 50, color: "var(--brand-primary)" },
-  { label: "Sci hall", x: 290, y: 55, color: "#D85A30" },
-  { label: "Gym", x: 60, y: 145, color: "#1D9E75" },
-  { label: "Dorm A", x: 310, y: 150, color: "#D4537E" },
-  { label: "Cafeteria", x: 130, y: 200, color: "var(--brand-primary)" },
-  { label: "Quad", x: 200, y: 110, color: "#1D9E75" },
-];
-
 export interface MapTeaserProps {
   /** URL of the real MappedIn viewer for this campus. */
   mapHref: string;
+  /**
+   * MappedIn-captured thumbnail for the venue. Set in the dashboard
+   * via "Capture thumbnail." When present, used in place of the
+   * fallback illustration so the teaser reflects the real campus.
+   */
+  thumbnailUrl?: string;
 }
 
 /**
  * Right-column card on the hero — a "Campus map" panel with a
- * live indicator dot, an illustrated overview, and four filter
- * pills underneath. Tap anywhere → drops the visitor into the
- * real MappedIn viewer at `mapHref`. The illustration is decoration
- * only; the pills are visual today and gain behaviour when we ship
- * categories on the real map in a later arc.
+ * live indicator dot, the real MappedIn-captured thumbnail of the
+ * venue (when set), and four filter pills underneath. Tap anywhere
+ * → drops the visitor into the real MappedIn viewer at `mapHref`.
+ *
+ * When no thumbnail is set, falls back to a small generic gradient
+ * placeholder rather than a cartoon SVG of fake buildings — better
+ * to look unfinished than to show buildings the campus doesn't have.
  */
-export function MapTeaser({ mapHref }: MapTeaserProps) {
+export function MapTeaser({ mapHref, thumbnailUrl }: MapTeaserProps) {
   return (
-    <div className="rounded-2xl border border-[var(--brand-line)] bg-white p-5">
+    <div className="flex h-full flex-col rounded-2xl border border-[var(--brand-line)] bg-white p-5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span
@@ -65,53 +52,28 @@ export function MapTeaser({ mapHref }: MapTeaserProps) {
       <Link
         href={mapHref}
         aria-label="Open campus map"
-        className="mt-4 block overflow-hidden rounded-xl"
+        className="mt-4 block aspect-[4/3] overflow-hidden rounded-xl"
+        style={
+          thumbnailUrl
+            ? undefined
+            : {
+                background:
+                  "linear-gradient(135deg, var(--brand-primary-bg) 0%, #E0F2EE 100%)",
+              }
+        }
       >
-        <svg
-          viewBox="0 0 380 250"
-          xmlns="http://www.w3.org/2000/svg"
-          className="block h-auto w-full"
-          role="img"
-          aria-label="Illustrated campus map"
-        >
-          <rect width="380" height="250" fill="#E0F2EE" />
-          {/* Cross-shaped walking paths */}
-          <line
-            x1="0"
-            y1="125"
-            x2="380"
-            y2="125"
-            stroke="#fff"
-            strokeWidth="14"
-            strokeLinecap="round"
-            opacity="0.7"
+        {thumbnailUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={thumbnailUrl}
+            alt="Campus map preview"
+            className="h-full w-full object-cover"
           />
-          <line
-            x1="190"
-            y1="0"
-            x2="190"
-            y2="250"
-            stroke="#fff"
-            strokeWidth="14"
-            strokeLinecap="round"
-            opacity="0.7"
-          />
-          {BUILDINGS.map((b) => (
-            <g key={b.label}>
-              <circle cx={b.x} cy={b.y} r="7" fill={b.color} />
-              <text
-                x={b.x}
-                y={b.y + 22}
-                textAnchor="middle"
-                fontSize="11"
-                fontWeight="500"
-                fill="#1A1A1A"
-              >
-                {b.label}
-              </text>
-            </g>
-          ))}
-        </svg>
+        ) : (
+          <span className="flex h-full w-full items-center justify-center text-sm text-[var(--brand-text-muted)]">
+            Map coming soon
+          </span>
+        )}
       </Link>
 
       <div className="mt-4 flex flex-wrap gap-2">

--- a/apps/campus/tailwind.config.ts
+++ b/apps/campus/tailwind.config.ts
@@ -5,6 +5,12 @@ const config: Config = {
   presets: [preset],
   content: [
     "./app/**/*.{ts,tsx}",
+    // `lib/` holds the public-surface components (`lib/consumer/`,
+    // `lib/mappedin/`, …) — scan it too or Tailwind's JIT skips the
+    // arbitrary values that don't also appear under `app/` (e.g.
+    // `max-w-[1280px]`, `grid-cols-[1.1fr_0.9fr]`, `bg-[var(--…)]`)
+    // and the layout silently collapses.
+    "./lib/**/*.{ts,tsx}",
     // Scan the shared design system so its component classes are generated.
     "../../packages/design-system/src/**/*.{ts,tsx}",
   ],


### PR DESCRIPTION
## What's broken

The consumer home shipped in #145 looked like this in production: full-width left-aligned sections, no soft-purple hero card, the SVG cartoon map blown up to full screen, single-column everything.

## Why

`apps/campus/tailwind.config.ts` only scanned `./app/**`. Everything in `lib/consumer/` that used an **arbitrary value** (`max-w-[1280px]`, `grid-cols-[1.1fr_0.9fr]`, `bg-[var(--brand-primary-bg)]`, …) was outside Tailwind's JIT view, so those classes compiled to nothing. The constants-only classes (e.g. `bg-[#D85A30]` on an event banner) still worked because Tailwind compiled them from `app/**` usages elsewhere — which is why the bug looked partial, not total.

The same trap would have hit Arcs 2 – 5 the moment any of their components introduced an arbitrary value.

## Fix 1 — scan `./lib/**`

```diff
content: [
  "./app/**/*.{ts,tsx}",
+ "./lib/**/*.{ts,tsx}",
  "../../packages/design-system/src/**/*.{ts,tsx}",
]
```

One line, unlocks the whole layout. 1280 px container centred, two-column hero, soft purple card behind the headline, hairline borders, the lot.

## Fix 2 — real thumbnail in the `MapTeaser`

The illustrated 6-building SVG was lying to the visitor about what's actually on campus (Library, Sci hall, Gym, Dorm A, Cafeteria, Quad — none of which match any real tenant). Replaced with the **`map.thumbnail`** the dashboard's "Capture thumbnail" button already produces (PR #144).

- When the thumbnail exists → `<img>` at 4:3, object-cover, anchored inside the card.
- When it doesn't → soft purple→teal gradient with *"Map coming soon"* — placeholder, not fiction.

## Memory update

Saving the Tailwind-scan trap to memory so I stop reinventing the failure:

> `apps/campus`'s `tailwind.config.ts` must list every directory that holds component source. Arbitrary values in unlisted directories silently no-op. `lib/` is now in; if a future arc puts components elsewhere, add that too.

## Files

- `apps/campus/tailwind.config.ts` — content array extended.
- `apps/campus/lib/consumer/MapTeaser.tsx` — thumbnail-aware + bounded.
- `apps/campus/lib/consumer/ConsumerHero.tsx` + `ConsumerHome.tsx` — thread `mapThumbnailUrl` through.
- `apps/campus/app/(public)/campus/[token]/page.tsx` — pass `map.thumbnail`.

`tsc --noEmit` clean. `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)