### PR TITLE
feat(campus): onboarding + "Try with sample data" — Arc 7

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/OnboardingClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/OnboardingClient.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { ArrowRight, Check, Palette, Sparkles, Map as MapIcon } from "lucide-react";
+import { Button, Panel } from "@klorad/design-system";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+  alreadySeeded: boolean;
+  hasBranding: boolean;
+  hasIndoorMap: boolean;
+  isPublished: boolean;
+}
+
+/**
+ * Three launcher cards. Each renders a small status pill ("done" or
+ * a CTA) and links into the matching admin surface — the existing
+ * Settings tab handles branding, the Indoor tab handles MappedIn,
+ * and Try with sample data POSTs to /api/maps/[mapId]/seed-sample.
+ */
+export function OnboardingClient({
+  orgId,
+  mapId,
+  alreadySeeded,
+  hasBranding,
+  hasIndoorMap,
+  isPublished,
+}: Props) {
+  const router = useRouter();
+  const [seeding, setSeeding] = useState(false);
+
+  const seed = async () => {
+    if (alreadySeeded || seeding) return;
+    setSeeding(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/seed-sample`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Seed failed");
+      }
+      const body = await res.json();
+      const counts = body.counts ?? {};
+      toast.success(
+        `Seeded ${counts.news ?? 0} news, ${counts.events ?? 0} events, ${
+          counts.clubs ?? 0
+        } clubs, ${counts.dining ?? 0} dining.`,
+      );
+      router.refresh();
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Seed failed");
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-3">
+      <StepCard
+        title="Try with sample data"
+        body="Drops a believable starter set — 4 news, 3 events, 4 clubs, 3 dining — into this campus so the public page isn't empty."
+        icon={<Sparkles size={20} strokeWidth={1.75} />}
+        accent="purple"
+        done={alreadySeeded}
+        doneLabel="Content present"
+      >
+        <Button
+          type="button"
+          onClick={() => void seed()}
+          disabled={alreadySeeded || seeding}
+        >
+          {alreadySeeded
+            ? "Already populated"
+            : seeding
+              ? "Seeding…"
+              : "Add sample data"}
+        </Button>
+      </StepCard>
+
+      <StepCard
+        title="Brand the campus"
+        body="Name, logo, accent colour. The public site picks these up immediately — the consumer purple turns into your primary."
+        icon={<Palette size={20} strokeWidth={1.75} />}
+        accent="coral"
+        done={hasBranding}
+        doneLabel="Branding set"
+      >
+        <Link
+          href={`/org/${orgId}/maps/${mapId}?tab=settings`}
+          className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
+        >
+          Open settings
+          <ArrowRight size={14} strokeWidth={1.75} />
+        </Link>
+      </StepCard>
+
+      <StepCard
+        title="Connect MappedIn"
+        body="Plug in the MappedIn venue id and the 3D map lights up for visitors — search, wayfinding, anchor chips all start working."
+        icon={<MapIcon size={20} strokeWidth={1.75} />}
+        accent="teal"
+        done={hasIndoorMap}
+        doneLabel="MappedIn linked"
+      >
+        <Link
+          href={`/org/${orgId}/maps/${mapId}?tab=indoor`}
+          className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
+        >
+          Open Indoor
+          <ArrowRight size={14} strokeWidth={1.75} />
+        </Link>
+      </StepCard>
+
+      <Panel className="md:col-span-3 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-text-primary">
+              Publish when you’re ready
+            </p>
+            <p className="mt-0.5 text-xs text-text-tertiary">
+              {isPublished
+                ? "This campus is live. Edits go out immediately."
+                : "The campus is still a draft. Publish from the Settings tab when you’re ready to share."}
+            </p>
+          </div>
+          <Link
+            href={`/org/${orgId}/maps/${mapId}?tab=settings`}
+            className="inline-flex items-center gap-1.5 rounded-full border border-solid border-line-soft bg-surface-1 px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent"
+          >
+            {isPublished ? "Manage publishing" : "Publish"}
+            <ArrowRight size={14} strokeWidth={1.75} />
+          </Link>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+interface StepCardProps {
+  title: string;
+  body: string;
+  icon: React.ReactNode;
+  /** Drives the colored chip on the icon. Matches the consumer palette. */
+  accent: "purple" | "coral" | "teal" | "pink";
+  done: boolean;
+  doneLabel: string;
+  children: React.ReactNode;
+}
+
+const ACCENT_HEX: Record<StepCardProps["accent"], string> = {
+  purple: "#534AB7",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+function StepCard({
+  title,
+  body,
+  icon,
+  accent,
+  done,
+  doneLabel,
+  children,
+}: StepCardProps) {
+  return (
+    <Panel className="flex flex-col gap-3 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <span
+          aria-hidden
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-white"
+          style={{ backgroundColor: ACCENT_HEX[accent] }}
+        >
+          {icon}
+        </span>
+        {done ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-accent-soft px-2.5 py-1 text-[0.7rem] font-medium text-accent">
+            <Check size={12} strokeWidth={2} />
+            {doneLabel}
+          </span>
+        ) : null}
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+        <p className="mt-1 text-xs leading-relaxed text-text-secondary">
+          {body}
+        </p>
+      </div>
+      <div className="mt-auto pt-2">{children}</div>
+    </Panel>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/page.tsx
@@ -1,0 +1,100 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { projectHasContent } from "@/lib/sample-seed";
+import { OnboardingClient } from "./OnboardingClient";
+
+type Params = Promise<{ orgId: string; mapId: string }>;
+
+/**
+ * `/org/[orgId]/maps/[mapId]/onboarding` — first-run wizard.
+ *
+ * Arc 7 of [[campus-consumer-pivot]]. Three-card hub that closes the
+ * "rector signs up and nothing's there" gap:
+ *
+ *  - "Try with sample data" — POSTs to `/api/maps/[mapId]/seed-sample`
+ *    so the public campus immediately has news / events / clubs /
+ *    dining to look at. Disabled when the project already has
+ *    content (the server endpoint also enforces this).
+ *  - "Brand the campus" — deep-links to the existing Settings tab.
+ *  - "Connect MappedIn" — deep-links to the existing Indoor tab.
+ *
+ * No intermediate state, no persisted progress — the page is just a
+ * launcher. If the user wants more onboarding, they can walk through
+ * each tab in their own time.
+ */
+export default async function OnboardingPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, mapId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/sign-in");
+
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+
+  const project = await prisma.project.findFirst({
+    where: { id: mapId, organizationId: orgId },
+    select: {
+      id: true,
+      title: true,
+      sceneData: true,
+      thumbnail: true,
+      isPublished: true,
+    },
+  });
+  if (!project) notFound();
+
+  const alreadySeeded = await projectHasContent(mapId);
+  const scene = (project.sceneData ?? {}) as {
+    branding?: { name?: string; logo?: string; primaryColor?: string };
+    indoorMapId?: string;
+  };
+  const hasBranding = Boolean(
+    scene.branding?.name || scene.branding?.logo || scene.branding?.primaryColor,
+  );
+  const hasIndoorMap = Boolean(scene.indoorMapId);
+
+  return (
+    <div className="mx-auto max-w-[960px] px-6 py-10">
+      <Link
+        href={`/org/${orgId}/maps/${mapId}`}
+        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
+      >
+        <ChevronLeft size={14} strokeWidth={1.75} />
+        Back to {project.title}
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-2xl font-semibold text-text-primary">
+          Welcome to {project.title}
+        </h1>
+        <p className="mt-1 text-sm text-text-tertiary">
+          Three quick steps to a campus students will actually open.
+          Do them in any order; everything can be changed later.
+        </p>
+      </div>
+
+      <OnboardingClient
+        orgId={orgId}
+        mapId={mapId}
+        alreadySeeded={alreadySeeded}
+        hasBranding={hasBranding}
+        hasIndoorMap={hasIndoorMap}
+        isPublished={project.isPublished}
+      />
+    </div>
+  );
+}

--- a/apps/campus/app/api/maps/[mapId]/seed-sample/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/seed-sample/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import {
+  projectHasContent,
+  seedSampleCampus,
+} from "@/lib/sample-seed";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * POST /api/maps/[mapId]/seed-sample
+ *
+ * Writes a starter set of news + events + clubs + dining into this
+ * project so a fresh campus doesn't open onto empty rails. Refuses
+ * to seed twice — checks `projectHasContent(projectId)` first and
+ * 409s if the project already has anything; callers wanting to
+ * re-seed are responsible for deleting the existing rows.
+ */
+export async function POST(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  if (await projectHasContent(mapId)) {
+    return NextResponse.json(
+      {
+        error:
+          "This campus already has content — delete the existing news / events / clubs / dining before re-seeding.",
+      },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const counts = await seedSampleCampus(mapId, project.organizationId);
+    revalidateTag(publicCampusTag(mapId));
+    return NextResponse.json({ ok: true, counts });
+  } catch (err) {
+    console.error("[seed-sample] failed", err);
+    return NextResponse.json(
+      { error: "Failed to seed sample data" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/campus/lib/sample-seed.ts
+++ b/apps/campus/lib/sample-seed.ts
@@ -1,0 +1,319 @@
+/**
+ * Sample-campus seed — DB shape (Arc 7 of [[campus-consumer-pivot]]).
+ *
+ * Companion to `lib/sample-campus.ts` (which is the *consumer-shape*
+ * sample used for empty-state fallback on the public home). This
+ * file holds the equivalent records shaped to the Prisma models we
+ * built in Arcs 2-5, so `POST /api/maps/[mapId]/seed-sample` can
+ * write a believable starter set into a fresh campus in one click.
+ *
+ * Kept deliberately small (4 news · 3 events · 4 clubs · 3 dining).
+ * The point is to show that the rails render, not to fake a real
+ * campus.
+ */
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import type {
+  ClubColor,
+  EventBanner,
+  EventIcon,
+  NewsCategory,
+} from "@prisma/client";
+
+interface SeedAnchor {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+interface SeedNews {
+  title: string;
+  body: string;
+  category: NewsCategory;
+  /** Days ago — turned into a real Date relative to now() at write time. */
+  publishedDaysAgo: number;
+  anchors: SeedAnchor[];
+}
+
+interface SeedEvent {
+  title: string;
+  description: string;
+  /** Days from now (positive = future). */
+  startsInDays: number;
+  /** Duration of the event in hours. */
+  durationHours: number;
+  bannerColor: EventBanner;
+  bannerIcon: EventIcon;
+  expectedAttendance: number;
+  anchors: SeedAnchor[];
+}
+
+interface SeedClub {
+  name: string;
+  description: string;
+  initials: string;
+  avatarColor: ClubColor;
+  memberCount: number;
+  meetsCadence: string;
+  externalLink: string;
+  popularityScore: number;
+}
+
+interface SeedDining {
+  name: string;
+  description: string;
+  hoursText: string;
+  cuisine: string;
+  menuUrl?: string;
+  anchors: SeedAnchor[];
+}
+
+const NEWS: SeedNews[] = [
+  {
+    title: "Library hours extended through finals",
+    body: "Engineering South stays open 24 / 7 until June 9. Quiet floors are on 2 and 3; free coffee on the second floor every night from 8 pm. Bring your student ID after 11 pm.",
+    category: "announcement",
+    publishedDaysAgo: 3,
+    anchors: [
+      { kind: "building", refId: "", refName: "Engineering South Building" },
+    ],
+  },
+  {
+    title: "Cafe Pavilion closed for renovation",
+    body: "Closed May 28 — June 2 for a kitchen refit. Grab-and-go meals available at the Marketplace in the meantime. The patio remains open for seating.",
+    category: "alert",
+    publishedDaysAgo: 1,
+    anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
+  },
+  {
+    title: "New 3D printers in the Graphic Arts lab",
+    body: "Six new printers landed last week — drop-in hours every weekday afternoon. Training session Tuesday at 4 pm; no sign-up needed.",
+    category: "news",
+    publishedDaysAgo: 7,
+    anchors: [
+      { kind: "building", refId: "", refName: "Graphic Arts Building" },
+    ],
+  },
+  {
+    title: "Fire drill — Wednesday 10:30 am",
+    body: "All-campus fire drill at 10:30 am Wednesday. Plan ~10 minutes outside. Faculty: please assist with attendance at your assembly point.",
+    category: "alert",
+    publishedDaysAgo: 0,
+    anchors: [
+      { kind: "building", refId: "", refName: "Mott Athletics Center" },
+      { kind: "building", refId: "", refName: "Engineering South Building" },
+    ],
+  },
+];
+
+const EVENTS: SeedEvent[] = [
+  {
+    title: "Open mic at the quad cafe",
+    description:
+      "Bring a poem, a song, a stand-up bit. Sign-up at the door, sets are five minutes. Free entry, drinks at bar prices.",
+    startsInDays: 2,
+    durationHours: 3,
+    bannerColor: "purple",
+    bannerIcon: "music",
+    expectedAttendance: 84,
+    anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
+  },
+  {
+    title: "Intramural basketball finals",
+    description:
+      "The Reds vs the Greens. Free entry with student ID. Doors at 5:30 pm, tip-off at 6.",
+    startsInDays: 3,
+    durationHours: 3,
+    bannerColor: "coral",
+    bannerIcon: "trophy",
+    expectedAttendance: 212,
+    anchors: [
+      { kind: "building", refId: "", refName: "Mott Athletics Center" },
+    ],
+  },
+  {
+    title: "Community garden volunteer day",
+    description:
+      "Planting summer tomatoes, weeding, and lunch. Tools provided; bring a hat and a refillable bottle.",
+    startsInDays: 4,
+    durationHours: 4,
+    bannerColor: "teal",
+    bannerIcon: "sprout",
+    expectedAttendance: 36,
+    anchors: [
+      { kind: "building", refId: "", refName: "1901 Marketplace Building" },
+    ],
+  },
+];
+
+const CLUBS: SeedClub[] = [
+  {
+    name: "Data science society",
+    description:
+      "Weekly study groups, guest speakers from industry, and an end-of-semester data viz hackathon. Open to every major.",
+    initials: "DS",
+    avatarColor: "purple",
+    memberCount: 248,
+    meetsCadence: "Meets Wednesdays at 6 pm",
+    externalLink: "https://discord.gg/example",
+    popularityScore: 90,
+  },
+  {
+    name: "Film club",
+    description:
+      "Screenings every Friday — student picks, classics, and the occasional director Q&A. Free popcorn while it lasts.",
+    initials: "FC",
+    avatarColor: "pink",
+    memberCount: 142,
+    meetsCadence: "Screenings every Friday at 8 pm",
+    externalLink: "https://instagram.com/example",
+    popularityScore: 80,
+  },
+  {
+    name: "Hiking & outdoors",
+    description:
+      "Day hikes most Saturdays, plus monthly overnight trips. Gear shares + carpools handled in the Discord.",
+    initials: "HK",
+    avatarColor: "coral",
+    memberCount: 186,
+    meetsCadence: "Trips most Saturdays",
+    externalLink: "https://discord.gg/example",
+    popularityScore: 85,
+  },
+  {
+    name: "Sustainability union",
+    description:
+      "Campus zero-waste projects, the community garden, and policy advocacy. Anyone can join — show up to one meeting.",
+    initials: "SU",
+    avatarColor: "teal",
+    memberCount: 97,
+    meetsCadence: "Meets Mondays at 5 pm",
+    externalLink: "https://instagram.com/example",
+    popularityScore: 70,
+  },
+];
+
+const DINING: SeedDining[] = [
+  {
+    name: "Cafe Pavilion",
+    description:
+      "Quick-service cafe with sandwiches, bowls, espresso, and a long patio. Bring a laptop, stay all afternoon.",
+    hoursText: "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed",
+    cuisine: "Sandwiches, salads, coffee",
+    anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
+  },
+  {
+    name: "Marketplace",
+    description:
+      "All-day food court — pizza, ramen, burrito bar, and a salad bar. Multiple stations, one card swipe.",
+    hoursText: "Mon-Sun 7am-9pm",
+    cuisine: "International, fast-casual",
+    anchors: [
+      { kind: "building", refId: "", refName: "1901 Marketplace Building" },
+    ],
+  },
+  {
+    name: "Mott juice bar",
+    description:
+      "Smoothies, açai bowls, cold-pressed juices. Inside the athletics centre, drop in after a workout.",
+    hoursText: "Mon-Fri 6am-8pm · Sat-Sun 8am-4pm",
+    cuisine: "Smoothies, bowls",
+    anchors: [
+      { kind: "building", refId: "", refName: "Mott Athletics Center" },
+    ],
+  },
+];
+
+/**
+ * Write the seed into a project. Idempotent — call it twice and you
+ * get two copies of everything. Callers gate on "the project has no
+ * existing content yet" if they want exactly-once semantics.
+ */
+export async function seedSampleCampus(
+  projectId: string,
+  organizationId: string,
+): Promise<{
+  news: number;
+  events: number;
+  clubs: number;
+  dining: number;
+}> {
+  const now = Date.now();
+  const day = 86_400_000;
+  const hour = 3_600_000;
+
+  const newsRows = NEWS.map((n) => ({
+    organizationId,
+    projectId,
+    title: n.title,
+    body: n.body,
+    category: n.category,
+    publishedAt: new Date(now - n.publishedDaysAgo * day),
+    anchors: n.anchors as unknown as Prisma.InputJsonValue,
+  }));
+
+  const eventRows = EVENTS.map((e) => {
+    const startsAt = new Date(now + e.startsInDays * day);
+    return {
+      organizationId,
+      projectId,
+      title: e.title,
+      description: e.description,
+      startsAt,
+      endsAt: new Date(startsAt.getTime() + e.durationHours * hour),
+      bannerColor: e.bannerColor,
+      bannerIcon: e.bannerIcon,
+      expectedAttendance: e.expectedAttendance,
+      anchors: e.anchors as unknown as Prisma.InputJsonValue,
+    };
+  });
+
+  const clubRows = CLUBS.map((c) => ({
+    organizationId,
+    projectId,
+    name: c.name,
+    description: c.description,
+    initials: c.initials,
+    avatarColor: c.avatarColor,
+    memberCount: c.memberCount,
+    meetsCadence: c.meetsCadence,
+    externalLink: c.externalLink,
+    popularityScore: c.popularityScore,
+  }));
+
+  const diningRows = DINING.map((d) => ({
+    organizationId,
+    projectId,
+    name: d.name,
+    description: d.description,
+    hoursText: d.hoursText,
+    cuisine: d.cuisine,
+    menuUrl: d.menuUrl ?? null,
+    anchors: d.anchors as unknown as Prisma.InputJsonValue,
+  }));
+
+  const [news, events, clubs, dining] = await Promise.all([
+    prisma.newsPost.createMany({ data: newsRows }),
+    prisma.eventPost.createMany({ data: eventRows }),
+    prisma.club.createMany({ data: clubRows }),
+    prisma.diningLocation.createMany({ data: diningRows }),
+  ]);
+
+  return {
+    news: news.count,
+    events: events.count,
+    clubs: clubs.count,
+    dining: dining.count,
+  };
+}
+
+/** Has this project been seeded already? "Anything in any rail" wins. */
+export async function projectHasContent(projectId: string): Promise<boolean> {
+  const [n, e, c, d] = await Promise.all([
+    prisma.newsPost.count({ where: { projectId } }),
+    prisma.eventPost.count({ where: { projectId } }),
+    prisma.club.count({ where: { projectId } }),
+    prisma.diningLocation.count({ where: { projectId } }),
+  ]);
+  return n + e + c + d > 0;
+}


### PR DESCRIPTION
## What this is

Arc 7 of [[campus-consumer-pivot]] — the closer. A first-run launcher that closes the "rector signs up and nothing's there" gap, and a one-click seed that fills the four Arc 2-5 rails with believable sample content.

## What's on the page

- `/org/[orgId]/maps/[mapId]/onboarding` — three-card hub:
  - **Try with sample data** — POSTs `/api/maps/[mapId]/seed-sample`. Shows a "Content present" pill when done; disables further clicks (the server endpoint enforces this too).
  - **Brand the campus** — deep-links to the existing Settings tab.
  - **Connect MappedIn** — deep-links to the existing Indoor tab.
  - A fourth row underneath summarises the publishing state.

## The seed

`lib/sample-seed.ts` writes:
- 4 news posts (one each in `announcement`, `news`, `alert`, plus a fire-drill alert with two anchors)
- 3 events (one-offs sized for the next few days)
- 4 clubs (purple / coral / teal / pink avatars; ranked by `popularityScore`)
- 3 dining locations (cafe, marketplace, juice bar)

Dates are computed at write time (`publishedDaysAgo`, `startsInDays`) so the seed is always "current." Idempotence via `projectHasContent(projectId)` — the endpoint 409s if any of the four tables already has a row for this project, so a re-seed is an explicit operator decision (delete first).

## API

| Verb | Path | Notes |
|---|---|---|
| POST | `/api/maps/[mapId]/seed-sample` | `requireCampusAccess("write")`; refuses double-seed; bumps the public cache tag |

## Out of scope (follow-ups)

- Auto-redirect to onboarding when a tenant creates their first project.
- "Reset sample" + "Replace with my data" flows.
- Inline admin invites (existing org membership UX covers it).
- A "campus health" checklist (has ≥3 events, ≥5 rooms labelled in MappedIn, etc.).

## Testing

`tsc --noEmit` clean. `next lint` clean. No new dependencies, no new migration — the seed writes through the existing four arc models.

## To use it once merged

1. Sign up a fresh org (or use a fresh project).
2. Visit `/org/[orgId]/maps/[mapId]/onboarding`.
3. Click "Add sample data" — 4 + 3 + 4 + 3 rows land in seconds.
4. Refresh the public campus → rails are populated, the chat can answer "what's happening this week?" with real titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)