### PR TITLE
feat(campus): clubs as a first-class model — Arc 4

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Image from "next/image";
+import { toast } from "react-toastify";
+import { Plus, Trash2, X } from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Select,
+  Textarea,
+} from "@klorad/design-system";
+import { uploadFile } from "@klorad/storage/client";
+import {
+  deriveInitials,
+  type Club,
+  type ClubColor,
+} from "@/lib/clubs-db";
+
+interface Props {
+  mapId: string;
+  initialClubs: Club[];
+}
+
+const COLORS: { value: ClubColor; label: string; swatch: string }[] = [
+  { value: "purple", label: "Purple", swatch: "#534AB7" },
+  { value: "coral", label: "Coral", swatch: "#D85A30" },
+  { value: "teal", label: "Teal", swatch: "#1D9E75" },
+  { value: "pink", label: "Pink", swatch: "#D4537E" },
+];
+
+/**
+ * Clubs admin client. List on the left (delete-only for Arc 4), an
+ * inline create form on the right. Initials auto-derive from the
+ * name unless the admin overrides them. The View button on the
+ * public site uses `externalLink`; if it's empty, the club still
+ * renders but the button is disabled.
+ */
+export function ClubsAdminClient({ mapId, initialClubs }: Props) {
+  const [clubs, setClubs] = useState<Club[]>(initialClubs);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [initialsOverride, setInitialsOverride] = useState("");
+  const [avatarColor, setAvatarColor] = useState<ClubColor>("purple");
+  const [memberCount, setMemberCount] = useState("");
+  const [meetsCadence, setMeetsCadence] = useState("");
+  const [externalLink, setExternalLink] = useState("");
+  const [popularityScore, setPopularityScore] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const previewInitials = (initialsOverride.trim() || deriveInitials(name)).slice(0, 3);
+
+  const handleImage = async (file: File) => {
+    setUploading(true);
+    try {
+      const result = await uploadFile(file, { prefix: "campus-news" });
+      setImageUrl(result.publicUrl);
+    } catch (e) {
+      console.error(e);
+      toast.error("Image upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const reset = () => {
+    setName("");
+    setDescription("");
+    setInitialsOverride("");
+    setAvatarColor("purple");
+    setMemberCount("");
+    setMeetsCadence("");
+    setExternalLink("");
+    setPopularityScore("");
+    setImageUrl(null);
+  };
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !description.trim()) {
+      toast.error("Name and description are required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/clubs`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim(),
+          initials: initialsOverride.trim() || undefined,
+          avatarColor,
+          memberCount: memberCount.trim()
+            ? Number.parseInt(memberCount, 10)
+            : 0,
+          popularityScore: popularityScore.trim()
+            ? Number.parseInt(popularityScore, 10)
+            : 0,
+          meetsCadence: meetsCadence.trim() || undefined,
+          externalLink: externalLink.trim() || undefined,
+          imageUrl,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? "Failed to publish");
+      }
+      const list = await fetch(`/api/maps/${mapId}/clubs`).then((r) =>
+        r.json(),
+      );
+      setClubs(list.clubs ?? []);
+      reset();
+      toast.success("Club published");
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Failed to publish");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm("Delete this club?")) return;
+    try {
+      const res = await fetch(`/api/clubs/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete");
+      setClubs((c) => c.filter((club) => club.id !== id));
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to delete");
+    }
+  };
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr]">
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          All clubs
+        </h2>
+        <p className="mt-1 text-xs text-text-tertiary">
+          {clubs.length} club{clubs.length === 1 ? "" : "s"}
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {clubs.length === 0 ? (
+            <p className="rounded-lg bg-surface-2 p-4 text-sm text-text-tertiary">
+              No clubs yet. Use the form to publish the first one.
+            </p>
+          ) : (
+            clubs.map((c) => {
+              const swatch =
+                COLORS.find((co) => co.value === c.avatarColor)?.swatch ??
+                "#534AB7";
+              return (
+                <article
+                  key={c.id}
+                  className="flex gap-3 rounded-lg border border-solid border-line-soft p-3"
+                >
+                  {c.imageUrl ? (
+                    <Image
+                      src={c.imageUrl}
+                      alt=""
+                      width={48}
+                      height={48}
+                      className="h-12 w-12 shrink-0 rounded-md object-cover"
+                    />
+                  ) : (
+                    <span
+                      aria-hidden
+                      className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md text-sm font-medium text-white"
+                      style={{ backgroundColor: swatch }}
+                    >
+                      {c.initials}
+                    </span>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <h3 className="truncate text-sm font-medium text-text-primary">
+                          {c.name}
+                        </h3>
+                        <p className="mt-0.5 text-[0.7rem] uppercase tracking-wide text-text-tertiary">
+                          {c.memberCount} members
+                          {c.meetsCadence ? ` · ${c.meetsCadence}` : ""}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => void onDelete(c.id)}
+                        aria-label="Delete"
+                        className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                      >
+                        <Trash2 size={14} strokeWidth={1.75} />
+                      </button>
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
+                      {c.description}
+                    </p>
+                  </div>
+                </article>
+              );
+            })
+          )}
+        </div>
+      </Panel>
+
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          New club
+        </h2>
+        <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
+          <Field label="Name">
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Data science society"
+              required
+            />
+          </Field>
+
+          <Field label="Description">
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What the club does."
+              rows={4}
+              required
+            />
+          </Field>
+
+          <div className="grid grid-cols-[auto_1fr] items-center gap-3">
+            <span
+              aria-hidden
+              className="flex h-10 w-10 items-center justify-center rounded-md text-sm font-medium text-white"
+              style={{
+                backgroundColor:
+                  COLORS.find((c) => c.value === avatarColor)?.swatch ??
+                  "#534AB7",
+              }}
+            >
+              {previewInitials}
+            </span>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Initials (auto)">
+                <Input
+                  value={initialsOverride}
+                  onChange={(e) => setInitialsOverride(e.target.value)}
+                  placeholder={deriveInitials(name) || "DS"}
+                  maxLength={3}
+                />
+              </Field>
+              <Field label="Avatar colour">
+                <Select
+                  value={avatarColor}
+                  onChange={(e) =>
+                    setAvatarColor(e.target.value as ClubColor)
+                  }
+                >
+                  {COLORS.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Members">
+              <Input
+                type="number"
+                min="0"
+                value={memberCount}
+                onChange={(e) => setMemberCount(e.target.value)}
+                placeholder="248"
+              />
+            </Field>
+            <Field label="Activity rank">
+              <Input
+                type="number"
+                value={popularityScore}
+                onChange={(e) => setPopularityScore(e.target.value)}
+                placeholder="0"
+              />
+            </Field>
+          </div>
+
+          <Field label="Meets">
+            <Input
+              value={meetsCadence}
+              onChange={(e) => setMeetsCadence(e.target.value)}
+              placeholder="Meets Wednesdays at 6 pm"
+            />
+          </Field>
+
+          <Field label="External link (Discord, Insta, group chat)">
+            <Input
+              type="url"
+              value={externalLink}
+              onChange={(e) => setExternalLink(e.target.value)}
+              placeholder="https://…"
+            />
+          </Field>
+
+          <Field label="Image (optional)">
+            {imageUrl ? (
+              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt=""
+                  className="h-16 w-16 rounded-md object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => setImageUrl(null)}
+                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
+                >
+                  <X size={14} strokeWidth={1.75} />
+                </button>
+              </div>
+            ) : (
+              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
+                <Plus size={16} strokeWidth={1.75} />
+                {uploading ? "Uploading…" : "Add image"}
+                <input
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  disabled={uploading}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleImage(file);
+                    e.target.value = "";
+                  }}
+                />
+              </label>
+            )}
+          </Field>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={reset}
+              disabled={submitting}
+            >
+              Reset
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Publishing…" : "Publish"}
+            </Button>
+          </div>
+        </form>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/page.tsx
@@ -1,0 +1,67 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { listClubsForAdmin } from "@/lib/clubs-db";
+import { ClubsAdminClient } from "./ClubsAdminClient";
+
+type Params = Promise<{ orgId: string; mapId: string }>;
+
+/**
+ * `/org/[orgId]/maps/[mapId]/clubs` — admin clubs authoring.
+ *
+ * Lists clubs (name asc) + an inline create form. Backed by the
+ * `Club` model from Arc 4 of [[campus-consumer-pivot]].
+ */
+export default async function ClubsAdminPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, mapId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/sign-in");
+
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+
+  const project = await prisma.project.findFirst({
+    where: { id: mapId, organizationId: orgId },
+    select: { id: true, title: true },
+  });
+  if (!project) notFound();
+
+  const clubs = await listClubsForAdmin(mapId);
+
+  return (
+    <div className="mx-auto max-w-[960px] px-6 py-10">
+      <Link
+        href={`/org/${orgId}/maps/${mapId}`}
+        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+      >
+        <ChevronLeft size={14} strokeWidth={1.75} />
+        Back to {project.title}
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-2xl font-semibold text-text-primary">Clubs</h1>
+        <p className="mt-1 text-sm text-text-tertiary">
+          Student societies, sport clubs, interest groups. The View
+          button on the consumer site opens the club&apos;s external
+          link — no login on the public site.
+        </p>
+      </div>
+
+      <ClubsAdminClient mapId={mapId} initialClubs={clubs} />
+    </div>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
@@ -1,0 +1,178 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft, ExternalLink, MapPin } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale } from "@/app/lib/i18n-core";
+import { getClub } from "@/lib/clubs-db";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string; id: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+const AVATAR_HEX: Record<string, string> = {
+  purple: "#534AB7",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token, id } = await params;
+  const [map, club] = await Promise.all([
+    getPublicCampusByToken(token),
+    getClub(id),
+  ]);
+  if (!club || !map || club.projectId !== map.id) return { title: "Club" };
+  return {
+    title: `${club.name} · Clubs`,
+    description: club.description.slice(0, 160),
+  };
+}
+
+/**
+ * `/campus/[token]/clubs/[id]` — public club detail.
+ *
+ * Avatar + name + meta (members, cadence), description, anchor
+ * chips (deep-link to map), View button → external link in a new
+ * tab. No identity, no tracking — see [[campus-consumer-pivot]].
+ */
+export default async function ClubDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token, id } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+  const club = await getClub(id);
+  if (!club || club.projectId !== map.id) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+  const avatarBg = AVATAR_HEX[club.avatarColor] ?? AVATAR_HEX.purple;
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <article className="mx-auto max-w-[760px] px-4 py-8 md:px-6 md:py-12">
+        <Link
+          href={`/campus/${token}${lang}`}
+          className="inline-flex items-center gap-1 text-sm text-[var(--brand-text-muted)] transition-colors hover:text-[var(--brand-primary)]"
+        >
+          <ChevronLeft size={16} strokeWidth={1.75} />
+          Back to {campusName}
+        </Link>
+
+        <div className="mt-6 flex items-center gap-4">
+          {club.imageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={club.imageUrl}
+              alt=""
+              className="h-16 w-16 rounded-2xl object-cover"
+            />
+          ) : (
+            <span
+              aria-hidden
+              className="flex h-16 w-16 items-center justify-center rounded-2xl text-xl font-medium text-white"
+              style={{ backgroundColor: avatarBg }}
+            >
+              {club.initials}
+            </span>
+          )}
+          <div>
+            <h1 className="text-2xl font-medium text-[var(--brand-text)] md:text-3xl">
+              {club.name}
+            </h1>
+            <p className="mt-1 text-sm text-[var(--brand-text-muted)]">
+              {club.memberCount} members
+              {club.meetsCadence ? ` · ${club.meetsCadence}` : ""}
+            </p>
+          </div>
+        </div>
+
+        {club.anchors.length > 0 ? (
+          <div className="mt-6 flex flex-wrap gap-2">
+            {club.anchors.map((a, i) =>
+              a.refId ? (
+                <Link
+                  key={`${a.refId}-${i}`}
+                  href={`${mapHref}&space=${encodeURIComponent(a.refId)}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
+                >
+                  <MapPin size={14} strokeWidth={1.75} />
+                  {a.refName}
+                </Link>
+              ) : (
+                <span
+                  key={`${a.refName}-${i}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]"
+                >
+                  <MapPin size={14} strokeWidth={1.75} />
+                  {a.refName}
+                </span>
+              ),
+            )}
+          </div>
+        ) : null}
+
+        <div className="mt-8 whitespace-pre-wrap text-base leading-relaxed text-[var(--brand-text)]">
+          {club.description}
+        </div>
+
+        {club.externalLink ? (
+          <div className="mt-8">
+            <a
+              href={club.externalLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+              style={{ backgroundColor: "var(--brand-primary)" }}
+            >
+              <ExternalLink size={16} strokeWidth={1.75} />
+              View on {new URL(club.externalLink).hostname.replace(/^www\./, "")}
+            </a>
+          </div>
+        ) : null}
+      </article>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -9,9 +9,14 @@ import {
   listUpcomingEventsForProject,
   type EventPost,
 } from "@/lib/events-db";
+import { listTopClubsForProject, type Club } from "@/lib/clubs-db";
 import NotPublishedPlaceholder from "./NotPublishedPlaceholder";
 import { ConsumerHome } from "@/lib/consumer/ConsumerHome";
-import type { ConsumerEvent, ConsumerNews } from "@/lib/consumer/types";
+import type {
+  ConsumerClub,
+  ConsumerEvent,
+  ConsumerNews,
+} from "@/lib/consumer/types";
 
 type Params = Promise<{ token: string }>;
 
@@ -106,13 +111,17 @@ export default async function CampusHomePage({
   // `NewsPost` or `EventPost` table is missing (operator hasn't run
   // `prisma migrate deploy` yet) the home renders with empty rails
   // + the sample-data fallback in `ConsumerHome` instead of 500ing.
-  const [dbPosts, dbEvents] = await Promise.all([
+  const [dbPosts, dbEvents, dbClubs] = await Promise.all([
     listNewsForProject(map.id).catch((err): NewsPost[] => {
       console.error("[public-home] news fetch failed", err);
       return [];
     }),
     listUpcomingEventsForProject(map.id, 12).catch((err): EventPost[] => {
       console.error("[public-home] events fetch failed", err);
+      return [];
+    }),
+    listTopClubsForProject(map.id, 6).catch((err): Club[] => {
+      console.error("[public-home] clubs fetch failed", err);
       return [];
     }),
   ]);
@@ -161,6 +170,20 @@ export default async function CampusHomePage({
     )
     .slice(0, 6);
 
+  // Club rows map 1:1 onto the consumer rail shape — `avatarColor`
+  // is the same union and the public rail honours an empty external
+  // link (View pill hides). Without externalLink, the consumer can
+  // still click through to the club's detail page in-app.
+  const clubs: ConsumerClub[] = dbClubs.map((c) => ({
+    id: c.id,
+    name: c.name,
+    initials: c.initials,
+    avatarColor: c.avatarColor,
+    memberCount: c.memberCount,
+    meetsCadence: c.meetsCadence ?? "",
+    externalLink: c.externalLink ?? "",
+  }));
+
   // EventPost rows map 1:1 onto the consumer card shape — the Prisma
   // enums (bannerColor / bannerIcon) match the ConsumerEvent unions.
   const events: ConsumerEvent[] = dbEvents.map((e) => ({
@@ -194,6 +217,7 @@ export default async function CampusHomePage({
       mapThumbnailUrl={map.thumbnail ?? undefined}
       news={news}
       events={events}
+      clubs={clubs}
     />
   );
 }

--- a/apps/campus/app/api/clubs/[id]/route.ts
+++ b/apps/campus/app/api/clubs/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ id: string }>;
+
+export async function DELETE(_req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const club = await prisma.club.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!club) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(club.organizationId, "write");
+  if (denied) return denied;
+  await prisma.club.delete({ where: { id } });
+  revalidateTag(publicCampusTag(club.projectId));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/app/api/maps/[mapId]/clubs/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/clubs/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { Prisma, type ClubColor } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import {
+  deriveInitials,
+  listClubsForAdmin,
+  type ClubAnchor,
+} from "@/lib/clubs-db";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ mapId: string }>;
+
+const VALID_COLORS: ClubColor[] = ["purple", "coral", "teal", "pink"];
+
+function parseAnchors(raw: unknown): ClubAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is ClubAnchor => !!a);
+}
+
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+  const clubs = await listClubsForAdmin(mapId);
+  return NextResponse.json({ clubs });
+}
+
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const description =
+    typeof body.description === "string" ? body.description.trim() : "";
+  if (!name || !description) {
+    return NextResponse.json(
+      { error: "name and description are required" },
+      { status: 400 },
+    );
+  }
+
+  const initials =
+    typeof body.initials === "string" && body.initials.trim().length > 0
+      ? body.initials.trim().slice(0, 3).toUpperCase()
+      : deriveInitials(name);
+
+  const avatarColor: ClubColor = VALID_COLORS.includes(
+    body.avatarColor as ClubColor,
+  )
+    ? (body.avatarColor as ClubColor)
+    : "purple";
+
+  const memberCount =
+    typeof body.memberCount === "number" && body.memberCount >= 0
+      ? Math.floor(body.memberCount)
+      : 0;
+  const popularityScore =
+    typeof body.popularityScore === "number" ? body.popularityScore : 0;
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const created = await prisma.club.create({
+    data: {
+      organizationId: project.organizationId,
+      projectId: mapId,
+      name,
+      description,
+      initials,
+      avatarColor,
+      memberCount,
+      popularityScore,
+      meetsCadence:
+        typeof body.meetsCadence === "string" &&
+        body.meetsCadence.trim().length > 0
+          ? body.meetsCadence.trim()
+          : null,
+      externalLink:
+        typeof body.externalLink === "string" &&
+        body.externalLink.trim().length > 0
+          ? body.externalLink.trim()
+          : null,
+      imageUrl:
+        typeof body.imageUrl === "string" && body.imageUrl.length > 0
+          ? body.imageUrl
+          : null,
+      anchors: parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  revalidateTag(publicCampusTag(mapId));
+  return NextResponse.json({ id: created.id });
+}

--- a/apps/campus/lib/clubs-db.ts
+++ b/apps/campus/lib/clubs-db.ts
@@ -1,0 +1,106 @@
+/**
+ * Student clubs — DB-backed (Arc 4 of [[campus-consumer-pivot]]).
+ *
+ * Per-Project club rows authored in the dashboard. Renders on the
+ * consumer home's "Most active clubs this week" rail (sorted by
+ * `popularityScore` desc, then `memberCount`). No tracking, no
+ * accounts — the View button opens an external link.
+ */
+import { prisma } from "@/lib/prisma";
+import type { Club as PrismaClub, ClubColor } from "@prisma/client";
+
+export type { ClubColor } from "@prisma/client";
+
+export interface ClubAnchor {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+export interface Club {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  initials: string;
+  avatarColor: ClubColor;
+  memberCount: number;
+  meetsCadence: string | null;
+  externalLink: string | null;
+  imageUrl: string | null;
+  popularityScore: number;
+  anchors: ClubAnchor[];
+}
+
+function parseAnchors(raw: unknown): ClubAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (a): a is ClubAnchor =>
+      !!a &&
+      typeof a === "object" &&
+      "refName" in a &&
+      typeof (a as { refName?: unknown }).refName === "string",
+  );
+}
+
+function fromPrisma(row: PrismaClub): Club {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    name: row.name,
+    description: row.description,
+    initials: row.initials,
+    avatarColor: row.avatarColor,
+    memberCount: row.memberCount,
+    meetsCadence: row.meetsCadence,
+    externalLink: row.externalLink,
+    imageUrl: row.imageUrl,
+    popularityScore: row.popularityScore,
+    anchors: parseAnchors(row.anchors),
+  };
+}
+
+/** Top N clubs for the consumer rail — popularityScore desc, then size. */
+export async function listTopClubsForProject(
+  projectId: string,
+  limit = 6,
+): Promise<Club[]> {
+  const rows = await prisma.club.findMany({
+    where: { projectId },
+    orderBy: [
+      { popularityScore: "desc" },
+      { memberCount: "desc" },
+      { name: "asc" },
+    ],
+    take: limit,
+  });
+  return rows.map(fromPrisma);
+}
+
+/** Admin view — everything by name asc. */
+export async function listClubsForAdmin(
+  projectId: string,
+): Promise<Club[]> {
+  const rows = await prisma.club.findMany({
+    where: { projectId },
+    orderBy: { name: "asc" },
+  });
+  return rows.map(fromPrisma);
+}
+
+export async function getClub(id: string): Promise<Club | null> {
+  const row = await prisma.club.findUnique({ where: { id } });
+  return row ? fromPrisma(row) : null;
+}
+
+/** "DS" from "Data Science Society". Two letters, uppercase. */
+export function deriveInitials(name: string): string {
+  const words = name
+    .replace(/[^\p{L}\s]/gu, "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length === 0) return "??";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}

--- a/apps/campus/lib/clubs-db.ts
+++ b/apps/campus/lib/clubs-db.ts
@@ -88,9 +88,20 @@ export async function listClubsForAdmin(
   return rows.map(fromPrisma);
 }
 
+/**
+ * Single club by id. Returns `null` both for "doesn't exist" and for
+ * "the runtime can't query yet" (pending migration / unregenerated
+ * client), so the detail page renders 404 instead of crashing. The
+ * error is logged so the deploy-time fix is still visible.
+ */
 export async function getClub(id: string): Promise<Club | null> {
-  const row = await prisma.club.findUnique({ where: { id } });
-  return row ? fromPrisma(row) : null;
+  try {
+    const row = await prisma.club.findUnique({ where: { id } });
+    return row ? fromPrisma(row) : null;
+  } catch (err) {
+    console.error("[clubs-db] getClub failed", err);
+    return null;
+  }
 }
 
 /** "DS" from "Data Science Society". Two letters, uppercase. */

--- a/apps/campus/lib/consumer/ClubRow.tsx
+++ b/apps/campus/lib/consumer/ClubRow.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { ConsumerClub } from "./types";
 
 const AVATAR_BG: Record<ConsumerClub["avatarColor"], string> = {
@@ -9,6 +10,13 @@ const AVATAR_BG: Record<ConsumerClub["avatarColor"], string> = {
 
 export interface ClubRowProps {
   club: ConsumerClub;
+  /**
+   * Optional detail-page URL. When set, the row's avatar + name area
+   * link to the in-app club detail; the View pill keeps opening the
+   * external link in a new tab. Without a detailHref, the name is
+   * static and only the View pill is interactive (Arc-1 behaviour).
+   */
+  detailHref?: string;
 }
 
 /**
@@ -16,10 +24,17 @@ export interface ClubRowProps {
  * with initials + name + member count + meets cadence on the left;
  * "View" pill on the right opens the club's external link in a new
  * tab. No identity / login involved — see [[campus-consumer-pivot]].
+ *
+ * When `detailHref` is set, the body links to the in-app detail
+ * page (Arc 4 onwards) while the View pill keeps pointing at the
+ * external link. When `externalLink` is empty, the pill is hidden.
  */
-export function ClubRow({ club }: ClubRowProps) {
-  return (
-    <div className="flex items-center gap-4 border-b border-[var(--brand-line)] py-3 last:border-b-0">
+export function ClubRow({ club, detailHref }: ClubRowProps) {
+  const bodyClass =
+    "flex min-w-0 flex-1 items-center gap-4 transition-opacity hover:opacity-80";
+
+  const body = (
+    <>
       <span
         aria-hidden
         className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-sm font-medium text-white"
@@ -27,23 +42,38 @@ export function ClubRow({ club }: ClubRowProps) {
       >
         {club.initials}
       </span>
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-[var(--brand-text)]">
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-medium text-[var(--brand-text)]">
           {club.name}
-        </div>
-        <div className="mt-0.5 text-xs text-[var(--brand-text-muted)]">
-          {club.memberCount} members · {club.meetsCadence}
-        </div>
-      </div>
-      <a
-        href={club.externalLink}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="shrink-0 rounded-full px-4 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
-        style={{ backgroundColor: "var(--brand-primary)" }}
-      >
-        View
-      </a>
+        </span>
+        <span className="mt-0.5 block text-xs text-[var(--brand-text-muted)]">
+          {club.memberCount} members
+          {club.meetsCadence ? ` · ${club.meetsCadence}` : ""}
+        </span>
+      </span>
+    </>
+  );
+
+  return (
+    <div className="flex items-center gap-3 border-b border-[var(--brand-line)] py-3 last:border-b-0">
+      {detailHref ? (
+        <Link href={detailHref} className={bodyClass}>
+          {body}
+        </Link>
+      ) : (
+        <div className={bodyClass}>{body}</div>
+      )}
+      {club.externalLink ? (
+        <a
+          href={club.externalLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 rounded-full px-4 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "var(--brand-primary)" }}
+        >
+          View
+        </a>
+      ) : null}
     </div>
   );
 }

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -12,7 +12,7 @@ import {
   SAMPLE_EVENTS,
   SAMPLE_NEWS,
 } from "../sample-campus";
-import type { ConsumerEvent, ConsumerNews } from "./types";
+import type { ConsumerClub, ConsumerEvent, ConsumerNews } from "./types";
 
 export interface ConsumerHomeProps {
   token: string;
@@ -34,6 +34,8 @@ export interface ConsumerHomeProps {
   news?: ConsumerNews[];
   /** Events for the "Happening this week" grid. Same fallback story. */
   events?: ConsumerEvent[];
+  /** Clubs for the "Most active this week" rail. Same fallback story. */
+  clubs?: ConsumerClub[];
 }
 
 /**
@@ -62,9 +64,11 @@ export function ConsumerHome({
   mapThumbnailUrl,
   news,
   events,
+  clubs,
 }: ConsumerHomeProps) {
   const newsItems = news?.length ? news : SAMPLE_NEWS;
   const eventItems = events?.length ? events : SAMPLE_EVENTS;
+  const clubItems = clubs?.length ? clubs : SAMPLE_CLUBS;
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
   // Per-org accent overrides the default purple at the wrapper, so
@@ -109,7 +113,7 @@ export function ConsumerHome({
           icon={Users}
           accent="pink"
           label="Browse clubs"
-          subtitle={`${SAMPLE_CLUBS.length}+ on campus`}
+          subtitle={`${clubItems.length}+ on campus`}
         />
         <QuickTile
           href={`/campus/${token}/events${lang}`}
@@ -144,8 +148,12 @@ export function ConsumerHome({
             Sorted by activity — no tracking
           </p>
           <div className="mt-4">
-            {SAMPLE_CLUBS.map((c) => (
-              <ClubRow key={c.id} club={c} />
+            {clubItems.slice(0, 4).map((c) => (
+              <ClubRow
+                key={c.id}
+                club={c}
+                detailHref={`/campus/${token}/clubs/${c.id}${lang}`}
+              />
             ))}
           </div>
         </div>

--- a/apps/campus/lib/events-db.ts
+++ b/apps/campus/lib/events-db.ts
@@ -90,9 +90,19 @@ export async function listEventsForAdmin(
   return rows.map(fromPrisma);
 }
 
+/**
+ * Single event by id. Returns `null` for "doesn't exist" and for a
+ * transient query failure so the detail page can 404 instead of
+ * 500.
+ */
 export async function getEventPost(id: string): Promise<EventPost | null> {
-  const row = await prisma.eventPost.findUnique({ where: { id } });
-  return row ? fromPrisma(row) : null;
+  try {
+    const row = await prisma.eventPost.findUnique({ where: { id } });
+    return row ? fromPrisma(row) : null;
+  } catch (err) {
+    console.error("[events-db] getEventPost failed", err);
+    return null;
+  }
 }
 
 /** "Tue 6:00 pm" — same compact format as the consumer rail. */

--- a/apps/campus/lib/news.ts
+++ b/apps/campus/lib/news.ts
@@ -99,10 +99,20 @@ export async function listNewsForAdmin(
   return rows.map(fromPrisma);
 }
 
-/** Single post by id — used by the public detail page. */
+/**
+ * Single post by id — used by the public detail page. Returns
+ * `null` both for "doesn't exist" and for a transient query failure
+ * (pending migration etc.) so the detail page can 404 instead of
+ * 500. The error is logged.
+ */
 export async function getNewsPost(id: string): Promise<NewsPost | null> {
-  const row = await prisma.newsPost.findUnique({ where: { id } });
-  return row ? fromPrisma(row) : null;
+  try {
+    const row = await prisma.newsPost.findUnique({ where: { id } });
+    return row ? fromPrisma(row) : null;
+  } catch (err) {
+    console.error("[news] getNewsPost failed", err);
+    return null;
+  }
 }
 
 /** Format a post's date for display. */

--- a/packages/prisma/migrations/20260526180000_add_club/migration.sql
+++ b/packages/prisma/migrations/20260526180000_add_club/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "ClubColor" AS ENUM ('purple', 'coral', 'teal', 'pink');
+
+-- CreateTable
+CREATE TABLE "Club" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "initials" TEXT NOT NULL,
+    "avatarColor" "ClubColor" NOT NULL DEFAULT 'purple',
+    "memberCount" INTEGER NOT NULL DEFAULT 0,
+    "meetsCadence" TEXT,
+    "externalLink" TEXT,
+    "imageUrl" TEXT,
+    "popularityScore" INTEGER NOT NULL DEFAULT 0,
+    "anchors" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Club_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Club_projectId_popularityScore_idx" ON "Club"("projectId", "popularityScore");
+
+-- CreateIndex
+CREATE INDEX "Club_organizationId_idx" ON "Club"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "Club" ADD CONSTRAINT "Club_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Club" ADD CONSTRAINT "Club_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -92,6 +92,7 @@ model Organization {
   cesiumAssets          CesiumAsset[]
   newsPosts             NewsPost[]
   eventPosts            EventPost[]
+  clubs                 Club[]
   plan                  Plan                   @relation(fields: [planCode], references: [code])
 
   @@index([planCode])
@@ -169,6 +170,8 @@ model Project {
   newsPosts    NewsPost[]
   // Campus events scoped to this project — see lib/events-db.ts.
   eventPosts   EventPost[]
+  // Student clubs scoped to this project — see lib/clubs-db.ts.
+  clubs        Club[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -472,4 +475,46 @@ enum EventIcon {
   trophy
   sprout
   calendar
+}
+
+/// Student club — Arc 4 of campus-consumer-pivot.
+/// Renders on the "Most active clubs this week" rail (sorted by
+/// popularityScore desc, then memberCount). Clubs are anonymous to
+/// the public site — no auth, no "join," just a View that opens an
+/// external link (Discord / Insta / group chat).
+model Club {
+  id              String     @id @default(cuid())
+  organizationId  String
+  projectId       String
+  name            String
+  description     String     @db.Text
+  /// Two-letter avatar, e.g. "DS" for Data Science Society.
+  initials        String
+  avatarColor     ClubColor  @default(purple)
+  memberCount     Int        @default(0)
+  /// Free-text frequency, "Meets Wednesdays at 6 pm."
+  meetsCadence    String?
+  /// External link the View button opens — Discord, Insta, etc.
+  externalLink    String?
+  imageUrl        String?
+  /// Admin-tunable rank for the "most active this week" sort. No
+  /// tracking; admin sets the number. Anonymous "interested" signals
+  /// in a phase-2 primitive could update this automatically.
+  popularityScore Int        @default(0)
+  anchors         Json       @default("[]")
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, popularityScore])
+  @@index([organizationId])
+}
+
+enum ClubColor {
+  purple
+  coral
+  teal
+  pink
 }


### PR DESCRIPTION
## What this is

Arc 4 of [[campus-consumer-pivot]] — mirrors Arcs 2 (news) + 3 (events) for student clubs. Promotes them from sample data to a real Prisma model with REST, an admin form, a public detail page with an external "View" CTA, and wires the consumer home's clubs rail to real rows.

## What's on the page

- `/org/[orgId]/maps/[mapId]/clubs` — admin page. List on the left (avatar / name / members / cadence / delete), inline create form on the right (name, description, initials override, avatar colour, members, activity rank, meets cadence, external link, image). Live avatar preview shows the colour + initials before save.
- `/campus/[token]/clubs/[id]` — public club detail. Avatar / image, name, meta, anchor chips (deep-link into MappedIn), description, **"View on `<hostname>`"** CTA opening the external link in a new tab. Token + id cross-checked.
- Consumer home's "Most active clubs this week" rail now reads real `Club` rows (top 6 by `popularityScore` desc, then memberCount). Quick tile's "X on campus" uses the real count. Row body now links to the detail page; the View pill keeps opening the external link.

## Schema

```prisma
model Club {
  id              String     @id @default(cuid())
  organizationId  String
  projectId       String
  name            String
  description     String     @db.Text
  initials        String
  avatarColor     ClubColor  @default(purple)
  memberCount     Int        @default(0)
  meetsCadence    String?
  externalLink    String?
  imageUrl        String?
  popularityScore Int        @default(0)
  anchors         Json       @default("[]")
  …
  @@index([projectId, popularityScore])
  @@index([organizationId])
}
enum ClubColor { purple coral teal pink }
```

Migration: `20260526180000_add_club`.

`popularityScore` is admin-tunable (no tracking). A phase-2 anonymous "interested" primitive could update it automatically without crossing the privacy line.

## API

| Verb | Path | Notes |
|---|---|---|
| GET | `/api/maps/[mapId]/clubs` | admin list (alphabetical) |
| POST | `/api/maps/[mapId]/clubs` | create — initials auto-derive if not overridden |
| DELETE | `/api/clubs/[id]` | resolves org from the row, write access required |

Each write bumps `revalidateTag(publicCampusTag(mapId))`.

## Hardening

- Home reads guard `listTopClubsForProject(...)` with the same `.catch()` story as news + events: empty list on transient failure, sample seed fills in on the consumer side.
- `getNewsPost` / `getEventPost` / `getClub` now wrap their Prisma calls in `try / catch` so a missing migration or an unregenerated client returns `null` → `notFound()` on the detail page instead of a runtime crash.

## Operator note (real fix)

When pulling this branch:

```bash
pnpm install                  # postinstall regenerates Prisma client
pnpm prisma migrate deploy    # applies 20260526180000_add_club
# restart dev server
```

The `try/catch` above is a safety net; the migration + client regeneration is what actually makes clubs work.

## Out of scope (follow-ups)

- Edit endpoint (delete works).
- Anchor picker over `mapData.search` — free text today.
- A dedicated `campus-clubs` Spaces prefix (reuses `campus-news`).
- "Org-level" clubs that span multiple campus maps (per-Project today).

## Testing

`tsc --noEmit` clean. `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)