### PR TITLE
fix(campus): public home tolerates pending migrations

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -4,8 +4,11 @@ import { getPublicCampusByToken } from "@/lib/public-campus";
 import { readHomePage } from "@/lib/home-page";
 import { detectLocale, pickText } from "@/app/lib/i18n-core";
 import { readPosts } from "@/lib/posts";
-import { listNewsForProject } from "@/lib/news";
-import { listUpcomingEventsForProject } from "@/lib/events-db";
+import { listNewsForProject, type NewsPost } from "@/lib/news";
+import {
+  listUpcomingEventsForProject,
+  type EventPost,
+} from "@/lib/events-db";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 import { ConsumerHome } from "@/lib/consumer/ConsumerHome";
 import type { ConsumerEvent, ConsumerNews } from "@/lib/consumer/types";
@@ -98,9 +101,20 @@ export default async function CampusHomePage({
   // Events rail: DB events only for now — ICS-feed-sourced events
   // continue to render through `events-server.ts` but are wired into
   // the consumer surface in a follow-up commit (Arc 3 follow-up).
+  //
+  // Guarded against pending migrations / DB unavailability: if the
+  // `NewsPost` or `EventPost` table is missing (operator hasn't run
+  // `prisma migrate deploy` yet) the home renders with empty rails
+  // + the sample-data fallback in `ConsumerHome` instead of 500ing.
   const [dbPosts, dbEvents] = await Promise.all([
-    listNewsForProject(map.id),
-    listUpcomingEventsForProject(map.id, 12),
+    listNewsForProject(map.id).catch((err): NewsPost[] => {
+      console.error("[public-home] news fetch failed", err);
+      return [];
+    }),
+    listUpcomingEventsForProject(map.id, 12).catch((err): EventPost[] => {
+      console.error("[public-home] events fetch failed", err);
+      return [];
+    }),
   ]);
   const legacyPosts = readPosts(map.sceneData);
   const news: ConsumerNews[] = [


### PR DESCRIPTION
## The bug

Public home 500s with:

\`\`\`
Runtime PrismaClientKnownRequestError
Invalid \`prisma.eventPost.findMany()\` invocation:
The table \`public.EventPost\` does not exist in the current database.
\`\`\`

Cause: Arcs 2 + 3 added the \`NewsPost\` + \`EventPost\` migrations but the operator hasn't run \`prisma migrate deploy\` yet, so the code is calling tables that aren't there.

## The fix in this PR

The two reads now \`.catch()\` and fall back to \`[]\`. The home renders empty rails (\`ConsumerHome\` fills them with sample data on an empty tenant) and the rest of the site keeps working. The error is logged so it shows up in server logs.

\`\`\`ts
listNewsForProject(map.id).catch((err): NewsPost[] => {
  console.error("[public-home] news fetch failed", err);
  return [];
}),
\`\`\`

## The real fix you also need

This PR is a safety net. The actual missing step is applying the migrations:

\`\`\`bash
pnpm prisma migrate deploy
\`\`\`

That picks up \`20260526120000_add_news_post\` + \`20260526150000_add_event_post\` and creates the tables. After that the page reads return the real rows again.

If you want to do it locally:

\`\`\`bash
cd packages/prisma
pnpm exec prisma migrate dev
\`\`\`

(Uses your local \`DATABASE_URL\`.)

## Testing

\`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)