### PR TITLE
feat(campus): news as a first-class model — Arc 2

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Image from "next/image";
+import { toast } from "react-toastify";
+import { Plus, Trash2, X } from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Select,
+  Textarea,
+} from "@klorad/design-system";
+import { uploadFile } from "@klorad/storage/client";
+import {
+  formatNewsDate,
+  type NewsPost,
+  type NewsCategory,
+} from "@/lib/news";
+
+interface Props {
+  mapId: string;
+  initialPosts: NewsPost[];
+}
+
+const CATEGORIES: { value: NewsCategory; label: string }[] = [
+  { value: "announcement", label: "Announcement" },
+  { value: "news", label: "News" },
+  { value: "alert", label: "Alert" },
+];
+
+/** Build a date suitable for an `<input type="date">` from today. */
+function todayISODate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Admin client for `/news`. Renders the existing posts on the left
+ * (delete-only for Arc 2 — edit lands in a follow-up commit) and a
+ * Create form on the right. The form posts to
+ * `POST /api/maps/[mapId]/news` and revalidates the cached public
+ * campus tag server-side so the new post shows up immediately.
+ */
+export function NewsAdminClient({ mapId, initialPosts }: Props) {
+  const [posts, setPosts] = useState<NewsPost[]>(initialPosts);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [category, setCategory] = useState<NewsCategory>("announcement");
+  const [publishedAt, setPublishedAt] = useState(todayISODate());
+  const [anchorName, setAnchorName] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleImage = async (file: File) => {
+    setUploading(true);
+    try {
+      const result = await uploadFile(file, { prefix: "campus-news" });
+      setImageUrl(result.publicUrl);
+    } catch (e) {
+      console.error(e);
+      toast.error("Image upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const reset = () => {
+    setTitle("");
+    setBody("");
+    setCategory("announcement");
+    setPublishedAt(todayISODate());
+    setAnchorName("");
+    setImageUrl(null);
+  };
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !body.trim()) {
+      toast.error("Title and body are required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/news`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          category,
+          // Datetime-local input gives a local-zone string; turn it
+          // into a UTC ISO so the server stores a clean instant.
+          publishedAt: new Date(publishedAt).toISOString(),
+          imageUrl,
+          anchors: anchorName.trim()
+            ? [
+                {
+                  kind: "building",
+                  refId: "",
+                  refName: anchorName.trim(),
+                },
+              ]
+            : [],
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? "Failed to publish");
+      }
+      // Optimistic refresh — re-fetch the list so the new post appears.
+      const list = await fetch(`/api/maps/${mapId}/news`).then((r) =>
+        r.json(),
+      );
+      setPosts(list.posts ?? []);
+      reset();
+      toast.success("Published");
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Failed to publish");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm("Delete this post?")) return;
+    try {
+      const res = await fetch(`/api/news/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete");
+      setPosts((p) => p.filter((post) => post.id !== id));
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to delete");
+    }
+  };
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr]">
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Published & scheduled
+        </h2>
+        <p className="mt-1 text-xs text-text-tertiary">
+          {posts.length} post{posts.length === 1 ? "" : "s"}
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {posts.length === 0 ? (
+            <p className="rounded-lg bg-surface-2 p-4 text-sm text-text-tertiary">
+              No news yet. Use the form to publish your first post.
+            </p>
+          ) : (
+            posts.map((p) => (
+              <article
+                key={p.id}
+                className="flex gap-3 rounded-lg border border-solid border-line-soft p-3"
+              >
+                {p.imageUrl ? (
+                  <Image
+                    src={p.imageUrl}
+                    alt=""
+                    width={64}
+                    height={64}
+                    className="h-16 w-16 shrink-0 rounded-md object-cover"
+                  />
+                ) : null}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <h3 className="truncate text-sm font-medium text-text-primary">
+                        {p.title}
+                      </h3>
+                      <p className="mt-0.5 text-[0.7rem] uppercase tracking-wide text-text-tertiary">
+                        {p.category} · {formatNewsDate(p.publishedAt)}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => void onDelete(p.id)}
+                      aria-label="Delete"
+                      className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                    >
+                      <Trash2 size={14} strokeWidth={1.75} />
+                    </button>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
+                    {p.body}
+                  </p>
+                  {p.anchors.length > 0 ? (
+                    <p className="mt-1 text-[0.7rem] text-text-tertiary">
+                      · {p.anchors.map((a) => a.refName).join(", ")}
+                    </p>
+                  ) : null}
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+      </Panel>
+
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          New post
+        </h2>
+        <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
+          <Field label="Title">
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Library hours extended through finals"
+              required
+            />
+          </Field>
+
+          <Field label="Body">
+            <Textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="What students need to know."
+              rows={5}
+              required
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Category">
+              <Select
+                value={category}
+                onChange={(e) =>
+                  setCategory(e.target.value as NewsCategory)
+                }
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+
+            <Field label="Publish on">
+              <Input
+                type="date"
+                value={publishedAt}
+                onChange={(e) => setPublishedAt(e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <Field label="Where on campus (optional)">
+            <Input
+              value={anchorName}
+              onChange={(e) => setAnchorName(e.target.value)}
+              placeholder="Library, Cafe Pavilion, Mott Athletics…"
+            />
+          </Field>
+
+          <Field label="Image (optional)">
+            {imageUrl ? (
+              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt=""
+                  className="h-16 w-16 rounded-md object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => setImageUrl(null)}
+                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
+                >
+                  <X size={14} strokeWidth={1.75} />
+                </button>
+              </div>
+            ) : (
+              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
+                <Plus size={16} strokeWidth={1.75} />
+                {uploading ? "Uploading…" : "Add image"}
+                <input
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  disabled={uploading}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleImage(file);
+                    e.target.value = "";
+                  }}
+                />
+              </label>
+            )}
+          </Field>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={reset}
+              disabled={submitting}
+            >
+              Reset
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Publishing…" : "Publish"}
+            </Button>
+          </div>
+        </form>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
@@ -1,0 +1,68 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { listNewsForAdmin } from "@/lib/news";
+import { NewsAdminClient } from "./NewsAdminClient";
+
+type Params = Promise<{ orgId: string; mapId: string }>;
+
+/**
+ * `/org/[orgId]/maps/[mapId]/news` — the new news authoring surface.
+ *
+ * Lists news posts on this campus + an inline create form. Backed by
+ * the `NewsPost` model added in Arc 2 of [[campus-consumer-pivot]].
+ * The legacy tab in `CampusProfileClient` (`NewsTab`) is untouched —
+ * existing bilingual posts in `sceneData.posts` keep their editor.
+ */
+export default async function NewsAdminPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, mapId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/sign-in");
+
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+
+  const project = await prisma.project.findFirst({
+    where: { id: mapId, organizationId: orgId },
+    select: { id: true, title: true },
+  });
+  if (!project) notFound();
+
+  const posts = await listNewsForAdmin(mapId);
+
+  return (
+    <div className="mx-auto max-w-[960px] px-6 py-10">
+      <Link
+        href={`/org/${orgId}/maps/${mapId}`}
+        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+      >
+        <ChevronLeft size={14} strokeWidth={1.75} />
+        Back to {project.title}
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-2xl font-semibold text-text-primary">News</h1>
+        <p className="mt-1 text-sm text-text-tertiary">
+          Geospatial posts pinned to buildings or rooms. They show up on
+          the public campus home and on the map.
+        </p>
+      </div>
+
+      <NewsAdminClient mapId={mapId} initialPosts={posts} />
+    </div>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft, MapPin } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale } from "@/app/lib/i18n-core";
+import {
+  formatNewsDate,
+  getNewsPost,
+} from "@/lib/news";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string; id: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token, id } = await params;
+  const [map, post] = await Promise.all([
+    getPublicCampusByToken(token),
+    getNewsPost(id),
+  ]);
+  if (!post || !map || post.projectId !== map.id) {
+    return { title: "News" };
+  }
+  return {
+    title: `${post.title} · News`,
+    description: post.body.slice(0, 160),
+    openGraph: {
+      title: post.title,
+      description: post.body.slice(0, 160),
+      type: "article",
+      images: post.imageUrl ? [post.imageUrl] : undefined,
+    },
+  };
+}
+
+/**
+ * `/campus/[token]/news/[id]` — public news detail page.
+ *
+ * Arc 2 of [[campus-consumer-pivot]]. Renders one `NewsPost` in the
+ * consumer visual language (flat cards, pill anchors, Klorad-purple
+ * tokens). 404s when the token + id don't match the same campus —
+ * the id alone can't leak a post via a different tenant's URL.
+ *
+ * Anchor chips deep-link into the MappedIn viewer at
+ * `/campus/[token]/map?space=<refId>` when an anchor has a MappedIn
+ * id; otherwise they render as static labels.
+ */
+export default async function NewsDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token, id } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+  const post = await getNewsPost(id);
+  if (!post || post.projectId !== map.id) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <article className="mx-auto max-w-[760px] px-4 py-8 md:px-6 md:py-12">
+        <Link
+          href={`/campus/${token}${lang}`}
+          className="inline-flex items-center gap-1 text-sm text-[var(--brand-text-muted)] transition-colors hover:text-[var(--brand-primary)]"
+        >
+          <ChevronLeft size={16} strokeWidth={1.75} />
+          Back to {campusName}
+        </Link>
+
+        <p className="mt-6 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
+          {post.category} · {formatNewsDate(post.publishedAt)}
+        </p>
+
+        <h1 className="mt-2 text-3xl font-medium leading-tight text-[var(--brand-text)] md:text-4xl">
+          {post.title}
+        </h1>
+
+        {post.anchors.length > 0 ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {post.anchors.map((a, i) =>
+              a.refId ? (
+                <Link
+                  key={`${a.refId}-${i}`}
+                  href={`${mapHref}&space=${encodeURIComponent(a.refId)}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
+                >
+                  <MapPin size={14} strokeWidth={1.75} />
+                  {a.refName}
+                </Link>
+              ) : (
+                <span
+                  key={`${a.refName}-${i}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]"
+                >
+                  <MapPin size={14} strokeWidth={1.75} />
+                  {a.refName}
+                </span>
+              ),
+            )}
+          </div>
+        ) : null}
+
+        {post.imageUrl ? (
+          <div className="mt-8 overflow-hidden rounded-2xl border border-[var(--brand-line)]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={post.imageUrl}
+              alt=""
+              className="block aspect-[16/9] w-full object-cover"
+            />
+          </div>
+        ) : null}
+
+        <div className="mt-8 whitespace-pre-wrap text-base leading-relaxed text-[var(--brand-text)]">
+          {post.body}
+        </div>
+      </article>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -3,8 +3,11 @@ import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
 import { readHomePage } from "@/lib/home-page";
 import { detectLocale, pickText } from "@/app/lib/i18n-core";
+import { readPosts } from "@/lib/posts";
+import { listNewsForProject } from "@/lib/news";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 import { ConsumerHome } from "@/lib/consumer/ConsumerHome";
+import type { ConsumerNews } from "@/lib/consumer/types";
 
 type Params = Promise<{ token: string }>;
 
@@ -88,6 +91,55 @@ export default async function CampusHomePage({
   const headline = pickText(home.headline, locale) || undefined;
   const subheading = pickText(home.tagline, locale) || undefined;
 
+  // News rail: combine the new `NewsPost` rows with legacy posts in
+  // `sceneData.posts` so existing tenants don't lose what's there
+  // while they migrate. Newest first, capped at 6.
+  const dbPosts = await listNewsForProject(map.id);
+  const legacyPosts = readPosts(map.sceneData);
+  const news: ConsumerNews[] = [
+    ...dbPosts.map((p) => ({
+      id: p.id,
+      title: p.title,
+      excerpt: p.body.length > 200 ? `${p.body.slice(0, 197)}…` : p.body,
+      category: p.category,
+      publishedAt: p.publishedAt,
+      anchors: p.anchors.map((a) => ({
+        kind: a.kind,
+        refId: a.refId,
+        refName: a.refName,
+      })),
+    })),
+    ...legacyPosts.map((p) => {
+      const title = pickText(p.title, locale) || "";
+      const bodyText = pickText(p.body, locale) || "";
+      return {
+        id: p.id,
+        title,
+        excerpt:
+          bodyText.length > 200 ? `${bodyText.slice(0, 197)}…` : bodyText,
+        category: "news" as const,
+        publishedAt: p.publishedAt,
+        anchors: p.place
+          ? [
+              {
+                // Legacy "floor" is collapsed to "building" — the new
+                // model doesn't carry a floor anchor kind.
+                kind: (p.place.kind === "room" ? "room" : "building") as
+                  | "room"
+                  | "building",
+                refId: p.place.id,
+                refName: p.place.name,
+              },
+            ]
+          : [],
+      };
+    }),
+  ]
+    .sort(
+      (a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt),
+    )
+    .slice(0, 6);
+
   return (
     <ConsumerHome
       token={token}
@@ -98,6 +150,7 @@ export default async function CampusHomePage({
       headline={headline}
       subheading={subheading}
       mapThumbnailUrl={map.thumbnail ?? undefined}
+      news={news}
     />
   );
 }

--- a/apps/campus/app/api/maps/[mapId]/news/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/news/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import {
+  listNewsForAdmin,
+  type NewsAnchor,
+} from "@/lib/news";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+import { Prisma, type NewsCategory } from "@prisma/client";
+
+type Params = Promise<{ mapId: string }>;
+
+const VALID_CATEGORIES: NewsCategory[] = ["announcement", "news", "alert"];
+
+/** Normalise the JSON body's anchors into clean rows. */
+function parseAnchors(raw: unknown): NewsAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is NewsAnchor => !!a);
+}
+
+/** Coerce a string / Date / undefined into a valid Date, or fall back. */
+function parseDate(value: unknown, fallback?: Date): Date | null {
+  if (value == null || value === "") return fallback ?? null;
+  if (typeof value === "string" || typeof value === "number") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? (fallback ?? null) : d;
+  }
+  return fallback ?? null;
+}
+
+/** GET /api/maps/[mapId]/news — admin listing (everything, including drafts). */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  const posts = await listNewsForAdmin(mapId);
+  return NextResponse.json({ posts });
+}
+
+/**
+ * POST /api/maps/[mapId]/news — create a news post on this campus.
+ * Body: { title, body, category?, publishedAt?, expiresAt?, anchors?, imageUrl? }
+ */
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const title =
+    typeof body.title === "string" ? body.title.trim() : "";
+  const post = typeof body.body === "string" ? body.body.trim() : "";
+  if (!title || !post) {
+    return NextResponse.json(
+      { error: "title and body are required" },
+      { status: 400 },
+    );
+  }
+
+  const category: NewsCategory = VALID_CATEGORIES.includes(
+    body.category as NewsCategory,
+  )
+    ? (body.category as NewsCategory)
+    : "announcement";
+
+  const publishedAt = parseDate(body.publishedAt, new Date()) ?? new Date();
+  const expiresAt = parseDate(body.expiresAt);
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const created = await prisma.newsPost.create({
+    data: {
+      organizationId: project.organizationId,
+      projectId: mapId,
+      title,
+      body: post,
+      category,
+      publishedAt,
+      expiresAt,
+      // Prisma's `Json` input wants `InputJsonValue`; our typed array
+      // is a `JsonArray` shape so the cast is safe.
+      anchors: parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue,
+      imageUrl:
+        typeof body.imageUrl === "string" && body.imageUrl.length > 0
+          ? body.imageUrl
+          : null,
+    },
+  });
+
+  // Public surface caches per token — bust this campus's tag so the
+  // new post shows up immediately without waiting for the 60 s TTL.
+  revalidateTag(publicCampusTag(mapId));
+
+  return NextResponse.json({ id: created.id });
+}

--- a/apps/campus/app/api/news/[id]/route.ts
+++ b/apps/campus/app/api/news/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ id: string }>;
+
+/** DELETE /api/news/[id] — remove a post. Admin / member / owner only. */
+export async function DELETE(_req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const post = await prisma.newsPost.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!post) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(post.organizationId, "write");
+  if (denied) return denied;
+
+  await prisma.newsPost.delete({ where: { id } });
+  revalidateTag(publicCampusTag(post.projectId));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/app/api/uploads/route.ts
+++ b/apps/campus/app/api/uploads/route.ts
@@ -8,6 +8,8 @@ const ALLOWED_PREFIXES = new Set([
   "campus-thumbnails",
   "campus-branding",
   "campus-hero",
+  // Per-news-post hero image — see lib/news.ts + the admin create form.
+  "campus-news",
 ]);
 const ALLOWED_TYPES = new Set([
   "image/png",

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -12,6 +12,7 @@ import {
   SAMPLE_EVENTS,
   SAMPLE_NEWS,
 } from "../sample-campus";
+import type { ConsumerNews } from "./types";
 
 export interface ConsumerHomeProps {
   token: string;
@@ -25,6 +26,12 @@ export interface ConsumerHomeProps {
   subheading?: string;
   /** Real venue thumbnail for the hero's MapTeaser. */
   mapThumbnailUrl?: string;
+  /**
+   * News items rendered in the News rail. Defaults to the sample seed
+   * when the page hasn't (yet) loaded real posts — keeps the layout
+   * populated for new tenants without forcing them to author first.
+   */
+  news?: ConsumerNews[];
 }
 
 /**
@@ -51,7 +58,9 @@ export function ConsumerHome({
   headline,
   subheading,
   mapThumbnailUrl,
+  news,
 }: ConsumerHomeProps) {
+  const newsItems = news?.length ? news : SAMPLE_NEWS;
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
   // Per-org accent overrides the default purple at the wrapper, so
@@ -143,7 +152,7 @@ export function ConsumerHome({
             Campus news
           </h2>
           <div className="mt-4">
-            {SAMPLE_NEWS.map((n) => (
+            {newsItems.map((n) => (
               <NewsItem
                 key={n.id}
                 item={n}

--- a/apps/campus/lib/news.ts
+++ b/apps/campus/lib/news.ts
@@ -1,0 +1,132 @@
+/**
+ * Campus news posts — server side.
+ *
+ * Arc 2 of [[campus-consumer-pivot]]. Promotes news from the
+ * legacy `sceneData.posts` JSON ([[lib/posts.ts]]) to a dedicated
+ * `NewsPost` Prisma model. The model is per-`Project` (a campus
+ * map) and carries multi-anchor metadata as a JSON column — see
+ * the `Anchor` shape below.
+ *
+ * Public reads land via `listNewsForProject` (sorted newest first,
+ * expired entries dropped). Admin reads land via `listNewsForOrg`.
+ */
+import { prisma } from "@/lib/prisma";
+import type { NewsPost as PrismaNewsPost, NewsCategory } from "@prisma/client";
+
+export type { NewsCategory } from "@prisma/client";
+
+/** Place a post is connected to — denormalised name + MappedIn id. */
+export interface NewsAnchor {
+  kind: "building" | "room";
+  /** MappedIn space id; may be empty until the proper picker lands. */
+  refId: string;
+  refName: string;
+}
+
+/** The shape we surface to client + public — JSON columns parsed. */
+export interface NewsPost {
+  id: string;
+  projectId: string;
+  title: string;
+  body: string;
+  imageUrl: string | null;
+  category: NewsCategory;
+  publishedAt: string;
+  expiresAt: string | null;
+  anchors: NewsAnchor[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Type-narrowing for the JSON `anchors` column off the Prisma row. */
+function parseAnchors(raw: unknown): NewsAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (a): a is NewsAnchor =>
+      !!a &&
+      typeof a === "object" &&
+      "refName" in a &&
+      typeof (a as { refName?: unknown }).refName === "string",
+  );
+}
+
+function fromPrisma(row: PrismaNewsPost): NewsPost {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    title: row.title,
+    body: row.body,
+    imageUrl: row.imageUrl,
+    category: row.category,
+    publishedAt: row.publishedAt.toISOString(),
+    expiresAt: row.expiresAt ? row.expiresAt.toISOString() : null,
+    anchors: parseAnchors(row.anchors),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * News for a public campus surface — published + unexpired only,
+ * newest first. Future arcs will add visibility flags; for now any
+ * row in `NewsPost` is "published" the moment it's saved.
+ */
+export async function listNewsForProject(
+  projectId: string,
+  limit = 20,
+): Promise<NewsPost[]> {
+  const now = new Date();
+  const rows = await prisma.newsPost.findMany({
+    where: {
+      projectId,
+      publishedAt: { lte: now },
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+    },
+    orderBy: { publishedAt: "desc" },
+    take: limit,
+  });
+  return rows.map(fromPrisma);
+}
+
+/** Admin view — everything for the project, including future-dated drafts. */
+export async function listNewsForAdmin(
+  projectId: string,
+): Promise<NewsPost[]> {
+  const rows = await prisma.newsPost.findMany({
+    where: { projectId },
+    orderBy: { publishedAt: "desc" },
+  });
+  return rows.map(fromPrisma);
+}
+
+/** Single post by id — used by the public detail page. */
+export async function getNewsPost(id: string): Promise<NewsPost | null> {
+  const row = await prisma.newsPost.findUnique({ where: { id } });
+  return row ? fromPrisma(row) : null;
+}
+
+/** Format a post's date for display. */
+export function formatNewsDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** Relative time ("2 days ago") — for the consumer rail. */
+export function relativeNewsTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  const day = 1000 * 60 * 60 * 24;
+  const days = Math.floor(diffMs / day);
+  if (days < 1) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days} days ago`;
+  if (days < 14) return "a week ago";
+  if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+  return formatNewsDate(iso);
+}

--- a/packages/prisma/migrations/20260526120000_add_news_post/migration.sql
+++ b/packages/prisma/migrations/20260526120000_add_news_post/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "NewsCategory" AS ENUM ('announcement', 'news', 'alert');
+
+-- CreateTable
+CREATE TABLE "NewsPost" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "category" "NewsCategory" NOT NULL DEFAULT 'announcement',
+    "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "anchors" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NewsPost_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "NewsPost_projectId_publishedAt_idx" ON "NewsPost"("projectId", "publishedAt");
+
+-- CreateIndex
+CREATE INDEX "NewsPost_organizationId_idx" ON "NewsPost"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "NewsPost" ADD CONSTRAINT "NewsPost_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NewsPost" ADD CONSTRAINT "NewsPost_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -90,6 +90,7 @@ model Organization {
   activities            Activity[]
   cesiumIonIntegrations CesiumIonIntegration[]
   cesiumAssets          CesiumAsset[]
+  newsPosts             NewsPost[]
   plan                  Plan                   @relation(fields: [planCode], references: [code])
 
   @@index([planCode])
@@ -163,6 +164,8 @@ model Project {
   assets       Asset[]
   // Activities related to this project
   activities   Activity[]
+  // Campus news posts scoped to this project — see lib/news.ts.
+  newsPosts    NewsPost[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -386,4 +389,37 @@ model ShowcaseTag {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+/// Campus news post — Arc 2 of campus-consumer-pivot.
+/// Scoped to a Project (one campus map). One post can apply to many
+/// anchors; stored as a JSON array of { kind, refId, refName } rather
+/// than a relation table because the list is short and we don't query
+/// across anchors (each post resolves its own).
+model NewsPost {
+  id             String       @id @default(cuid())
+  organizationId String
+  projectId      String
+  title          String
+  body           String       @db.Text
+  imageUrl       String?
+  category       NewsCategory @default(announcement)
+  publishedAt    DateTime     @default(now())
+  expiresAt      DateTime?
+  // [{ kind, refId, refName }] — see ConsumerAnchor in lib/consumer/types.
+  anchors        Json         @default("[]")
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, publishedAt])
+  @@index([organizationId])
+}
+
+enum NewsCategory {
+  announcement
+  news
+  alert
 }


### PR DESCRIPTION
## What this is

Arc 2 of [[campus-consumer-pivot]] — graduates news from the legacy `sceneData.posts` JSON ([[lib/posts.ts]]) to a real Prisma model with REST + an admin form + a public detail page, and lights the consumer home up with real content.

## What's on the page

- `/org/[orgId]/maps/[mapId]/news` — new admin page. List of posts on the left (delete-only for Arc 2), inline create form on the right (title, body, category, publish-on date, "where on campus" free-text, optional image upload via the existing presigned PUT flow). The legacy `NewsTab` is **untouched** — bilingual posts in `sceneData.posts` keep their editor.
- `/campus/[token]/news/[id]` — public news detail page in the consumer visual language. Anchor chips deep-link into the MappedIn viewer when the anchor carries a `refId`, otherwise render as static labels. Token + id cross-checked so a post can't leak through another tenant's URL.
- The consumer home (`/campus/[token]`) now reads from **both** `NewsPost` rows and legacy `sceneData.posts` (mapped to the same shape) and renders the merged list newest-first, capped at 6. Existing tenants don't lose any content during the transition.

## Schema

```prisma
model NewsPost {
  id             String       @id @default(cuid())
  organizationId String
  projectId      String
  title          String
  body           String       @db.Text
  imageUrl       String?
  category       NewsCategory @default(announcement)
  publishedAt    DateTime     @default(now())
  expiresAt      DateTime?
  anchors        Json         @default("[]")  // [{ kind, refId, refName }]
  …
  @@index([projectId, publishedAt])
  @@index([organizationId])
}
enum NewsCategory { announcement  news  alert }
```

Anchors stored as JSON because the list is short, never queried across, and the shape changes more often than the schema should. Migration is `20260526120000_add_news_post`.

## API

| Verb | Path | Notes |
|---|---|---|
| GET | `/api/maps/[mapId]/news` | admin list (everything, including future-dated) |
| POST | `/api/maps/[mapId]/news` | create — write access required |
| DELETE | `/api/news/[id]` | resolves org from the post, write access required |

Each write calls `revalidateTag(publicCampusTag(mapId))` so the consumer home picks up the change without waiting for the 60 s ISR window.

## Auth

Existing `requireCampusAccess` / `requireOrgAccess` from `lib/authz`. Reads = any member; writes = owner / admin / member; `publicViewer` is denied. No new auth surface.

## Out of scope for this PR (follow-ups, possibly on this same branch)

- **Edit endpoint** — delete works; edit is one PATCH route + a switch in the admin form. Not blocker for Arc 2's loop.
- **Anchor picker over `mapData.search`** — free-text input for now. Picker will reuse `SearchableSelect` once we wire it up.
- **CSV import.**
- **Bilingual title / body.** Plain `String` columns today; promoting to `Localizable` JSON is non-breaking.
- **A discover-the-new-page link inside the legacy `NewsTab`.**

## Testing

`tsc --noEmit` clean. `next lint` clean. Migration generated against the empty schema and trimmed to only the news bits — no other tables touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)