### PR TITLE
feat(campus): edit UI on all four admin authoring forms

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Plus, Trash2, X } from "lucide-react";
+import { Pencil, Plus, Trash2, X } from "lucide-react";
 import {
   Button,
   Field,
@@ -40,6 +40,7 @@ const COLORS: { value: ClubColor; label: string; swatch: string }[] = [
  */
 export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   const [clubs, setClubs] = useState<Club[]>(initialClubs);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [initialsOverride, setInitialsOverride] = useState("");
@@ -68,6 +69,7 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   };
 
   const reset = () => {
+    setEditingId(null);
     setName("");
     setDescription("");
     setInitialsOverride("");
@@ -79,6 +81,22 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
     setImageUrl(null);
   };
 
+  const startEdit = (club: Club) => {
+    setEditingId(club.id);
+    setName(club.name);
+    setDescription(club.description);
+    setInitialsOverride(club.initials);
+    setAvatarColor(club.avatarColor);
+    setMemberCount(String(club.memberCount));
+    setMeetsCadence(club.meetsCadence ?? "");
+    setExternalLink(club.externalLink ?? "");
+    setPopularityScore(String(club.popularityScore));
+    setImageUrl(club.imageUrl);
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!name.trim() || !description.trim()) {
@@ -87,8 +105,12 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
     }
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/maps/${mapId}/clubs`, {
-        method: "POST",
+      const url = editingId
+        ? `/api/clubs/${editingId}`
+        : `/api/maps/${mapId}/clubs`;
+      const method = editingId ? "PATCH" : "POST";
+      const res = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
@@ -108,17 +130,17 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(err.error ?? "Failed to publish");
+        throw new Error(err.error ?? "Failed to save");
       }
       const list = await fetch(`/api/maps/${mapId}/clubs`).then((r) =>
         r.json(),
       );
       setClubs(list.clubs ?? []);
       reset();
-      toast.success("Club published");
+      toast.success(editingId ? "Updated" : "Club published");
     } catch (e) {
       console.error(e);
-      toast.error(e instanceof Error ? e.message : "Failed to publish");
+      toast.error(e instanceof Error ? e.message : "Failed to save");
     } finally {
       setSubmitting(false);
     }
@@ -189,14 +211,24 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
                           {c.meetsCadence ? ` · ${c.meetsCadence}` : ""}
                         </p>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => void onDelete(c.id)}
-                        aria-label="Delete"
-                        className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
-                      >
-                        <Trash2 size={14} strokeWidth={1.75} />
-                      </button>
+                      <div className="flex shrink-0 items-center gap-0.5">
+                        <button
+                          type="button"
+                          onClick={() => startEdit(c)}
+                          aria-label="Edit"
+                          className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-accent"
+                        >
+                          <Pencil size={14} strokeWidth={1.75} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void onDelete(c.id)}
+                          aria-label="Delete"
+                          className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                        >
+                          <Trash2 size={14} strokeWidth={1.75} />
+                        </button>
+                      </div>
                     </div>
                     <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
                       {c.description}
@@ -210,9 +242,20 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
       </Panel>
 
       <Panel className="p-5">
-        <h2 className="text-sm font-semibold text-text-primary">
-          New club
-        </h2>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">
+            {editingId ? "Edit club" : "New club"}
+          </h2>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={reset}
+              className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+            >
+              Cancel edit
+            </button>
+          ) : null}
+        </div>
         <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
           <Field label="Name">
             <Input
@@ -354,7 +397,13 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
               Reset
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting ? "Publishing…" : "Publish"}
+              {submitting
+                ? editingId
+                  ? "Saving…"
+                  : "Publishing…"
+                : editingId
+                  ? "Save changes"
+                  : "Publish"}
             </Button>
           </div>
         </form>

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Plus, Trash2, X } from "lucide-react";
+import { Pencil, Plus, Trash2, X } from "lucide-react";
 import {
   Button,
   Field,
@@ -36,6 +36,7 @@ export function DiningAdminClient({
   indoorMapId,
 }: Props) {
   const [locations, setLocations] = useState<DiningLocation[]>(initialLocations);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [hoursText, setHoursText] = useState("");
@@ -60,6 +61,7 @@ export function DiningAdminClient({
   };
 
   const reset = () => {
+    setEditingId(null);
     setName("");
     setDescription("");
     setHoursText("");
@@ -67,6 +69,27 @@ export function DiningAdminClient({
     setMenuUrl("");
     setAnchor(EMPTY_ANCHOR);
     setImageUrl(null);
+  };
+
+  const startEdit = (location: DiningLocation) => {
+    setEditingId(location.id);
+    setName(location.name);
+    setDescription(location.description);
+    setHoursText(location.hoursText ?? "");
+    setCuisine(location.cuisine ?? "");
+    setMenuUrl(location.menuUrl ?? "");
+    setAnchor(
+      location.anchors[0]
+        ? {
+            refName: location.anchors[0].refName,
+            refId: location.anchors[0].refId,
+          }
+        : EMPTY_ANCHOR,
+    );
+    setImageUrl(location.imageUrl);
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
   };
 
   const onSubmit = async (e: FormEvent) => {
@@ -77,8 +100,12 @@ export function DiningAdminClient({
     }
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/maps/${mapId}/dining`, {
-        method: "POST",
+      const url = editingId
+        ? `/api/dining/${editingId}`
+        : `/api/maps/${mapId}/dining`;
+      const method = editingId ? "PATCH" : "POST";
+      const res = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
@@ -107,7 +134,7 @@ export function DiningAdminClient({
       );
       setLocations(list.locations ?? []);
       reset();
-      toast.success("Location published");
+      toast.success(editingId ? "Updated" : "Location published");
     } catch (e) {
       console.error(e);
       toast.error(e instanceof Error ? e.message : "Failed to publish");
@@ -169,14 +196,24 @@ export function DiningAdminClient({
                         {l.hoursText ? ` · ${l.hoursText}` : ""}
                       </p>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => void onDelete(l.id)}
-                      aria-label="Delete"
-                      className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
-                    >
-                      <Trash2 size={14} strokeWidth={1.75} />
-                    </button>
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => startEdit(l)}
+                        aria-label="Edit"
+                        className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-accent"
+                      >
+                        <Pencil size={14} strokeWidth={1.75} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void onDelete(l.id)}
+                        aria-label="Delete"
+                        className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                      >
+                        <Trash2 size={14} strokeWidth={1.75} />
+                      </button>
+                    </div>
                   </div>
                   <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
                     {l.description}
@@ -194,9 +231,20 @@ export function DiningAdminClient({
       </Panel>
 
       <Panel className="p-5">
-        <h2 className="text-sm font-semibold text-text-primary">
-          New location
-        </h2>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">
+            {editingId ? "Edit location" : "New location"}
+          </h2>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={reset}
+              className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+            >
+              Cancel edit
+            </button>
+          ) : null}
+        </div>
         <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
           <Field label="Name">
             <Input
@@ -298,7 +346,13 @@ export function DiningAdminClient({
               Reset
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting ? "Publishing…" : "Publish"}
+              {submitting
+                ? editingId
+                  ? "Saving…"
+                  : "Publishing…"
+                : editingId
+                  ? "Save changes"
+                  : "Publish"}
             </Button>
           </div>
         </form>

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Plus, Trash2, X } from "lucide-react";
+import { Pencil, Plus, Trash2, X } from "lucide-react";
 import {
   Button,
   Field,
@@ -64,6 +64,7 @@ export function EventsAdminClient({
   indoorMapId,
 }: Props) {
   const [events, setEvents] = useState<EventPost[]>(initialEvents);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [startsAt, setStartsAt] = useState(plusHoursLocal(24));
@@ -92,6 +93,7 @@ export function EventsAdminClient({
   };
 
   const reset = () => {
+    setEditingId(null);
     setTitle("");
     setDescription("");
     setStartsAt(plusHoursLocal(24));
@@ -105,6 +107,38 @@ export function EventsAdminClient({
     setImageUrl(null);
   };
 
+  /** `<input type="datetime-local">` value from an ISO string in local TZ. */
+  const isoToLocal = (iso: string): string => {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
+    const off = d.getTimezoneOffset();
+    return new Date(d.getTime() - off * 60_000).toISOString().slice(0, 16);
+  };
+
+  const startEdit = (event: EventPost) => {
+    setEditingId(event.id);
+    setTitle(event.title);
+    setDescription(event.description);
+    setStartsAt(isoToLocal(event.startsAt));
+    setEndsAt(isoToLocal(event.endsAt));
+    setBannerColor(event.bannerColor);
+    setBannerIcon(event.bannerIcon);
+    setAnchor(
+      event.anchors[0]
+        ? { refName: event.anchors[0].refName, refId: event.anchors[0].refId }
+        : EMPTY_ANCHOR,
+    );
+    setRegistrationUrl(event.registrationUrl ?? "");
+    setOrganizer(event.organizer ?? "");
+    setExpectedAttendance(
+      event.expectedAttendance != null ? String(event.expectedAttendance) : "",
+    );
+    setImageUrl(event.imageUrl);
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !description.trim()) {
@@ -116,8 +150,12 @@ export function EventsAdminClient({
       const attendance = expectedAttendance.trim()
         ? Number.parseInt(expectedAttendance, 10)
         : undefined;
-      const res = await fetch(`/api/maps/${mapId}/events`, {
-        method: "POST",
+      const url = editingId
+        ? `/api/events/${editingId}`
+        : `/api/maps/${mapId}/events`;
+      const method = editingId ? "PATCH" : "POST";
+      const res = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: title.trim(),
@@ -146,17 +184,17 @@ export function EventsAdminClient({
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(err.error ?? "Failed to publish");
+        throw new Error(err.error ?? "Failed to save");
       }
       const list = await fetch(`/api/maps/${mapId}/events`).then((r) =>
         r.json(),
       );
       setEvents(list.events ?? []);
       reset();
-      toast.success("Event published");
+      toast.success(editingId ? "Updated" : "Event published");
     } catch (e) {
       console.error(e);
-      toast.error(e instanceof Error ? e.message : "Failed to publish");
+      toast.error(e instanceof Error ? e.message : "Failed to save");
     } finally {
       setSubmitting(false);
     }
@@ -214,14 +252,24 @@ export function EventsAdminClient({
                         {formatEventWhen(e.startsAt)}
                       </p>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => void onDelete(e.id)}
-                      aria-label="Delete"
-                      className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
-                    >
-                      <Trash2 size={14} strokeWidth={1.75} />
-                    </button>
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => startEdit(e)}
+                        aria-label="Edit"
+                        className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-accent"
+                      >
+                        <Pencil size={14} strokeWidth={1.75} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void onDelete(e.id)}
+                        aria-label="Delete"
+                        className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                      >
+                        <Trash2 size={14} strokeWidth={1.75} />
+                      </button>
+                    </div>
                   </div>
                   <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
                     {e.description}
@@ -239,9 +287,20 @@ export function EventsAdminClient({
       </Panel>
 
       <Panel className="p-5">
-        <h2 className="text-sm font-semibold text-text-primary">
-          New event
-        </h2>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">
+            {editingId ? "Edit event" : "New event"}
+          </h2>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={reset}
+              className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+            >
+              Cancel edit
+            </button>
+          ) : null}
+        </div>
         <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
           <Field label="Title">
             <Input
@@ -396,7 +455,13 @@ export function EventsAdminClient({
               Reset
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting ? "Publishing…" : "Publish"}
+              {submitting
+                ? editingId
+                  ? "Saving…"
+                  : "Publishing…"
+                : editingId
+                  ? "Save changes"
+                  : "Publish"}
             </Button>
           </div>
         </form>

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Plus, Trash2, X } from "lucide-react";
+import { Pencil, Plus, Trash2, X } from "lucide-react";
 import {
   Button,
   Field,
@@ -53,6 +53,8 @@ export function NewsAdminClient({
   indoorMapId,
 }: Props) {
   const [posts, setPosts] = useState<NewsPost[]>(initialPosts);
+  /** Non-null when the form is editing an existing post. */
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [category, setCategory] = useState<NewsCategory>("announcement");
@@ -76,12 +78,32 @@ export function NewsAdminClient({
   };
 
   const reset = () => {
+    setEditingId(null);
     setTitle("");
     setBody("");
     setCategory("announcement");
     setPublishedAt(todayISODate());
     setAnchor(EMPTY_ANCHOR);
     setImageUrl(null);
+  };
+
+  /** Populate the form with a post's current values for editing. */
+  const startEdit = (post: NewsPost) => {
+    setEditingId(post.id);
+    setTitle(post.title);
+    setBody(post.body);
+    setCategory(post.category);
+    setPublishedAt(post.publishedAt.slice(0, 10));
+    setAnchor(
+      post.anchors[0]
+        ? { refName: post.anchors[0].refName, refId: post.anchors[0].refId }
+        : EMPTY_ANCHOR,
+    );
+    setImageUrl(post.imageUrl);
+    // Send focus to the top so the form is in view.
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
   };
 
   const onSubmit = async (e: FormEvent) => {
@@ -92,8 +114,12 @@ export function NewsAdminClient({
     }
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/maps/${mapId}/news`, {
-        method: "POST",
+      const url = editingId
+        ? `/api/news/${editingId}`
+        : `/api/maps/${mapId}/news`;
+      const method = editingId ? "PATCH" : "POST";
+      const res = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: title.trim(),
@@ -116,18 +142,18 @@ export function NewsAdminClient({
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(err.error ?? "Failed to publish");
+        throw new Error(err.error ?? "Failed to save");
       }
-      // Optimistic refresh — re-fetch the list so the new post appears.
+      // Optimistic refresh — re-fetch the list so the post updates.
       const list = await fetch(`/api/maps/${mapId}/news`).then((r) =>
         r.json(),
       );
       setPosts(list.posts ?? []);
       reset();
-      toast.success("Published");
+      toast.success(editingId ? "Updated" : "Published");
     } catch (e) {
       console.error(e);
-      toast.error(e instanceof Error ? e.message : "Failed to publish");
+      toast.error(e instanceof Error ? e.message : "Failed to save");
     } finally {
       setSubmitting(false);
     }
@@ -185,14 +211,24 @@ export function NewsAdminClient({
                         {p.category} · {formatNewsDate(p.publishedAt)}
                       </p>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => void onDelete(p.id)}
-                      aria-label="Delete"
-                      className="shrink-0 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
-                    >
-                      <Trash2 size={14} strokeWidth={1.75} />
-                    </button>
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => startEdit(p)}
+                        aria-label="Edit"
+                        className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-accent"
+                      >
+                        <Pencil size={14} strokeWidth={1.75} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void onDelete(p.id)}
+                        aria-label="Delete"
+                        className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-600"
+                      >
+                        <Trash2 size={14} strokeWidth={1.75} />
+                      </button>
+                    </div>
                   </div>
                   <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary">
                     {p.body}
@@ -210,9 +246,20 @@ export function NewsAdminClient({
       </Panel>
 
       <Panel className="p-5">
-        <h2 className="text-sm font-semibold text-text-primary">
-          New post
-        </h2>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">
+            {editingId ? "Edit post" : "New post"}
+          </h2>
+          {editingId ? (
+            <button
+              type="button"
+              onClick={reset}
+              className="text-xs text-text-tertiary transition-colors hover:text-text-primary"
+            >
+              Cancel edit
+            </button>
+          ) : null}
+        </div>
         <form onSubmit={(e) => void onSubmit(e)} className="mt-4 space-y-4">
           <Field label="Title">
             <Input
@@ -314,7 +361,13 @@ export function NewsAdminClient({
               Reset
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting ? "Publishing…" : "Publish"}
+              {submitting
+                ? editingId
+                  ? "Saving…"
+                  : "Publishing…"
+                : editingId
+                  ? "Save changes"
+                  : "Publish"}
             </Button>
           </div>
         </form>


### PR DESCRIPTION
## What this is

The other half of [[#154]]'s PATCH endpoints. Each admin form now has a real edit path — buttons + form-state switch — so an admin can fix a typo without delete-then-recreate.

## What changed

Same pattern applied four times, one per content type:

- **Pencil button** next to the Trash2 on every list row.
- **`editingId` state**; setting it fills the form with the row's values + scrolls to top.
- **Header swaps** "New post" → "Edit post", adds a small *"Cancel edit"* link that resets.
- **Submit switches** to `PATCH /api/<model>/[id]`; button text reflects mode ("Save changes" / "Publish").
- **Reset** clears `editingId` so the next *new* flow starts clean.
- **Toast wording** flips between "Updated" and the original "Published."

## Per-model details

- **News** — `publishedAt` rehydrates as `YYYY-MM-DD` for `<input type="date">`.
- **Events** — new `isoToLocal()` helper turns the row's ISO start/end into the local-time slice `<input type="datetime-local">` wants, so the picker shows what the visitor actually sees.
- **Clubs** — `initialsOverride` pre-fills from `club.initials` so the saved letters appear (not the auto-derived ones).
- **Dining** — `anchor` rehydrates the shape `AnchorPicker` emits — `{ refId, refName }` from the first stored anchor.

## Testing

`tsc --noEmit` clean. `next lint` clean. No new endpoints, no new deps, no migration. Pure UI on top of PR #154's PATCH routes.

## What's still on the v1 list

- ICS feed sync writing through `EventPost`.
- Localised content fields (when bilingual comes back).
- "Campus health" checklist on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)