### PR TITLE
feat(campus): v1 polish — anchor picker, PATCH endpoints, assistant rate limit

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -13,11 +13,16 @@ import {
 } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
 import { type DiningLocation } from "@/lib/dining-db";
+import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
 
 interface Props {
   mapId: string;
   initialLocations: DiningLocation[];
+  /** MappedIn venue id — when set, the anchor input becomes a picker. */
+  indoorMapId?: string | null;
 }
+
+const EMPTY_ANCHOR: AnchorValue = { refName: "", refId: "" };
 
 /**
  * Admin client for /dining. List on the left (delete-only for
@@ -25,14 +30,18 @@ interface Props {
  * cards are simple enough to author blind. Reuses the
  * `campus-news` Spaces prefix for images.
  */
-export function DiningAdminClient({ mapId, initialLocations }: Props) {
+export function DiningAdminClient({
+  mapId,
+  initialLocations,
+  indoorMapId,
+}: Props) {
   const [locations, setLocations] = useState<DiningLocation[]>(initialLocations);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [hoursText, setHoursText] = useState("");
   const [cuisine, setCuisine] = useState("");
   const [menuUrl, setMenuUrl] = useState("");
-  const [anchorName, setAnchorName] = useState("");
+  const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -56,7 +65,7 @@ export function DiningAdminClient({ mapId, initialLocations }: Props) {
     setHoursText("");
     setCuisine("");
     setMenuUrl("");
-    setAnchorName("");
+    setAnchor(EMPTY_ANCHOR);
     setImageUrl(null);
   };
 
@@ -78,12 +87,12 @@ export function DiningAdminClient({ mapId, initialLocations }: Props) {
           cuisine: cuisine.trim() || undefined,
           menuUrl: menuUrl.trim() || undefined,
           imageUrl,
-          anchors: anchorName.trim()
+          anchors: anchor.refName.trim()
             ? [
                 {
                   kind: "building",
-                  refId: "",
-                  refName: anchorName.trim(),
+                  refId: anchor.refId,
+                  refName: anchor.refName.trim(),
                 },
               ]
             : [],
@@ -234,10 +243,12 @@ export function DiningAdminClient({ mapId, initialLocations }: Props) {
           </Field>
 
           <Field label="Where on campus (optional)">
-            <Input
-              value={anchorName}
-              onChange={(e) => setAnchorName(e.target.value)}
+            <AnchorPicker
+              indoorMapId={indoorMapId}
+              value={anchor}
+              onChange={setAnchor}
               placeholder="Cafe Pavilion, Marketplace…"
+              ariaLabel="Anchor"
             />
           </Field>
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/page.tsx
@@ -37,10 +37,13 @@ export default async function DiningAdminPage({
 
   const project = await prisma.project.findFirst({
     where: { id: mapId, organizationId: orgId },
-    select: { id: true, title: true },
+    select: { id: true, title: true, sceneData: true },
   });
   if (!project) notFound();
 
+  const indoorMapId =
+    (project.sceneData as { indoorMapId?: string } | null)?.indoorMapId ??
+    null;
   const locations = await listDiningForProject(mapId);
 
   return (
@@ -63,7 +66,11 @@ export default async function DiningAdminPage({
         </p>
       </div>
 
-      <DiningAdminClient mapId={mapId} initialLocations={locations} />
+      <DiningAdminClient
+        mapId={mapId}
+        initialLocations={locations}
+        indoorMapId={indoorMapId}
+      />
     </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -19,11 +19,16 @@ import {
   type EventBanner,
   type EventIcon,
 } from "@/lib/events-db";
+import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
 
 interface Props {
   mapId: string;
   initialEvents: EventPost[];
+  /** MappedIn venue id — when set, the anchor input becomes a picker. */
+  indoorMapId?: string | null;
 }
+
+const EMPTY_ANCHOR: AnchorValue = { refName: "", refId: "" };
 
 const BANNERS: { value: EventBanner; label: string; swatch: string }[] = [
   { value: "purple", label: "Purple", swatch: "#534AB7" },
@@ -53,7 +58,11 @@ function plusHoursLocal(hours: number): string {
  * expected attendance). POST goes to /api/maps/[mapId]/events; the
  * server bumps the public cache tag so the rail updates instantly.
  */
-export function EventsAdminClient({ mapId, initialEvents }: Props) {
+export function EventsAdminClient({
+  mapId,
+  initialEvents,
+  indoorMapId,
+}: Props) {
   const [events, setEvents] = useState<EventPost[]>(initialEvents);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -61,7 +70,7 @@ export function EventsAdminClient({ mapId, initialEvents }: Props) {
   const [endsAt, setEndsAt] = useState(plusHoursLocal(26));
   const [bannerColor, setBannerColor] = useState<EventBanner>("purple");
   const [bannerIcon, setBannerIcon] = useState<EventIcon>("calendar");
-  const [anchorName, setAnchorName] = useState("");
+  const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
   const [registrationUrl, setRegistrationUrl] = useState("");
   const [organizer, setOrganizer] = useState("");
   const [expectedAttendance, setExpectedAttendance] = useState("");
@@ -89,7 +98,7 @@ export function EventsAdminClient({ mapId, initialEvents }: Props) {
     setEndsAt(plusHoursLocal(26));
     setBannerColor("purple");
     setBannerIcon("calendar");
-    setAnchorName("");
+    setAnchor(EMPTY_ANCHOR);
     setRegistrationUrl("");
     setOrganizer("");
     setExpectedAttendance("");
@@ -124,12 +133,12 @@ export function EventsAdminClient({ mapId, initialEvents }: Props) {
             attendance != null && !Number.isNaN(attendance)
               ? attendance
               : undefined,
-          anchors: anchorName.trim()
+          anchors: anchor.refName.trim()
             ? [
                 {
                   kind: "building",
-                  refId: "",
-                  refName: anchorName.trim(),
+                  refId: anchor.refId,
+                  refName: anchor.refName.trim(),
                 },
               ]
             : [],
@@ -304,10 +313,12 @@ export function EventsAdminClient({ mapId, initialEvents }: Props) {
           </div>
 
           <Field label="Where on campus (optional)">
-            <Input
-              value={anchorName}
-              onChange={(e) => setAnchorName(e.target.value)}
+            <AnchorPicker
+              indoorMapId={indoorMapId}
+              value={anchor}
+              onChange={setAnchor}
               placeholder="Library, Cafe Pavilion, Mott Athletics…"
+              ariaLabel="Anchor"
             />
           </Field>
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
@@ -38,10 +38,13 @@ export default async function EventsAdminPage({
 
   const project = await prisma.project.findFirst({
     where: { id: mapId, organizationId: orgId },
-    select: { id: true, title: true },
+    select: { id: true, title: true, sceneData: true },
   });
   if (!project) notFound();
 
+  const indoorMapId =
+    (project.sceneData as { indoorMapId?: string } | null)?.indoorMapId ??
+    null;
   const events = await listEventsForAdmin(mapId);
 
   return (
@@ -64,7 +67,11 @@ export default async function EventsAdminPage({
         </p>
       </div>
 
-      <EventsAdminClient mapId={mapId} initialEvents={events} />
+      <EventsAdminClient
+        mapId={mapId}
+        initialEvents={events}
+        indoorMapId={indoorMapId}
+      />
     </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -18,11 +18,16 @@ import {
   type NewsPost,
   type NewsCategory,
 } from "@/lib/news";
+import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
 
 interface Props {
   mapId: string;
   initialPosts: NewsPost[];
+  /** MappedIn venue id — when set, the anchor input becomes a picker. */
+  indoorMapId?: string | null;
 }
+
+const EMPTY_ANCHOR: AnchorValue = { refName: "", refId: "" };
 
 const CATEGORIES: { value: NewsCategory; label: string }[] = [
   { value: "announcement", label: "Announcement" },
@@ -42,13 +47,17 @@ function todayISODate(): string {
  * `POST /api/maps/[mapId]/news` and revalidates the cached public
  * campus tag server-side so the new post shows up immediately.
  */
-export function NewsAdminClient({ mapId, initialPosts }: Props) {
+export function NewsAdminClient({
+  mapId,
+  initialPosts,
+  indoorMapId,
+}: Props) {
   const [posts, setPosts] = useState<NewsPost[]>(initialPosts);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [category, setCategory] = useState<NewsCategory>("announcement");
   const [publishedAt, setPublishedAt] = useState(todayISODate());
-  const [anchorName, setAnchorName] = useState("");
+  const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -71,7 +80,7 @@ export function NewsAdminClient({ mapId, initialPosts }: Props) {
     setBody("");
     setCategory("announcement");
     setPublishedAt(todayISODate());
-    setAnchorName("");
+    setAnchor(EMPTY_ANCHOR);
     setImageUrl(null);
   };
 
@@ -94,12 +103,12 @@ export function NewsAdminClient({ mapId, initialPosts }: Props) {
           // into a UTC ISO so the server stores a clean instant.
           publishedAt: new Date(publishedAt).toISOString(),
           imageUrl,
-          anchors: anchorName.trim()
+          anchors: anchor.refName.trim()
             ? [
                 {
                   kind: "building",
-                  refId: "",
-                  refName: anchorName.trim(),
+                  refId: anchor.refId,
+                  refName: anchor.refName.trim(),
                 },
               ]
             : [],
@@ -250,10 +259,12 @@ export function NewsAdminClient({ mapId, initialPosts }: Props) {
           </div>
 
           <Field label="Where on campus (optional)">
-            <Input
-              value={anchorName}
-              onChange={(e) => setAnchorName(e.target.value)}
+            <AnchorPicker
+              indoorMapId={indoorMapId}
+              value={anchor}
+              onChange={setAnchor}
               placeholder="Library, Cafe Pavilion, Mott Athletics…"
+              ariaLabel="Anchor"
             />
           </Field>
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
@@ -38,10 +38,13 @@ export default async function NewsAdminPage({
 
   const project = await prisma.project.findFirst({
     where: { id: mapId, organizationId: orgId },
-    select: { id: true, title: true },
+    select: { id: true, title: true, sceneData: true },
   });
   if (!project) notFound();
 
+  const indoorMapId =
+    (project.sceneData as { indoorMapId?: string } | null)?.indoorMapId ??
+    null;
   const posts = await listNewsForAdmin(mapId);
 
   return (
@@ -62,7 +65,11 @@ export default async function NewsAdminPage({
         </p>
       </div>
 
-      <NewsAdminClient mapId={mapId} initialPosts={posts} />
+      <NewsAdminClient
+        mapId={mapId}
+        initialPosts={posts}
+        indoorMapId={indoorMapId}
+      />
     </div>
   );
 }

--- a/apps/campus/app/api/assistant/route.ts
+++ b/apps/campus/app/api/assistant/route.ts
@@ -7,6 +7,7 @@ import {
   type AssistantSpace,
   type ToolContext,
 } from "@/lib/assistant/tools";
+import { checkRateLimit, clientIp } from "@/lib/assistant/rate-limit";
 
 interface AssistantTurn {
   role: "user" | "assistant";
@@ -208,6 +209,26 @@ async function runClaude(
 }
 
 export async function POST(req: Request) {
+  // Public endpoint, paid LLM — token-bucket the caller's IP so a
+  // tab loop or a small abuse campaign can't run the bill. See
+  // lib/assistant/rate-limit.ts for the swap-out story (Upstash).
+  const ip = clientIp(req);
+  const limit = checkRateLimit(ip);
+  if (!limit.ok) {
+    return NextResponse.json(
+      {
+        error: "Too many requests — slow down for a minute.",
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(Math.ceil(limit.resetIn / 1000)),
+          "X-RateLimit-Remaining": "0",
+        },
+      },
+    );
+  }
+
   let body: RequestBody;
   try {
     body = (await req.json()) as RequestBody;

--- a/apps/campus/app/api/clubs/[id]/route.ts
+++ b/apps/campus/app/api/clubs/[id]/route.ts
@@ -1,10 +1,115 @@
 import { NextResponse } from "next/server";
+import { Prisma, type ClubColor } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
 type Params = Promise<{ id: string }>;
+
+const VALID_COLORS: ClubColor[] = ["purple", "coral", "teal", "pink"];
+
+interface AnchorIn {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+function parseAnchors(raw: unknown): AnchorIn[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is AnchorIn => !!a);
+}
+
+/** PATCH /api/clubs/[id] — partial edit. */
+export async function PATCH(req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const existing = await prisma.club.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(existing.organizationId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const data: Prisma.ClubUpdateInput = {};
+
+  if (typeof body.name === "string") {
+    const v = body.name.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "name cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.name = v;
+  }
+  if (typeof body.description === "string") {
+    const v = body.description.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "description cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.description = v;
+  }
+  if (typeof body.initials === "string" && body.initials.trim().length > 0) {
+    data.initials = body.initials.trim().slice(0, 3).toUpperCase();
+  }
+  if (VALID_COLORS.includes(body.avatarColor as ClubColor)) {
+    data.avatarColor = body.avatarColor as ClubColor;
+  }
+  if (typeof body.memberCount === "number" && body.memberCount >= 0) {
+    data.memberCount = Math.floor(body.memberCount);
+  }
+  if (typeof body.popularityScore === "number") {
+    data.popularityScore = body.popularityScore;
+  }
+  if (body.meetsCadence !== undefined) {
+    data.meetsCadence =
+      typeof body.meetsCadence === "string" && body.meetsCadence.length > 0
+        ? body.meetsCadence
+        : null;
+  }
+  if (body.externalLink !== undefined) {
+    data.externalLink =
+      typeof body.externalLink === "string" && body.externalLink.length > 0
+        ? body.externalLink
+        : null;
+  }
+  if (body.imageUrl !== undefined) {
+    data.imageUrl =
+      typeof body.imageUrl === "string" && body.imageUrl.length > 0
+        ? body.imageUrl
+        : null;
+  }
+  if (Array.isArray(body.anchors)) {
+    data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
+  }
+
+  await prisma.club.update({ where: { id }, data });
+  revalidateTag(publicCampusTag(existing.projectId));
+  return NextResponse.json({ ok: true });
+}
 
 export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;

--- a/apps/campus/app/api/dining/[id]/route.ts
+++ b/apps/campus/app/api/dining/[id]/route.ts
@@ -1,10 +1,107 @@
 import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
 type Params = Promise<{ id: string }>;
+
+interface AnchorIn {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+function parseAnchors(raw: unknown): AnchorIn[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is AnchorIn => !!a);
+}
+
+/** PATCH /api/dining/[id] — partial edit. */
+export async function PATCH(req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const existing = await prisma.diningLocation.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(existing.organizationId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const data: Prisma.DiningLocationUpdateInput = {};
+
+  if (typeof body.name === "string") {
+    const v = body.name.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "name cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.name = v;
+  }
+  if (typeof body.description === "string") {
+    const v = body.description.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "description cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.description = v;
+  }
+  if (body.hoursText !== undefined) {
+    data.hoursText =
+      typeof body.hoursText === "string" && body.hoursText.length > 0
+        ? body.hoursText
+        : null;
+  }
+  if (body.cuisine !== undefined) {
+    data.cuisine =
+      typeof body.cuisine === "string" && body.cuisine.length > 0
+        ? body.cuisine
+        : null;
+  }
+  if (body.menuUrl !== undefined) {
+    data.menuUrl =
+      typeof body.menuUrl === "string" && body.menuUrl.length > 0
+        ? body.menuUrl
+        : null;
+  }
+  if (body.imageUrl !== undefined) {
+    data.imageUrl =
+      typeof body.imageUrl === "string" && body.imageUrl.length > 0
+        ? body.imageUrl
+        : null;
+  }
+  if (Array.isArray(body.anchors)) {
+    data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
+  }
+
+  await prisma.diningLocation.update({ where: { id }, data });
+  revalidateTag(publicCampusTag(existing.projectId));
+  return NextResponse.json({ ok: true });
+}
 
 export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;

--- a/apps/campus/app/api/events/[id]/route.ts
+++ b/apps/campus/app/api/events/[id]/route.ts
@@ -1,10 +1,138 @@
 import { NextResponse } from "next/server";
+import { Prisma, type EventBanner, type EventIcon } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
 type Params = Promise<{ id: string }>;
+
+const VALID_BANNER: EventBanner[] = ["purple", "coral", "teal", "pink"];
+const VALID_ICON: EventIcon[] = ["music", "trophy", "sprout", "calendar"];
+
+interface AnchorIn {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+function parseAnchors(raw: unknown): AnchorIn[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is AnchorIn => !!a);
+}
+
+function parseDate(value: unknown): Date | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "string" || typeof value === "number") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+/** PATCH /api/events/[id] — partial edit. */
+export async function PATCH(req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const existing = await prisma.eventPost.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true, startsAt: true, endsAt: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(existing.organizationId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const data: Prisma.EventPostUpdateInput = {};
+
+  if (typeof body.title === "string") {
+    const v = body.title.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "title cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.title = v;
+  }
+  if (typeof body.description === "string") {
+    const v = body.description.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "description cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.description = v;
+  }
+
+  // Validate start/end together so we never accept end < start.
+  const newStart = parseDate(body.startsAt) ?? existing.startsAt;
+  const newEnd = parseDate(body.endsAt) ?? existing.endsAt;
+  if (newEnd.getTime() < newStart.getTime()) {
+    return NextResponse.json(
+      { error: "endsAt must be after startsAt" },
+      { status: 400 },
+    );
+  }
+  if (body.startsAt !== undefined) data.startsAt = newStart;
+  if (body.endsAt !== undefined) data.endsAt = newEnd;
+
+  if (VALID_BANNER.includes(body.bannerColor as EventBanner)) {
+    data.bannerColor = body.bannerColor as EventBanner;
+  }
+  if (VALID_ICON.includes(body.bannerIcon as EventIcon)) {
+    data.bannerIcon = body.bannerIcon as EventIcon;
+  }
+  if (body.imageUrl !== undefined) {
+    data.imageUrl =
+      typeof body.imageUrl === "string" && body.imageUrl.length > 0
+        ? body.imageUrl
+        : null;
+  }
+  if (body.registrationUrl !== undefined) {
+    data.registrationUrl =
+      typeof body.registrationUrl === "string" && body.registrationUrl.length > 0
+        ? body.registrationUrl
+        : null;
+  }
+  if (body.organizer !== undefined) {
+    data.organizer =
+      typeof body.organizer === "string" && body.organizer.length > 0
+        ? body.organizer
+        : null;
+  }
+  if (body.expectedAttendance !== undefined) {
+    data.expectedAttendance =
+      typeof body.expectedAttendance === "number"
+        ? body.expectedAttendance
+        : null;
+  }
+  if (Array.isArray(body.anchors)) {
+    data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
+  }
+
+  await prisma.eventPost.update({ where: { id }, data });
+  revalidateTag(publicCampusTag(existing.projectId));
+  return NextResponse.json({ ok: true });
+}
 
 export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;

--- a/apps/campus/app/api/news/[id]/route.ts
+++ b/apps/campus/app/api/news/[id]/route.ts
@@ -1,10 +1,114 @@
 import { NextResponse } from "next/server";
+import { Prisma, type NewsCategory } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
 type Params = Promise<{ id: string }>;
+
+const VALID_CATEGORIES: NewsCategory[] = ["announcement", "news", "alert"];
+
+interface AnchorIn {
+  kind: "building" | "room";
+  refId: string;
+  refName: string;
+}
+
+function parseAnchors(raw: unknown): AnchorIn[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((a) => {
+      if (!a || typeof a !== "object") return null;
+      const r = a as Record<string, unknown>;
+      const kind = r.kind === "room" ? "room" : "building";
+      const refName =
+        typeof r.refName === "string" ? r.refName.trim() : "";
+      const refId = typeof r.refId === "string" ? r.refId : "";
+      return refName ? { kind, refId, refName } : null;
+    })
+    .filter((a): a is AnchorIn => !!a);
+}
+
+function parseDate(value: unknown): Date | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "string" || typeof value === "number") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+/**
+ * PATCH /api/news/[id] — partial edit. Only the fields present in
+ * the body are touched; everything else stays. Dates expect ISO
+ * strings; an empty string for `expiresAt` clears the expiry.
+ */
+export async function PATCH(req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const existing = await prisma.newsPost.findUnique({
+    where: { id },
+    select: { organizationId: true, projectId: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const denied = await requireOrgAccess(existing.organizationId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const data: Prisma.NewsPostUpdateInput = {};
+
+  if (typeof body.title === "string") {
+    const v = body.title.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "title cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.title = v;
+  }
+  if (typeof body.body === "string") {
+    const v = body.body.trim();
+    if (!v) {
+      return NextResponse.json(
+        { error: "body cannot be empty" },
+        { status: 400 },
+      );
+    }
+    data.body = v;
+  }
+  if (VALID_CATEGORIES.includes(body.category as NewsCategory)) {
+    data.category = body.category as NewsCategory;
+  }
+  if (body.publishedAt !== undefined) {
+    const d = parseDate(body.publishedAt);
+    if (d) data.publishedAt = d;
+  }
+  if (body.expiresAt !== undefined) {
+    data.expiresAt = parseDate(body.expiresAt);
+  }
+  if (body.imageUrl !== undefined) {
+    data.imageUrl =
+      typeof body.imageUrl === "string" && body.imageUrl.length > 0
+        ? body.imageUrl
+        : null;
+  }
+  if (Array.isArray(body.anchors)) {
+    data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
+  }
+
+  await prisma.newsPost.update({ where: { id }, data });
+  revalidateTag(publicCampusTag(existing.projectId));
+  return NextResponse.json({ ok: true });
+}
 
 /** DELETE /api/news/[id] — remove a post. Admin / member / owner only. */
 export async function DELETE(_req: Request, { params }: { params: Params }) {

--- a/apps/campus/lib/admin/AnchorPicker.tsx
+++ b/apps/campus/lib/admin/AnchorPicker.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { SearchableSelect } from "@/lib/mappedin/SearchableSelect";
+
+export interface AnchorValue {
+  refName: string;
+  refId: string;
+}
+
+interface MappedinSpaceLite {
+  id: string;
+  name: string;
+}
+
+export interface AnchorPickerProps {
+  /** MappedIn venue id from sceneData.indoorMapId. When unset, falls back to free text. */
+  indoorMapId?: string | null;
+  value: AnchorValue;
+  onChange: (v: AnchorValue) => void;
+  placeholder?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Anchor picker for the admin authoring surfaces.
+ *
+ * When the campus has a MappedIn venue (`indoorMapId` set), loads
+ * the spaces client-side and renders a `SearchableSelect` so the
+ * admin picks a real room — the resulting `{ refId, refName }`
+ * makes "Get directions" deep-links on the public side land on the
+ * right space.
+ *
+ * Without a MappedIn venue, falls back to a plain text input — the
+ * `refName` still drives the chip on the public surface, but
+ * `refId` stays empty (no deep-link).
+ *
+ * Legacy rows with `refName` but no `refId` are upgraded on first
+ * render: if an exact-name match exists in the loaded spaces, the
+ * id is filled in silently.
+ */
+export function AnchorPicker({
+  indoorMapId,
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+}: AnchorPickerProps) {
+  const [spaces, setSpaces] = useState<MappedinSpaceLite[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load MappedIn spaces client-side; the SDK isn't safe in the
+  // server bundle (the workbench dynamic-imports it for the same
+  // reason). Reuses the publishable NEXT_PUBLIC_MAPPEDIN_* creds.
+  useEffect(() => {
+    if (!indoorMapId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const { getMapData } = await import("@mappedin/mappedin-js");
+        const { resolveVenue } = await import("@/lib/mappedin/config");
+        const venue = resolveVenue();
+        const mapData = await getMapData({
+          key: venue.key,
+          secret: venue.secret,
+          mapId: indoorMapId,
+        });
+        const list = mapData
+          .getByType("space")
+          .filter((s) => Boolean(s.name))
+          .map((s) => ({ id: s.id, name: s.name as string }));
+        list.sort((a, b) => a.name.localeCompare(b.name));
+        if (!cancelled) setSpaces(list);
+      } catch (err) {
+        console.error("[AnchorPicker] failed to load spaces", err);
+        if (!cancelled) setError("Couldn't load rooms");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [indoorMapId]);
+
+  // Legacy-row upgrade: if we got an old anchor with a name but no
+  // id and one of the loaded spaces matches by name, fill the id.
+  useEffect(() => {
+    if (!value.refName || value.refId || spaces.length === 0) return;
+    const match = spaces.find(
+      (s) => s.name.toLowerCase() === value.refName.toLowerCase(),
+    );
+    if (match) onChange({ refName: match.name, refId: match.id });
+    // We intentionally don't depend on `onChange` — only run when
+    // the inputs to the match change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spaces, value.refName, value.refId]);
+
+  const selectOptions = useMemo(
+    () => spaces.map((s) => ({ id: s.id, name: s.name })),
+    [spaces],
+  );
+
+  // Free-text fallback when there's no MappedIn venue connected.
+  if (!indoorMapId) {
+    return (
+      <input
+        type="text"
+        value={value.refName}
+        onChange={(e) =>
+          onChange({ refName: e.target.value, refId: "" })
+        }
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="w-full rounded-md border border-solid border-line-soft bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-accent"
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <SearchableSelect
+        options={selectOptions}
+        value={value.refId}
+        onChange={(refId) => {
+          const picked = spaces.find((s) => s.id === refId);
+          if (picked) onChange({ refName: picked.name, refId: picked.id });
+        }}
+        placeholder={
+          loading
+            ? "Loading rooms…"
+            : error
+              ? error
+              : (placeholder ?? "Pick a room")
+        }
+        searchPlaceholder="Search rooms…"
+        ariaLabel={ariaLabel}
+      />
+      {/* Surface a non-fatal load error inline; user can still save
+          a row without an anchor. */}
+      {error ? (
+        <span className="text-[0.7rem] text-text-tertiary">
+          Couldn’t load MappedIn rooms — leave anchor blank or retry.
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/campus/lib/assistant/rate-limit.ts
+++ b/apps/campus/lib/assistant/rate-limit.ts
@@ -1,0 +1,75 @@
+/**
+ * In-memory rate limiter for /api/assistant.
+ *
+ * The assistant is public (no auth, no token) and calls a paid LLM,
+ * so an unbounded endpoint is a liability. This module is the
+ * cheapest defence — per-IP token bucket, fixed window — and is
+ * good enough for one-instance deployments and the first wave of
+ * traffic. Multi-instance prod wants Redis (or Upstash). The seam
+ * for that swap is `checkRateLimit`; nothing else has to change.
+ */
+
+const RATE_LIMIT = 30;
+const WINDOW_MS = 60_000;
+/** Hard cap so a one-process memory leak isn't a thing. */
+const MAX_BUCKETS = 10_000;
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+/** Best-effort caller-ip extraction from the request headers. */
+export function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = req.headers.get("x-real-ip");
+  if (real) return real;
+  return "unknown";
+}
+
+export interface RateCheck {
+  ok: boolean;
+  remaining: number;
+  resetIn: number;
+}
+
+/** Returns whether the IP may proceed, plus headers-friendly metadata. */
+export function checkRateLimit(ip: string): RateCheck {
+  const now = Date.now();
+
+  // Garbage-collect expired buckets when the table grows large.
+  if (buckets.size > MAX_BUCKETS) {
+    for (const [key, bucket] of buckets) {
+      if (bucket.resetAt < now) buckets.delete(key);
+    }
+  }
+
+  const bucket = buckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    buckets.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return {
+      ok: true,
+      remaining: RATE_LIMIT - 1,
+      resetIn: WINDOW_MS,
+    };
+  }
+  if (bucket.count >= RATE_LIMIT) {
+    return {
+      ok: false,
+      remaining: 0,
+      resetIn: Math.max(0, bucket.resetAt - now),
+    };
+  }
+  bucket.count += 1;
+  return {
+    ok: true,
+    remaining: RATE_LIMIT - bucket.count,
+    resetIn: Math.max(0, bucket.resetAt - now),
+  };
+}


### PR DESCRIPTION
## What this is

Three v1-readiness gaps the MVP recap flagged as follow-ups. One branch, two commits, no new migration.

## What landed

### 1. MappedIn anchor picker on every admin authoring form

New `lib/admin/AnchorPicker.tsx`. When the campus has a MappedIn venue (`sceneData.indoorMapId` set), dynamic-imports the SDK client-side, loads the venue's spaces, and renders the existing Radix-Popover `SearchableSelect` so the admin picks a real room. The resulting `{ refName, refId }` is what the public surface needs to build *"Get directions"* deep-links that **actually focus the right MappedIn space** instead of just opening the map.

Without a venue, falls back to a plain text input — the chip still renders, just no deep-link. Legacy rows with `refName` but no `refId` are silently upgraded on first render when an exact-name match exists in the loaded spaces.

Plumbed into:
- `NewsAdminClient`
- `EventsAdminClient`
- `DiningAdminClient`

(Clubs don't expose an anchor field today.)

### 2. PATCH endpoints on the four `/api/<model>/[id]` routes

`news` · `events` · `clubs` · `dining` now accept partial updates with the same shape as their POST. Fields not in the body stay as-is; required fields reject empty strings; nullable fields clear with `""`. Each write bumps the public cache tag.

Edit *UI* in the admin clients is the next follow-up — endpoints first.

Events specifically validates `endsAt >= startsAt` using the row's existing values when only one date moves, so you can edit just one without re-sending both.

### 3. Rate limit on `/api/assistant`

`lib/assistant/rate-limit.ts` — per-IP token bucket, **30 reqs / 60 s**, lazy GC at 10k buckets. The endpoint is public + no-auth + paid LLM; an unbounded version is a real liability. Over the limit → `429` with `Retry-After`.

In-memory is intentional for the first wave (single-instance deployments). The swap to Upstash / Redis is the body of `checkRateLimit()` and nothing else has to change.

## Testing

`tsc --noEmit` clean across both commits. `next lint` clean.

## What's still on the v1 list (next PRs)

- **Edit UI** in the four admin clients — buttons + form-mode switch. Endpoints above are ready.
- **ICS feed sync** for events — `events-server.ts` already parses; just needs a nightly job that writes through `EventPost`.
- **Localised content fields** when bilingual posts come back.
- **A "campus health" checklist** ("≥3 events," "≥5 rooms with MappedIn ids," etc.) on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)