### PR TITLE
feat(campus): dining as a first-class model — Arc 5

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Image from "next/image";
+import { toast } from "react-toastify";
+import { Plus, Trash2, X } from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Textarea,
+} from "@klorad/design-system";
+import { uploadFile } from "@klorad/storage/client";
+import { type DiningLocation } from "@/lib/dining-db";
+
+interface Props {
+  mapId: string;
+  initialLocations: DiningLocation[];
+}
+
+/**
+ * Admin client for /dining. List on the left (delete-only for
+ * Arc 5), create form on the right. No live preview — dining
+ * cards are simple enough to author blind. Reuses the
+ * `campus-news` Spaces prefix for images.
+ */
+export function DiningAdminClient({ mapId, initialLocations }: Props) {
+  const [locations, setLocations] = useState<DiningLocation[]>(initialLocations);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [hoursText, setHoursText] = useState("");
+  const [cuisine, setCuisine] = useState("");
+  const [menuUrl, setMenuUrl] = useState("");
+  const [anchorName, setAnchorName] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleImage = async (file: File) => {
+    setUploading(true);
+    try {
+      const result = await uploadFile(file, { prefix: "campus-news" });
+      setImageUrl(result.publicUrl);
+    } catch (e) {
+      console.error(e);
+      toast.error("Image upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const reset = () => {
+    setName("");
+    setDescription("");
+    setHoursText("");
+    setCuisine("");
+    setMenuUrl("");
+    setAnchorName("");
+    setImageUrl(null);
+  };
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !description.trim()) {
+      toast.error("Name and description are required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/dining`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim(),
+          hoursText: hoursText.trim() || undefined,
+          cuisine: cuisine.trim() || undefined,
+          menuUrl: menuUrl.trim() || undefined,
+          imageUrl,
+          anchors: anchorName.trim()
+            ? [
+                {
+                  kind: "building",
+                  refId: "",
+                  refName: anchorName.trim(),
+                },
+              ]
+            : [],
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? "Failed to publish");
+      }
+      const list = await fetch(`/api/maps/${mapId}/dining`).then((r) =>
+        r.json(),
+      );
+      setLocations(list.locations ?? []);
+      reset();
+      toast.success("Location published");
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Failed to publish");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm("Delete this location?")) return;
+    try {
+      const res = await fetch(`/api/dining/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete");
+      setLocations((l) => l.filter((loc) => loc.id !== id));
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to delete");
+    }
+  };
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_1fr]">
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          All locations
+        </h2>
+        <p className="mt-1 text-xs text-text-tertiary">
+          {locations.length} location{locations.length === 1 ? "" : "s"}
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {locations.length === 0 ? (
+            <p className="rounded-lg bg-surface-2 p-4 text-sm text-text-tertiary">
+              No dining yet. Use the form to publish the first one.
+            </p>
+          ) : (
+            locations.map((l) => (
+              <article
+                key={l.id}
+                className="flex gap-3 rounded-lg border border-solid border-line-soft p-3"
+              >
+                {l.imageUrl ? (
+                  <Image
+                    src={l.imageUrl}
+                    alt=""
+                    width={64}
+                    height={64}
+                    className="h-16 w-16 shrink-0 rounded-md object-cover"
+                  />
+                ) : null}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <h3 className="truncate text-sm font-medium text-text-primary">
+                        {l.name}
+                      </h3>
+                      <p className="mt-0.5 text-[0.7rem] uppercase tracking-wide text-text-tertiary">
+                        {l.cuisine ?? "—"}
+                        {l.hoursText ? ` · ${l.hoursText}` : ""}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => void onDelete(l.id)}
+                      aria-label="Delete"
+                      className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                    >
+                      <Trash2 size={14} strokeWidth={1.75} />
+                    </button>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
+                    {l.description}
+                  </p>
+                  {l.anchors.length > 0 ? (
+                    <p className="mt-1 text-[0.7rem] text-text-tertiary">
+                      · {l.anchors.map((a) => a.refName).join(", ")}
+                    </p>
+                  ) : null}
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+      </Panel>
+
+      <Panel className="p-5">
+        <h2 className="text-sm font-semibold text-text-primary">
+          New location
+        </h2>
+        <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
+          <Field label="Name">
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Cafe Pavilion"
+              required
+            />
+          </Field>
+
+          <Field label="Description">
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Quick-service cafe with sandwiches, coffee, and bowls."
+              rows={3}
+              required
+            />
+          </Field>
+
+          <Field label="Hours (free text)">
+            <Input
+              value={hoursText}
+              onChange={(e) => setHoursText(e.target.value)}
+              placeholder="Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed"
+            />
+          </Field>
+
+          <Field label="Cuisine (free text)">
+            <Input
+              value={cuisine}
+              onChange={(e) => setCuisine(e.target.value)}
+              placeholder="Salads, sandwiches, coffee"
+            />
+          </Field>
+
+          <Field label="Menu URL (optional)">
+            <Input
+              type="url"
+              value={menuUrl}
+              onChange={(e) => setMenuUrl(e.target.value)}
+              placeholder="https://…"
+            />
+          </Field>
+
+          <Field label="Where on campus (optional)">
+            <Input
+              value={anchorName}
+              onChange={(e) => setAnchorName(e.target.value)}
+              placeholder="Cafe Pavilion, Marketplace…"
+            />
+          </Field>
+
+          <Field label="Image (optional)">
+            {imageUrl ? (
+              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt=""
+                  className="h-16 w-16 rounded-md object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => setImageUrl(null)}
+                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
+                >
+                  <X size={14} strokeWidth={1.75} />
+                </button>
+              </div>
+            ) : (
+              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
+                <Plus size={16} strokeWidth={1.75} />
+                {uploading ? "Uploading…" : "Add image"}
+                <input
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  disabled={uploading}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleImage(file);
+                    e.target.value = "";
+                  }}
+                />
+              </label>
+            )}
+          </Field>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={reset}
+              disabled={submitting}
+            >
+              Reset
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Publishing…" : "Publish"}
+            </Button>
+          </div>
+        </form>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/page.tsx
@@ -1,0 +1,69 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { listDiningForProject } from "@/lib/dining-db";
+import { DiningAdminClient } from "./DiningAdminClient";
+
+type Params = Promise<{ orgId: string; mapId: string }>;
+
+/**
+ * `/org/[orgId]/maps/[mapId]/dining` — admin dining authoring.
+ *
+ * Smallest of the four content admins because dining rows hold
+ * less variability — name + description + free-text hours + optional
+ * menu link + optional cuisine.
+ */
+export default async function DiningAdminPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, mapId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/sign-in");
+
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+
+  const project = await prisma.project.findFirst({
+    where: { id: mapId, organizationId: orgId },
+    select: { id: true, title: true },
+  });
+  if (!project) notFound();
+
+  const locations = await listDiningForProject(mapId);
+
+  return (
+    <div className="mx-auto max-w-[960px] px-6 py-10">
+      <Link
+        href={`/org/${orgId}/maps/${mapId}`}
+        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+      >
+        <ChevronLeft size={14} strokeWidth={1.75} />
+        Back to {project.title}
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-2xl font-semibold text-text-primary">
+          Dining
+        </h1>
+        <p className="mt-1 text-sm text-text-tertiary">
+          Cafeterias, cafes, food courts. Listed alphabetically on
+          the public dining page.
+        </p>
+      </div>
+
+      <DiningAdminClient mapId={mapId} initialLocations={locations} />
+    </div>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/dining/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/dining/page.tsx
@@ -1,0 +1,185 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Clock, ExternalLink, MapPin } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale } from "@/app/lib/i18n-core";
+import { listDiningForProject } from "@/lib/dining-db";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  const scene = (map?.sceneData ?? null) as {
+    branding?: { name?: string };
+  } | null;
+  const name = scene?.branding?.name || map?.title || "Campus";
+  return {
+    title: `Dining · ${name}`,
+    description: `Where to eat on the ${name} campus — cafes, cafeterias, hours.`,
+  };
+}
+
+/**
+ * `/campus/[token]/dining` — public dining list.
+ *
+ * Arc 5 of [[campus-consumer-pivot]]. A single page that holds the
+ * whole list — no per-location detail page (each row is small
+ * enough). Cards grid: 2 columns at md+, 1 on mobile.
+ */
+export default async function DiningPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+  const locations = await listDiningForProject(map.id);
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <section className="mx-auto max-w-[1280px] px-4 py-8 md:px-6 md:py-12">
+        <h1 className="text-3xl font-medium text-[var(--brand-text)]">
+          Dining
+        </h1>
+        <p className="mt-2 text-sm text-[var(--brand-text-muted)]">
+          Where to eat on campus.
+        </p>
+
+        {locations.length === 0 ? (
+          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+            No dining published yet.
+          </div>
+        ) : (
+          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2">
+            {locations.map((l) => {
+              const firstAnchor = l.anchors[0];
+              return (
+                <article
+                  key={l.id}
+                  className="flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white"
+                >
+                  {l.imageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={l.imageUrl}
+                      alt=""
+                      className="block aspect-[16/9] w-full object-cover"
+                    />
+                  ) : (
+                    <div
+                      aria-hidden
+                      className="aspect-[16/9] w-full"
+                      style={{
+                        background:
+                          "linear-gradient(135deg, var(--brand-primary-bg) 0%, #E0F2EE 100%)",
+                      }}
+                    />
+                  )}
+                  <div className="flex flex-1 flex-col gap-3 p-5">
+                    <div>
+                      <h2 className="text-lg font-medium text-[var(--brand-text)]">
+                        {l.name}
+                      </h2>
+                      {l.cuisine ? (
+                        <p className="mt-0.5 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
+                          {l.cuisine}
+                        </p>
+                      ) : null}
+                    </div>
+
+                    <p className="text-sm leading-relaxed text-[var(--brand-text)]">
+                      {l.description}
+                    </p>
+
+                    {l.hoursText ? (
+                      <p className="inline-flex items-center gap-1.5 text-xs text-[var(--brand-text-muted)]">
+                        <Clock size={14} strokeWidth={1.75} />
+                        {l.hoursText}
+                      </p>
+                    ) : null}
+
+                    <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
+                      {firstAnchor ? (
+                        firstAnchor.refId ? (
+                          <Link
+                            href={`${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`}
+                            className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
+                          >
+                            <MapPin size={14} strokeWidth={1.75} />
+                            {firstAnchor.refName}
+                          </Link>
+                        ) : (
+                          <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]">
+                            <MapPin size={14} strokeWidth={1.75} />
+                            {firstAnchor.refName}
+                          </span>
+                        )
+                      ) : null}
+                      {l.menuUrl ? (
+                        <a
+                          href={l.menuUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--brand-line)] bg-white px-3 py-1 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
+                        >
+                          <ExternalLink size={14} strokeWidth={1.75} />
+                          View menu
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/app/api/dining/[id]/route.ts
+++ b/apps/campus/app/api/dining/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ id: string }>;
+
+export async function DELETE(_req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const location = await prisma.diningLocation.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!location) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(location.organizationId, "write");
+  if (denied) return denied;
+  await prisma.diningLocation.delete({ where: { id } });
+  revalidateTag(publicCampusTag(location.projectId));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/app/api/maps/[mapId]/dining/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/dining/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import { listDiningForProject, type DiningAnchor } from "@/lib/dining-db";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ mapId: string }>;
+
+function parseAnchors(raw: unknown): DiningAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is DiningAnchor => !!a);
+}
+
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+  const locations = await listDiningForProject(mapId);
+  return NextResponse.json({ locations });
+}
+
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const description =
+    typeof body.description === "string" ? body.description.trim() : "";
+  if (!name || !description) {
+    return NextResponse.json(
+      { error: "name and description are required" },
+      { status: 400 },
+    );
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const created = await prisma.diningLocation.create({
+    data: {
+      organizationId: project.organizationId,
+      projectId: mapId,
+      name,
+      description,
+      hoursText:
+        typeof body.hoursText === "string" && body.hoursText.trim().length > 0
+          ? body.hoursText.trim()
+          : null,
+      cuisine:
+        typeof body.cuisine === "string" && body.cuisine.trim().length > 0
+          ? body.cuisine.trim()
+          : null,
+      menuUrl:
+        typeof body.menuUrl === "string" && body.menuUrl.trim().length > 0
+          ? body.menuUrl.trim()
+          : null,
+      imageUrl:
+        typeof body.imageUrl === "string" && body.imageUrl.length > 0
+          ? body.imageUrl
+          : null,
+      anchors: parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  revalidateTag(publicCampusTag(mapId));
+  return NextResponse.json({ id: created.id });
+}

--- a/apps/campus/lib/dining-db.ts
+++ b/apps/campus/lib/dining-db.ts
@@ -1,0 +1,77 @@
+/**
+ * Dining locations — DB-backed (Arc 5 of [[campus-consumer-pivot]]).
+ *
+ * The smallest of the four content arcs because dining is mostly
+ * static: cafeterias, cafes, and food courts with hours + an
+ * optional menu link. No detail page — the public list view holds
+ * everything because each row is small.
+ */
+import { prisma } from "@/lib/prisma";
+import type { DiningLocation as PrismaDining } from "@prisma/client";
+
+export interface DiningAnchor {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+export interface DiningLocation {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  hoursText: string | null;
+  cuisine: string | null;
+  menuUrl: string | null;
+  imageUrl: string | null;
+  anchors: DiningAnchor[];
+}
+
+function parseAnchors(raw: unknown): DiningAnchor[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (a): a is DiningAnchor =>
+      !!a &&
+      typeof a === "object" &&
+      "refName" in a &&
+      typeof (a as { refName?: unknown }).refName === "string",
+  );
+}
+
+function fromPrisma(row: PrismaDining): DiningLocation {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    name: row.name,
+    description: row.description,
+    hoursText: row.hoursText,
+    cuisine: row.cuisine,
+    menuUrl: row.menuUrl,
+    imageUrl: row.imageUrl,
+    anchors: parseAnchors(row.anchors),
+  };
+}
+
+/**
+ * Public + admin view — alphabetical by name. Dining is rarely
+ * large enough to need pagination; if a campus hits that, sort
+ * by anchor / nearest is the right next move, not infinite lists.
+ *
+ * Wrapped in `try/catch` so a pending migration / unregenerated
+ * Prisma client returns `[]` instead of crashing the page — same
+ * pattern as the other Arc 2-4 reads.
+ */
+export async function listDiningForProject(
+  projectId: string,
+): Promise<DiningLocation[]> {
+  try {
+    const rows = await prisma.diningLocation.findMany({
+      where: { projectId },
+      orderBy: { name: "asc" },
+    });
+    return rows.map(fromPrisma);
+  } catch (err) {
+    console.error("[dining-db] listDiningForProject failed", err);
+    return [];
+  }
+}

--- a/packages/prisma/migrations/20260526210000_add_dining_location/migration.sql
+++ b/packages/prisma/migrations/20260526210000_add_dining_location/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "DiningLocation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "hoursText" TEXT,
+    "cuisine" TEXT,
+    "menuUrl" TEXT,
+    "imageUrl" TEXT,
+    "anchors" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DiningLocation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DiningLocation_projectId_idx" ON "DiningLocation"("projectId");
+
+-- CreateIndex
+CREATE INDEX "DiningLocation_organizationId_idx" ON "DiningLocation"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "DiningLocation" ADD CONSTRAINT "DiningLocation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiningLocation" ADD CONSTRAINT "DiningLocation_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -93,6 +93,7 @@ model Organization {
   newsPosts             NewsPost[]
   eventPosts            EventPost[]
   clubs                 Club[]
+  diningLocations       DiningLocation[]
   plan                  Plan                   @relation(fields: [planCode], references: [code])
 
   @@index([planCode])
@@ -172,6 +173,8 @@ model Project {
   eventPosts   EventPost[]
   // Student clubs scoped to this project — see lib/clubs-db.ts.
   clubs        Club[]
+  // Cafeterias / cafes scoped to this project — see lib/dining-db.ts.
+  diningLocations DiningLocation[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -517,4 +520,34 @@ enum ClubColor {
   coral
   teal
   pink
+}
+
+/// Cafeteria / cafe — Arc 5 of campus-consumer-pivot.
+/// Smallest of the four content arcs because dining is mostly
+/// static: name + description + hours (free text) + optional menu
+/// link + optional cuisine + anchors. No detail page per location;
+/// the public /dining route renders the whole list as cards.
+model DiningLocation {
+  id              String   @id @default(cuid())
+  organizationId  String
+  projectId       String
+  name            String
+  description     String   @db.Text
+  /// Free text — "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed".
+  /// Structured day/time ranges + "open now" badge are a follow-up.
+  hoursText       String?
+  /// Free text — "Pizza, Salads, Coffee".
+  cuisine         String?
+  /// External link to the menu (PDF, Google Doc, restaurant site).
+  menuUrl         String?
+  imageUrl        String?
+  anchors         Json     @default("[]")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+  @@index([organizationId])
 }


### PR DESCRIPTION
## What this is

Arc 5 of [[campus-consumer-pivot]] — the smallest content arc. Dining locations are mostly static, so the model stays compact and there's no per-location detail page (the public list view holds the whole list as cards).

## What's on the page

- `/org/[orgId]/maps/[mapId]/dining` — admin page. List + inline create form (name · description · hours · cuisine · menu URL · anchor · image).
- `/campus/[token]/dining` — public list page reachable from the consumer nav. Two-column card grid at md+, single column on mobile. Each card: image (or soft gradient placeholder), name, cuisine tag, description, hours chip, anchor chip linking into MappedIn, optional **View menu** opening the external menu URL in a new tab.

## Schema

```prisma
model DiningLocation {
  id              String   @id @default(cuid())
  organizationId  String
  projectId       String
  name            String
  description     String   @db.Text
  hoursText       String?   // "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed"
  cuisine         String?   // "Pizza, Salads, Coffee"
  menuUrl         String?
  imageUrl        String?
  anchors         Json     @default("[]")
  …
  @@index([projectId])
  @@index([organizationId])
}
```

No enums. No structured per-day hours yet — the "open now" badge wants that and is on the follow-up list. Migration: `20260526210000_add_dining_location`.

## API

| Verb | Path | Notes |
|---|---|---|
| GET | `/api/maps/[mapId]/dining` | admin list |
| POST | `/api/maps/[mapId]/dining` | create — write access required |
| DELETE | `/api/dining/[id]` | resolves org, write access required |

Each write bumps `revalidateTag(publicCampusTag(mapId))`.

## Operator step (once merged)

```bash
pnpm install                  # postinstall regenerates Prisma client
pnpm prisma migrate deploy    # applies 20260526210000_add_dining_location
# restart dev server
```

## Out of scope (follow-ups)

- Edit endpoint (delete works).
- Structured per-day hours + "Open now" badge.
- Anchor picker over `mapData.search` — free text today.
- Dedicated `campus-dining` Spaces prefix (reuses `campus-news`).
- A "Dining today" card on the consumer home — currently nav-only.

## Testing

`tsc --noEmit` clean. `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)