### PR TITLE
feat(campus): events as a first-class model — Arc 3

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Image from "next/image";
+import { toast } from "react-toastify";
+import { Plus, Trash2, X } from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Select,
+  Textarea,
+} from "@klorad/design-system";
+import { uploadFile } from "@klorad/storage/client";
+import {
+  formatEventWhen,
+  type EventPost,
+  type EventBanner,
+  type EventIcon,
+} from "@/lib/events-db";
+
+interface Props {
+  mapId: string;
+  initialEvents: EventPost[];
+}
+
+const BANNERS: { value: EventBanner; label: string; swatch: string }[] = [
+  { value: "purple", label: "Purple", swatch: "#534AB7" },
+  { value: "coral", label: "Coral", swatch: "#D85A30" },
+  { value: "teal", label: "Teal", swatch: "#1D9E75" },
+  { value: "pink", label: "Pink", swatch: "#D4537E" },
+];
+
+const ICONS: { value: EventIcon; label: string }[] = [
+  { value: "calendar", label: "Calendar" },
+  { value: "music", label: "Music" },
+  { value: "trophy", label: "Trophy" },
+  { value: "sprout", label: "Sprout" },
+];
+
+/** `<input type="datetime-local">` wants `YYYY-MM-DDTHH:mm` in local time. */
+function plusHoursLocal(hours: number): string {
+  const d = new Date(Date.now() + hours * 3_600_000);
+  const off = d.getTimezoneOffset();
+  return new Date(d.getTime() - off * 60_000).toISOString().slice(0, 16);
+}
+
+/**
+ * Events admin client. List + delete on the left; create form on the
+ * right (title · description · start / end · banner colour + icon ·
+ * anchor name · optional image / registration URL / organizer /
+ * expected attendance). POST goes to /api/maps/[mapId]/events; the
+ * server bumps the public cache tag so the rail updates instantly.
+ */
+export function EventsAdminClient({ mapId, initialEvents }: Props) {
+  const [events, setEvents] = useState<EventPost[]>(initialEvents);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [startsAt, setStartsAt] = useState(plusHoursLocal(24));
+  const [endsAt, setEndsAt] = useState(plusHoursLocal(26));
+  const [bannerColor, setBannerColor] = useState<EventBanner>("purple");
+  const [bannerIcon, setBannerIcon] = useState<EventIcon>("calendar");
+  const [anchorName, setAnchorName] = useState("");
+  const [registrationUrl, setRegistrationUrl] = useState("");
+  const [organizer, setOrganizer] = useState("");
+  const [expectedAttendance, setExpectedAttendance] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleImage = async (file: File) => {
+    setUploading(true);
+    try {
+      const result = await uploadFile(file, { prefix: "campus-news" });
+      setImageUrl(result.publicUrl);
+    } catch (e) {
+      console.error(e);
+      toast.error("Image upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const reset = () => {
+    setTitle("");
+    setDescription("");
+    setStartsAt(plusHoursLocal(24));
+    setEndsAt(plusHoursLocal(26));
+    setBannerColor("purple");
+    setBannerIcon("calendar");
+    setAnchorName("");
+    setRegistrationUrl("");
+    setOrganizer("");
+    setExpectedAttendance("");
+    setImageUrl(null);
+  };
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !description.trim()) {
+      toast.error("Title and description are required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const attendance = expectedAttendance.trim()
+        ? Number.parseInt(expectedAttendance, 10)
+        : undefined;
+      const res = await fetch(`/api/maps/${mapId}/events`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim(),
+          startsAt: new Date(startsAt).toISOString(),
+          endsAt: new Date(endsAt).toISOString(),
+          bannerColor,
+          bannerIcon,
+          imageUrl,
+          registrationUrl: registrationUrl.trim() || undefined,
+          organizer: organizer.trim() || undefined,
+          expectedAttendance:
+            attendance != null && !Number.isNaN(attendance)
+              ? attendance
+              : undefined,
+          anchors: anchorName.trim()
+            ? [
+                {
+                  kind: "building",
+                  refId: "",
+                  refName: anchorName.trim(),
+                },
+              ]
+            : [],
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? "Failed to publish");
+      }
+      const list = await fetch(`/api/maps/${mapId}/events`).then((r) =>
+        r.json(),
+      );
+      setEvents(list.events ?? []);
+      reset();
+      toast.success("Event published");
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Failed to publish");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm("Delete this event?")) return;
+    try {
+      const res = await fetch(`/api/events/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete");
+      setEvents((e) => e.filter((event) => event.id !== id));
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to delete");
+    }
+  };
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr]">
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Upcoming & past
+        </h2>
+        <p className="mt-1 text-xs text-text-tertiary">
+          {events.length} event{events.length === 1 ? "" : "s"}
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {events.length === 0 ? (
+            <p className="rounded-lg bg-surface-2 p-4 text-sm text-text-tertiary">
+              No events yet. Use the form to publish your first one.
+            </p>
+          ) : (
+            events.map((e) => (
+              <article
+                key={e.id}
+                className="flex gap-3 rounded-lg border border-solid border-line-soft p-3"
+              >
+                {e.imageUrl ? (
+                  <Image
+                    src={e.imageUrl}
+                    alt=""
+                    width={64}
+                    height={64}
+                    className="h-16 w-16 shrink-0 rounded-md object-cover"
+                  />
+                ) : null}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <h3 className="truncate text-sm font-medium text-text-primary">
+                        {e.title}
+                      </h3>
+                      <p className="mt-0.5 text-[0.7rem] uppercase tracking-wide text-text-tertiary">
+                        {formatEventWhen(e.startsAt)}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => void onDelete(e.id)}
+                      aria-label="Delete"
+                      className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                    >
+                      <Trash2 size={14} strokeWidth={1.75} />
+                    </button>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
+                    {e.description}
+                  </p>
+                  {e.anchors.length > 0 ? (
+                    <p className="mt-1 text-[0.7rem] text-text-tertiary">
+                      · {e.anchors.map((a) => a.refName).join(", ")}
+                    </p>
+                  ) : null}
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+      </Panel>
+
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          New event
+        </h2>
+        <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
+          <Field label="Title">
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Open mic at the quad cafe"
+              required
+            />
+          </Field>
+
+          <Field label="Description">
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What students need to know."
+              rows={4}
+              required
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Starts">
+              <Input
+                type="datetime-local"
+                value={startsAt}
+                onChange={(e) => setStartsAt(e.target.value)}
+                required
+              />
+            </Field>
+            <Field label="Ends">
+              <Input
+                type="datetime-local"
+                value={endsAt}
+                onChange={(e) => setEndsAt(e.target.value)}
+                required
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Banner colour">
+              <Select
+                value={bannerColor}
+                onChange={(e) =>
+                  setBannerColor(e.target.value as EventBanner)
+                }
+              >
+                {BANNERS.map((b) => (
+                  <option key={b.value} value={b.value}>
+                    {b.label}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+            <Field label="Banner icon">
+              <Select
+                value={bannerIcon}
+                onChange={(e) =>
+                  setBannerIcon(e.target.value as EventIcon)
+                }
+              >
+                {ICONS.map((i) => (
+                  <option key={i.value} value={i.value}>
+                    {i.label}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+          </div>
+
+          <Field label="Where on campus (optional)">
+            <Input
+              value={anchorName}
+              onChange={(e) => setAnchorName(e.target.value)}
+              placeholder="Library, Cafe Pavilion, Mott Athletics…"
+            />
+          </Field>
+
+          <Field label="Registration URL (optional)">
+            <Input
+              type="url"
+              value={registrationUrl}
+              onChange={(e) => setRegistrationUrl(e.target.value)}
+              placeholder="https://…"
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Organizer (optional)">
+              <Input
+                value={organizer}
+                onChange={(e) => setOrganizer(e.target.value)}
+                placeholder="Music society"
+              />
+            </Field>
+            <Field label="Expected attendance">
+              <Input
+                type="number"
+                min="0"
+                value={expectedAttendance}
+                onChange={(e) => setExpectedAttendance(e.target.value)}
+                placeholder="84"
+              />
+            </Field>
+          </div>
+
+          <Field label="Image (optional)">
+            {imageUrl ? (
+              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt=""
+                  className="h-16 w-16 rounded-md object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => setImageUrl(null)}
+                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
+                >
+                  <X size={14} strokeWidth={1.75} />
+                </button>
+              </div>
+            ) : (
+              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
+                <Plus size={16} strokeWidth={1.75} />
+                {uploading ? "Uploading…" : "Add image"}
+                <input
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  disabled={uploading}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleImage(file);
+                    e.target.value = "";
+                  }}
+                />
+              </label>
+            )}
+          </Field>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={reset}
+              disabled={submitting}
+            >
+              Reset
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Publishing…" : "Publish"}
+            </Button>
+          </div>
+        </form>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
@@ -1,0 +1,70 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { listEventsForAdmin } from "@/lib/events-db";
+import { EventsAdminClient } from "./EventsAdminClient";
+
+type Params = Promise<{ orgId: string; mapId: string }>;
+
+/**
+ * `/org/[orgId]/maps/[mapId]/events` — admin events authoring.
+ *
+ * Lists events (newest scheduled first) + an inline create form.
+ * Backed by the `EventPost` model from Arc 3 of
+ * [[campus-consumer-pivot]]. ICS-feed-sourced recurring events are
+ * untouched and continue to render via `events-server.ts`.
+ */
+export default async function EventsAdminPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, mapId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/sign-in");
+
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+
+  const project = await prisma.project.findFirst({
+    where: { id: mapId, organizationId: orgId },
+    select: { id: true, title: true },
+  });
+  if (!project) notFound();
+
+  const events = await listEventsForAdmin(mapId);
+
+  return (
+    <div className="mx-auto max-w-[960px] px-6 py-10">
+      <Link
+        href={`/org/${orgId}/maps/${mapId}`}
+        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+      >
+        <ChevronLeft size={14} strokeWidth={1.75} />
+        Back to {project.title}
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-2xl font-semibold text-text-primary">
+          Events
+        </h1>
+        <p className="mt-1 text-sm text-text-tertiary">
+          Anything happening on campus — pinned to a building or room.
+          Recurring ICS feeds keep rendering separately.
+        </p>
+      </div>
+
+      <EventsAdminClient mapId={mapId} initialEvents={events} />
+    </div>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft, MapPin, Compass, ExternalLink } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale } from "@/app/lib/i18n-core";
+import {
+  formatEventWhen,
+  getEventPost,
+} from "@/lib/events-db";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string; id: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token, id } = await params;
+  const [map, event] = await Promise.all([
+    getPublicCampusByToken(token),
+    getEventPost(id),
+  ]);
+  if (!event || !map || event.projectId !== map.id) return { title: "Event" };
+  return {
+    title: `${event.title} · Events`,
+    description: event.description.slice(0, 160),
+    openGraph: {
+      title: event.title,
+      description: event.description.slice(0, 160),
+      type: "article",
+      images: event.imageUrl ? [event.imageUrl] : undefined,
+    },
+  };
+}
+
+/**
+ * `/campus/[token]/events/[id]` — public event detail.
+ *
+ * Hero image (if any), title, when, organizer + expected attendance,
+ * anchor chips that deep-link into the MappedIn viewer, description,
+ * and the primary "Get directions" CTA that drops onto the map
+ * focused on the event's anchor. Optional "Register" link opens the
+ * organiser's URL in a new tab.
+ */
+export default async function EventDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token, id } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+  const event = await getEventPost(id);
+  if (!event || event.projectId !== map.id) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+  const firstAnchor = event.anchors[0];
+  // Anchor with a refId → drop onto the map focused on that space.
+  // Without a refId we still link to the map (the visitor can search).
+  const directionsHref = firstAnchor?.refId
+    ? `${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`
+    : mapHref;
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <article className="mx-auto max-w-[760px] px-4 py-8 md:px-6 md:py-12">
+        <Link
+          href={`/campus/${token}${lang}`}
+          className="inline-flex items-center gap-1 text-sm text-[var(--brand-text-muted)] transition-colors hover:text-[var(--brand-primary)]"
+        >
+          <ChevronLeft size={16} strokeWidth={1.75} />
+          Back to {campusName}
+        </Link>
+
+        {event.imageUrl ? (
+          <div className="mt-6 overflow-hidden rounded-2xl border border-[var(--brand-line)]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={event.imageUrl}
+              alt=""
+              className="block aspect-[16/9] w-full object-cover"
+            />
+          </div>
+        ) : null}
+
+        <h1 className="mt-8 text-3xl font-medium leading-tight text-[var(--brand-text)] md:text-4xl">
+          {event.title}
+        </h1>
+
+        <p className="mt-3 text-sm text-[var(--brand-text-muted)]">
+          {formatEventWhen(event.startsAt)}
+          {event.organizer ? ` · ${event.organizer}` : ""}
+          {event.expectedAttendance
+            ? ` · ${event.expectedAttendance} going`
+            : ""}
+        </p>
+
+        {event.anchors.length > 0 ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {event.anchors.map((a, i) =>
+              a.refId ? (
+                <Link
+                  key={`${a.refId}-${i}`}
+                  href={`${mapHref}&space=${encodeURIComponent(a.refId)}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
+                >
+                  <MapPin size={14} strokeWidth={1.75} />
+                  {a.refName}
+                </Link>
+              ) : (
+                <span
+                  key={`${a.refName}-${i}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]"
+                >
+                  <MapPin size={14} strokeWidth={1.75} />
+                  {a.refName}
+                </span>
+              ),
+            )}
+          </div>
+        ) : null}
+
+        <div className="mt-8 whitespace-pre-wrap text-base leading-relaxed text-[var(--brand-text)]">
+          {event.description}
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link
+            href={directionsHref}
+            className="inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: "var(--brand-primary)" }}
+          >
+            <Compass size={16} strokeWidth={1.75} />
+            Get directions
+          </Link>
+          {event.registrationUrl ? (
+            <a
+              href={event.registrationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-line)] bg-white px-5 py-2.5 text-sm font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
+            >
+              <ExternalLink size={16} strokeWidth={1.75} />
+              Register
+            </a>
+          ) : null}
+        </div>
+      </article>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -5,9 +5,10 @@ import { readHomePage } from "@/lib/home-page";
 import { detectLocale, pickText } from "@/app/lib/i18n-core";
 import { readPosts } from "@/lib/posts";
 import { listNewsForProject } from "@/lib/news";
+import { listUpcomingEventsForProject } from "@/lib/events-db";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 import { ConsumerHome } from "@/lib/consumer/ConsumerHome";
-import type { ConsumerNews } from "@/lib/consumer/types";
+import type { ConsumerEvent, ConsumerNews } from "@/lib/consumer/types";
 
 type Params = Promise<{ token: string }>;
 
@@ -94,7 +95,13 @@ export default async function CampusHomePage({
   // News rail: combine the new `NewsPost` rows with legacy posts in
   // `sceneData.posts` so existing tenants don't lose what's there
   // while they migrate. Newest first, capped at 6.
-  const dbPosts = await listNewsForProject(map.id);
+  // Events rail: DB events only for now — ICS-feed-sourced events
+  // continue to render through `events-server.ts` but are wired into
+  // the consumer surface in a follow-up commit (Arc 3 follow-up).
+  const [dbPosts, dbEvents] = await Promise.all([
+    listNewsForProject(map.id),
+    listUpcomingEventsForProject(map.id, 12),
+  ]);
   const legacyPosts = readPosts(map.sceneData);
   const news: ConsumerNews[] = [
     ...dbPosts.map((p) => ({
@@ -140,6 +147,27 @@ export default async function CampusHomePage({
     )
     .slice(0, 6);
 
+  // EventPost rows map 1:1 onto the consumer card shape — the Prisma
+  // enums (bannerColor / bannerIcon) match the ConsumerEvent unions.
+  const events: ConsumerEvent[] = dbEvents.map((e) => ({
+    id: e.id,
+    title: e.title,
+    blurb:
+      e.description.length > 200
+        ? `${e.description.slice(0, 197)}…`
+        : e.description,
+    startsAt: e.startsAt,
+    endsAt: e.endsAt,
+    bannerColor: e.bannerColor,
+    bannerIcon: e.bannerIcon,
+    anchors: e.anchors.map((a) => ({
+      kind: a.kind,
+      refId: a.refId,
+      refName: a.refName,
+    })),
+    expectedAttendance: e.expectedAttendance ?? undefined,
+  }));
+
   return (
     <ConsumerHome
       token={token}
@@ -151,6 +179,7 @@ export default async function CampusHomePage({
       subheading={subheading}
       mapThumbnailUrl={map.thumbnail ?? undefined}
       news={news}
+      events={events}
     />
   );
 }

--- a/apps/campus/app/api/events/[id]/route.ts
+++ b/apps/campus/app/api/events/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ id: string }>;
+
+export async function DELETE(_req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const event = await prisma.eventPost.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!event) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(event.organizationId, "write");
+  if (denied) return denied;
+  await prisma.eventPost.delete({ where: { id } });
+  revalidateTag(publicCampusTag(event.projectId));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/app/api/maps/[mapId]/events/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/events/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from "next/server";
+import { Prisma, type EventBanner, type EventIcon } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import {
+  listEventsForAdmin,
+  type EventAnchor,
+} from "@/lib/events-db";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ mapId: string }>;
+
+const VALID_BANNER: EventBanner[] = ["purple", "coral", "teal", "pink"];
+const VALID_ICON: EventIcon[] = ["music", "trophy", "sprout", "calendar"];
+
+function parseAnchors(raw: unknown): EventAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is EventAnchor => !!a);
+}
+
+function parseDate(value: unknown): Date | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "string" || typeof value === "number") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+  const events = await listEventsForAdmin(mapId);
+  return NextResponse.json({ events });
+}
+
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const title =
+    typeof body.title === "string" ? body.title.trim() : "";
+  const description =
+    typeof body.description === "string" ? body.description.trim() : "";
+  const startsAt = parseDate(body.startsAt);
+  const endsAt = parseDate(body.endsAt);
+
+  if (!title || !description) {
+    return NextResponse.json(
+      { error: "title and description are required" },
+      { status: 400 },
+    );
+  }
+  if (!startsAt || !endsAt) {
+    return NextResponse.json(
+      { error: "startsAt and endsAt are required" },
+      { status: 400 },
+    );
+  }
+  if (endsAt.getTime() < startsAt.getTime()) {
+    return NextResponse.json(
+      { error: "endsAt must be after startsAt" },
+      { status: 400 },
+    );
+  }
+
+  const bannerColor: EventBanner = VALID_BANNER.includes(
+    body.bannerColor as EventBanner,
+  )
+    ? (body.bannerColor as EventBanner)
+    : "purple";
+  const bannerIcon: EventIcon = VALID_ICON.includes(
+    body.bannerIcon as EventIcon,
+  )
+    ? (body.bannerIcon as EventIcon)
+    : "calendar";
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const created = await prisma.eventPost.create({
+    data: {
+      organizationId: project.organizationId,
+      projectId: mapId,
+      title,
+      description,
+      startsAt,
+      endsAt,
+      bannerColor,
+      bannerIcon,
+      imageUrl:
+        typeof body.imageUrl === "string" && body.imageUrl.length > 0
+          ? body.imageUrl
+          : null,
+      registrationUrl:
+        typeof body.registrationUrl === "string" &&
+        body.registrationUrl.length > 0
+          ? body.registrationUrl
+          : null,
+      organizer:
+        typeof body.organizer === "string" && body.organizer.length > 0
+          ? body.organizer
+          : null,
+      expectedAttendance:
+        typeof body.expectedAttendance === "number"
+          ? body.expectedAttendance
+          : null,
+      anchors: parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  revalidateTag(publicCampusTag(mapId));
+  return NextResponse.json({ id: created.id });
+}

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -12,7 +12,7 @@ import {
   SAMPLE_EVENTS,
   SAMPLE_NEWS,
 } from "../sample-campus";
-import type { ConsumerNews } from "./types";
+import type { ConsumerEvent, ConsumerNews } from "./types";
 
 export interface ConsumerHomeProps {
   token: string;
@@ -32,6 +32,8 @@ export interface ConsumerHomeProps {
    * populated for new tenants without forcing them to author first.
    */
   news?: ConsumerNews[];
+  /** Events for the "Happening this week" grid. Same fallback story. */
+  events?: ConsumerEvent[];
 }
 
 /**
@@ -59,8 +61,10 @@ export function ConsumerHome({
   subheading,
   mapThumbnailUrl,
   news,
+  events,
 }: ConsumerHomeProps) {
   const newsItems = news?.length ? news : SAMPLE_NEWS;
+  const eventItems = events?.length ? events : SAMPLE_EVENTS;
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
   // Per-org accent overrides the default purple at the wrapper, so
@@ -112,7 +116,7 @@ export function ConsumerHome({
           icon={Calendar}
           accent="teal"
           label="This week's events"
-          subtitle={`${SAMPLE_EVENTS.length} happening near you`}
+          subtitle={`${eventItems.length} happening near you`}
         />
       </section>
 
@@ -121,7 +125,7 @@ export function ConsumerHome({
           Happening this week
         </h2>
         <div className="mt-4 grid grid-cols-1 gap-5 md:grid-cols-3">
-          {SAMPLE_EVENTS.map((e) => (
+          {eventItems.slice(0, 3).map((e) => (
             <EventCard
               key={e.id}
               event={e}

--- a/apps/campus/lib/events-db.ts
+++ b/apps/campus/lib/events-db.ts
@@ -1,0 +1,112 @@
+/**
+ * Campus events — DB-backed (Arc 3 of [[campus-consumer-pivot]]).
+ *
+ * Per-Project event rows authored in the dashboard. ICS-sourced
+ * recurring events still flow through `events-server.ts` and the
+ * consumer surface merges both lists.
+ */
+import { prisma } from "@/lib/prisma";
+import type {
+  EventPost as PrismaEventPost,
+  EventBanner,
+  EventIcon,
+} from "@prisma/client";
+
+export type { EventBanner, EventIcon } from "@prisma/client";
+
+export interface EventAnchor {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+export interface EventPost {
+  id: string;
+  projectId: string;
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  startsAt: string;
+  endsAt: string;
+  registrationUrl: string | null;
+  organizer: string | null;
+  bannerColor: EventBanner;
+  bannerIcon: EventIcon;
+  expectedAttendance: number | null;
+  anchors: EventAnchor[];
+}
+
+function parseAnchors(raw: unknown): EventAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (a): a is EventAnchor =>
+      !!a &&
+      typeof a === "object" &&
+      "refName" in a &&
+      typeof (a as { refName?: unknown }).refName === "string",
+  );
+}
+
+function fromPrisma(row: PrismaEventPost): EventPost {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    title: row.title,
+    description: row.description,
+    imageUrl: row.imageUrl,
+    startsAt: row.startsAt.toISOString(),
+    endsAt: row.endsAt.toISOString(),
+    registrationUrl: row.registrationUrl,
+    organizer: row.organizer,
+    bannerColor: row.bannerColor,
+    bannerIcon: row.bannerIcon,
+    expectedAttendance: row.expectedAttendance,
+    anchors: parseAnchors(row.anchors),
+  };
+}
+
+/** Upcoming + ongoing events — what the consumer rail wants. */
+export async function listUpcomingEventsForProject(
+  projectId: string,
+  limit = 12,
+): Promise<EventPost[]> {
+  const now = new Date();
+  const rows = await prisma.eventPost.findMany({
+    where: { projectId, endsAt: { gte: now } },
+    orderBy: { startsAt: "asc" },
+    take: limit,
+  });
+  return rows.map(fromPrisma);
+}
+
+/** Admin view — every event including ones that already finished. */
+export async function listEventsForAdmin(
+  projectId: string,
+): Promise<EventPost[]> {
+  const rows = await prisma.eventPost.findMany({
+    where: { projectId },
+    orderBy: { startsAt: "desc" },
+  });
+  return rows.map(fromPrisma);
+}
+
+export async function getEventPost(id: string): Promise<EventPost | null> {
+  const row = await prisma.eventPost.findUnique({ where: { id } });
+  return row ? fromPrisma(row) : null;
+}
+
+/** "Tue 6:00 pm" — same compact format as the consumer rail. */
+export function formatEventWhen(startIso: string): string {
+  const d = new Date(startIso);
+  if (Number.isNaN(d.getTime())) return "";
+  const day = d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const time = d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: d.getMinutes() === 0 ? undefined : "2-digit",
+  });
+  return `${day} · ${time.toLowerCase()}`;
+}

--- a/packages/prisma/migrations/20260526150000_add_event_post/migration.sql
+++ b/packages/prisma/migrations/20260526150000_add_event_post/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "EventBanner" AS ENUM ('purple', 'coral', 'teal', 'pink');
+
+-- CreateEnum
+CREATE TYPE "EventIcon" AS ENUM ('music', 'trophy', 'sprout', 'calendar');
+
+-- CreateTable
+CREATE TABLE "EventPost" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "registrationUrl" TEXT,
+    "organizer" TEXT,
+    "bannerColor" "EventBanner" NOT NULL DEFAULT 'purple',
+    "bannerIcon" "EventIcon" NOT NULL DEFAULT 'calendar',
+    "expectedAttendance" INTEGER,
+    "anchors" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EventPost_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EventPost_projectId_startsAt_idx" ON "EventPost"("projectId", "startsAt");
+
+-- CreateIndex
+CREATE INDEX "EventPost_organizationId_idx" ON "EventPost"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "EventPost" ADD CONSTRAINT "EventPost_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EventPost" ADD CONSTRAINT "EventPost_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -91,6 +91,7 @@ model Organization {
   cesiumIonIntegrations CesiumIonIntegration[]
   cesiumAssets          CesiumAsset[]
   newsPosts             NewsPost[]
+  eventPosts            EventPost[]
   plan                  Plan                   @relation(fields: [planCode], references: [code])
 
   @@index([planCode])
@@ -166,6 +167,8 @@ model Project {
   activities   Activity[]
   // Campus news posts scoped to this project — see lib/news.ts.
   newsPosts    NewsPost[]
+  // Campus events scoped to this project — see lib/events-db.ts.
+  eventPosts   EventPost[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -422,4 +425,51 @@ enum NewsCategory {
   announcement
   news
   alert
+}
+
+/// Campus event — Arc 3 of campus-consumer-pivot.
+/// Discrete occurrence per row. ICS-sourced recurring events keep
+/// rendering through the existing `lib/events-server.ts` expansion;
+/// EventPost is for admin-authored one-offs and (later) for ICS rows
+/// that get materialised on sync. Anchors mirror NewsPost.
+model EventPost {
+  id              String      @id @default(cuid())
+  organizationId  String
+  projectId       String
+  title           String
+  description     String      @db.Text
+  imageUrl        String?
+  startsAt        DateTime
+  endsAt          DateTime
+  registrationUrl String?
+  organizer       String?
+  /// Banner colour for the consumer card — see ConsumerEvent.
+  bannerColor     EventBanner @default(purple)
+  /// Lucide icon name for the banner.
+  bannerIcon      EventIcon   @default(calendar)
+  /// Vanity "expected attendance" — admin-set. See campus-consumer-pivot.
+  expectedAttendance Int?
+  anchors         Json        @default("[]")
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, startsAt])
+  @@index([organizationId])
+}
+
+enum EventBanner {
+  purple
+  coral
+  teal
+  pink
+}
+
+enum EventIcon {
+  music
+  trophy
+  sprout
+  calendar
 }


### PR DESCRIPTION
## What this is

Arc 3 of [[campus-consumer-pivot]]. The event analogue of Arc 2 — adds the `EventPost` Prisma model, an admin form, a public detail page with a "Get directions" CTA, and wires the consumer home's "Happening this week" grid to real rows.

## What's on the page

- `/org/[orgId]/maps/[mapId]/events` — new admin page. List of upcoming + past events on the left (delete-only for Arc 3), inline create form on the right (title · description · starts / ends · banner colour + icon · "where on campus" · optional image upload · registration URL · organizer · expected attendance).
- `/campus/[token]/events/[id]` — public event detail. Hero image, title, when + organizer + expected attendance, anchor chips that deep-link into MappedIn, body, and **"Get directions"** CTA → focuses the map on the event's anchor (`refId`). Optional **"Register"** opens the org's URL in a new tab. Token + id cross-checked to prevent cross-tenant leaks.
- The consumer home (`/campus/[token]`) now reads real `EventPost` rows and renders them in the "Happening this week" grid (top 3, with sample-data fallback for empty tenants).

## Schema

```prisma
model EventPost {
  id              String      @id @default(cuid())
  organizationId  String
  projectId       String
  title           String
  description     String      @db.Text
  imageUrl        String?
  startsAt        DateTime
  endsAt          DateTime
  registrationUrl String?
  organizer       String?
  bannerColor     EventBanner @default(purple)
  bannerIcon      EventIcon   @default(calendar)
  expectedAttendance Int?
  anchors         Json        @default("[]")
  …
  @@index([projectId, startsAt])
  @@index([organizationId])
}
enum EventBanner { purple coral teal pink }
enum EventIcon   { music trophy sprout calendar }
```

The two enums deliberately mirror the union types on `ConsumerEvent` (`lib/consumer/types.ts`), so a row maps 1:1 onto the card shape — no transform, no impedance. Migration: `20260526150000_add_event_post`.

## API

| Verb | Path | Notes |
|---|---|---|
| GET | `/api/maps/[mapId]/events` | admin list |
| POST | `/api/maps/[mapId]/events` | create — write access required, dates validated |
| DELETE | `/api/events/[id]` | resolves org from the event, write access required |

Each write bumps `revalidateTag(publicCampusTag(mapId))` so the rail updates without waiting for the 60 s ISR window.

## Out of scope for this PR (follow-ups, possibly on this branch)

- **Edit** (PATCH route + form-state switch).
- **ICS-sourced recurring events** on the new home. They still render via `events-server.ts` — re-wiring into ConsumerHome is one read + a `map()` merge.
- **"Get directions" prefilling `To` on the wayfinding side panel.** Currently focuses the map on the anchor; opening Navigate with the destination prefilled is a small `MappedinViewer` prop away.
- **Anchor picker over `mapData.search`** — free text for now.
- **Month-view admin** — list-only.
- **Recurring-event authoring (RRULE).** Per-occurrence today.

## Testing

`tsc --noEmit` clean. `next lint` clean. Migration trimmed to the event bits — no other tables touched.

## To use it once merged

1. `pnpm prisma migrate deploy` (or `prisma migrate dev` locally) to apply `20260526150000_add_event_post`.
2. Visit `/org/[orgId]/maps/[mapId]/events` → publish an event → refresh the public campus home → it appears in the rail.
3. Tap the card → detail page → *Get directions* → MappedIn map focuses on the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)