### PR TITLE
feat(campus): public list pages for events, news, clubs

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ExternalLink, MapPin } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale } from "@/app/lib/i18n-core";
+import { listTopClubsForProject } from "@/lib/clubs-db";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+const AVATAR_BG: Record<string, string> = {
+  purple: "var(--brand-primary)",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  const scene = (map?.sceneData ?? null) as {
+    branding?: { name?: string };
+  } | null;
+  const name = scene?.branding?.name || map?.title || "Campus";
+  return {
+    title: `Clubs · ${name}`,
+    description: `Student clubs and societies at ${name}.`,
+  };
+}
+
+/**
+ * `/campus/[token]/clubs` — public clubs list.
+ *
+ * Larger than the home's rail — every club on campus, ranked by
+ * activity. Each card links to its detail page; the View pill opens
+ * the club's external link (Discord / Insta / …) in a new tab.
+ */
+export default async function ClubsPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const clubs = await listTopClubsForProject(map.id, 50);
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <section className="mx-auto max-w-[1280px] px-4 py-8 md:px-6 md:py-12">
+        <h1 className="text-3xl font-medium text-[var(--brand-text)]">
+          Clubs
+        </h1>
+        <p className="mt-2 text-sm text-[var(--brand-text-muted)]">
+          Student societies, sport clubs, interest groups — ranked by
+          activity.
+        </p>
+
+        {clubs.length === 0 ? (
+          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+            No clubs published yet.
+          </div>
+        ) : (
+          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {clubs.map((c) => (
+              <article
+                key={c.id}
+                className="flex flex-col gap-3 rounded-2xl border border-[var(--brand-line)] bg-white p-5"
+              >
+                <div className="flex items-center gap-3">
+                  {c.imageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={c.imageUrl}
+                      alt=""
+                      className="h-12 w-12 rounded-xl object-cover"
+                    />
+                  ) : (
+                    <span
+                      aria-hidden
+                      className="flex h-12 w-12 items-center justify-center rounded-xl text-sm font-medium text-white"
+                      style={{ backgroundColor: AVATAR_BG[c.avatarColor] }}
+                    >
+                      {c.initials}
+                    </span>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <Link
+                      href={`/campus/${token}/clubs/${c.id}${lang}`}
+                      className="block truncate text-base font-medium text-[var(--brand-text)] transition-colors hover:text-[var(--brand-primary)]"
+                    >
+                      {c.name}
+                    </Link>
+                    <p className="mt-0.5 truncate text-xs text-[var(--brand-text-muted)]">
+                      {c.memberCount} members
+                      {c.meetsCadence ? ` · ${c.meetsCadence}` : ""}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="line-clamp-3 text-sm leading-relaxed text-[var(--brand-text)]">
+                  {c.description}
+                </p>
+
+                {c.anchors[0] ? (
+                  <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]">
+                    <MapPin size={12} strokeWidth={1.75} />
+                    {c.anchors[0].refName}
+                  </span>
+                ) : null}
+
+                <div className="mt-auto flex items-center gap-2 pt-2">
+                  <Link
+                    href={`/campus/${token}/clubs/${c.id}${lang}`}
+                    className="rounded-full border border-[var(--brand-line)] bg-white px-3 py-1.5 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
+                  >
+                    Details
+                  </Link>
+                  {c.externalLink ? (
+                    <a
+                      href={c.externalLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                      style={{ backgroundColor: "var(--brand-primary)" }}
+                    >
+                      <ExternalLink size={12} strokeWidth={1.75} />
+                      View
+                    </a>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/events/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Calendar, Compass, MapPin } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale } from "@/app/lib/i18n-core";
+import {
+  formatEventWhen,
+  listUpcomingEventsForProject,
+} from "@/lib/events-db";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+const BANNER_BG: Record<string, string> = {
+  purple: "var(--brand-primary)",
+  coral: "#D85A30",
+  teal: "#1D9E75",
+  pink: "#D4537E",
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  const scene = (map?.sceneData ?? null) as {
+    branding?: { name?: string };
+  } | null;
+  const name = scene?.branding?.name || map?.title || "Campus";
+  return {
+    title: `Events · ${name}`,
+    description: `What's happening on the ${name} campus this week and beyond.`,
+  };
+}
+
+/**
+ * `/campus/[token]/events` — public events list.
+ *
+ * Mirrors the home's "Happening this week" rail but in a single-page
+ * list view: every upcoming and ongoing event in one place. Each row
+ * links to its detail page; the anchor chip deep-links into MappedIn
+ * when a `refId` is set.
+ */
+export default async function EventsPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+  const events = await listUpcomingEventsForProject(map.id, 50);
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <section className="mx-auto max-w-[1280px] px-4 py-8 md:px-6 md:py-12">
+        <h1 className="text-3xl font-medium text-[var(--brand-text)]">
+          Events
+        </h1>
+        <p className="mt-2 text-sm text-[var(--brand-text-muted)]">
+          What’s happening this week and beyond on campus.
+        </p>
+
+        {events.length === 0 ? (
+          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+            No events published yet.
+          </div>
+        ) : (
+          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {events.map((e) => {
+              const firstAnchor = e.anchors[0];
+              return (
+                <Link
+                  key={e.id}
+                  href={`/campus/${token}/events/${e.id}${lang}`}
+                  className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
+                >
+                  <div
+                    className="flex h-20 items-end justify-start p-4"
+                    style={{
+                      backgroundColor: BANNER_BG[e.bannerColor] ?? "#534AB7",
+                    }}
+                  >
+                    <Calendar
+                      size={24}
+                      strokeWidth={1.5}
+                      className="text-white"
+                      aria-hidden
+                    />
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2 p-5">
+                    <h2 className="text-base font-medium text-[var(--brand-text)]">
+                      {e.title}
+                    </h2>
+                    <span className="text-xs text-[var(--brand-text-muted)]">
+                      {formatEventWhen(e.startsAt)}
+                    </span>
+                    <p className="line-clamp-2 text-xs leading-relaxed text-[var(--brand-text-muted)]">
+                      {e.description}
+                    </p>
+                    <div className="mt-auto flex flex-wrap items-center gap-2 pt-2 text-xs text-[var(--brand-text-muted)]">
+                      {firstAnchor ? (
+                        <span className="inline-flex items-center gap-1">
+                          <MapPin size={14} strokeWidth={1.75} />
+                          {firstAnchor.refName}
+                        </span>
+                      ) : null}
+                      {firstAnchor?.refId ? (
+                        <span className="ml-auto inline-flex items-center gap-1 text-[var(--brand-primary)] group-hover:underline">
+                          <Compass size={14} strokeWidth={1.75} />
+                          Directions
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
+        <Link
+          href={mapHref}
+          className="mt-10 inline-flex items-center gap-2 text-sm font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
+        >
+          <Compass size={16} strokeWidth={1.75} />
+          Open the campus map
+        </Link>
+      </section>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/news/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/page.tsx
@@ -1,0 +1,170 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MapPin } from "lucide-react";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+import { detectLocale, pickText } from "@/app/lib/i18n-core";
+import {
+  listNewsForProject,
+  relativeNewsTime,
+} from "@/lib/news";
+import { readPosts } from "@/lib/posts";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
+import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+
+type Params = Promise<{ token: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  const scene = (map?.sceneData ?? null) as {
+    branding?: { name?: string };
+  } | null;
+  const name = scene?.branding?.name || map?.title || "Campus";
+  return {
+    title: `News · ${name}`,
+    description: `Latest announcements and updates from the ${name} campus.`,
+  };
+}
+
+/**
+ * `/campus/[token]/news` — public news list.
+ *
+ * Combines `NewsPost` rows with legacy `sceneData.posts` so existing
+ * tenants don't lose their content during the migration — same merge
+ * the consumer home uses, just unbounded.
+ */
+export default async function NewsPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { token } = await params;
+  const sp = await searchParams;
+  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
+
+  const map = await getPublicCampusByToken(token);
+  if (!map) notFound();
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const campusName = branding.name || map.title;
+  const accentColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : undefined;
+  const themeStyle = accentColor
+    ? ({ ["--brand-primary" as string]: accentColor } as React.CSSProperties)
+    : undefined;
+
+  const lang = `?lang=${locale}`;
+  const mapHref = `/campus/${token}/map${lang}`;
+
+  const [dbPosts, legacyPosts] = await Promise.all([
+    listNewsForProject(map.id, 100),
+    Promise.resolve(readPosts(map.sceneData)),
+  ]);
+
+  // Merge into one display shape, newest first. Legacy posts use
+  // their `?lang` pick; the new model is plain strings.
+  const news = [
+    ...dbPosts.map((p) => ({
+      id: p.id,
+      title: p.title,
+      body: p.body,
+      publishedAt: p.publishedAt,
+      anchors: p.anchors,
+      detailHref: `/campus/${token}/news/${p.id}${lang}`,
+    })),
+    ...legacyPosts.map((p) => ({
+      id: p.id,
+      title: pickText(p.title, locale) || "",
+      body: pickText(p.body, locale) || "",
+      publishedAt: p.publishedAt,
+      anchors: p.place
+        ? [
+            {
+              kind: (p.place.kind === "room" ? "room" : "building") as
+                | "room"
+                | "building",
+              refId: p.place.id,
+              refName: p.place.name,
+            },
+          ]
+        : [],
+      // Legacy posts don't have detail pages — link to the map with
+      // the place focused, or to the home if there's no place.
+      detailHref: p.place
+        ? `${mapHref}&space=${encodeURIComponent(p.place.id)}`
+        : `/campus/${token}${lang}`,
+    })),
+  ].sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt));
+
+  return (
+    <main data-consumer lang={locale} style={themeStyle}>
+      <ConsumerNav
+        campusName={campusName}
+        logoUrl={branding.logo}
+        token={token}
+        locale={locale}
+      />
+
+      <section className="mx-auto max-w-[820px] px-4 py-8 md:px-6 md:py-12">
+        <h1 className="text-3xl font-medium text-[var(--brand-text)]">News</h1>
+        <p className="mt-2 text-sm text-[var(--brand-text-muted)]">
+          Announcements, updates, and alerts.
+        </p>
+
+        {news.length === 0 ? (
+          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+            No news published yet.
+          </div>
+        ) : (
+          <div className="mt-6">
+            {news.map((n) => (
+              <article
+                key={n.id}
+                className="border-b border-[var(--brand-line)] py-5 last:border-b-0"
+              >
+                <Link href={n.detailHref} className="group block">
+                  <h2 className="text-base font-medium text-[var(--brand-text)] transition-colors group-hover:text-[var(--brand-primary)]">
+                    {n.title}
+                  </h2>
+                  <p className="mt-1 line-clamp-3 text-sm leading-relaxed text-[var(--brand-text-muted)]">
+                    {n.body}
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-3 text-[0.7rem] uppercase tracking-wide text-[var(--brand-text-muted)]">
+                    <span>{relativeNewsTime(n.publishedAt)}</span>
+                    {n.anchors[0] ? (
+                      <span className="inline-flex items-center gap-1 normal-case tracking-normal">
+                        <MapPin size={12} strokeWidth={1.75} />
+                        {n.anchors[0].refName}
+                      </span>
+                    ) : null}
+                  </div>
+                </Link>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <ConsumerFooter campusName={campusName} />
+    </main>
+  );
+}


### PR DESCRIPTION
## What this is

The consumer nav points at `/events`, `/news`, `/clubs`, `/dining` — only `/dining` had a list page (Arc 5). The other three 404'd. Fixing.

## What landed

### `/campus/[token]/events`
3-col card grid (lg) → 2-col (md) → 1-col (mobile). Each card links to its detail page. Coloured banner header, when + blurb, anchor chip + a "Directions" hint when the anchor carries a `refId`. CTA at the bottom opens the campus map.

### `/campus/[token]/news`
Single-column list, headlines link into the detail page. Uses the home's **NewsPost + legacy `sceneData.posts` merge** so existing tenants don't lose any content during the transition. Legacy posts (no detail page) link to the map with the place focused — best we can do without a detail route.

### `/campus/[token]/clubs`
Card grid sorted by `popularityScore`. Each card carries a *Details* pill (in-app) **and** a *View* pill (external link) when the club has one. Anchor chip when set.

## Shared

All three:
- `ConsumerNav` + `ConsumerFooter`, `data-consumer` wrapper so per-org accent flows.
- Empty-state cards on each page.
- `mapHref` falls back to `/campus/[token]/map` consistently with the rest of the consumer surface.

## Testing

`tsc --noEmit` clean. `next lint` clean. No new deps, no new schema. Pure rendering on top of existing reads (`listUpcomingEventsForProject` / `listNewsForProject` / `listTopClubsForProject`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)