### PR TITLE
feat(campus): campus health checklist + ICS on the events list page

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/CampusHealth.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/CampusHealth.tsx
@@ -1,0 +1,159 @@
+import { Check, X } from "lucide-react";
+import { Panel } from "@klorad/design-system";
+
+export interface CampusHealthProps {
+  brandComplete: boolean;
+  hasIndoorMap: boolean;
+  isPublished: boolean;
+  newsCount: number;
+  eventsCount: number;
+  clubsCount: number;
+  diningCount: number;
+  feedCount: number;
+  /** `process.env.ANTHROPIC_API_KEY` truthy at request time. */
+  assistantEnabled: boolean;
+}
+
+interface Check {
+  label: string;
+  /** Optional helper line under the label. */
+  hint?: string;
+  ok: boolean;
+  /** When `false`, the check is informational (greyed out) rather than red. */
+  required?: boolean;
+}
+
+/**
+ * Bottom-of-page "Campus health" panel — one ✓/✗ per dimension the
+ * tenant is likely to forget. Mostly informational; the counts come
+ * from the same Prisma reads the public surface uses, plus the
+ * `ANTHROPIC_API_KEY` env var (server-only). The numbers in the
+ * thresholds are intentionally low — we want a *healthy* tenant to
+ * easily hit them, not a *complete* one.
+ */
+export function CampusHealth({
+  brandComplete,
+  hasIndoorMap,
+  isPublished,
+  newsCount,
+  eventsCount,
+  clubsCount,
+  diningCount,
+  feedCount,
+  assistantEnabled,
+}: CampusHealthProps) {
+  const checks: Check[] = [
+    {
+      label: "Branding is complete",
+      hint: "Name, logo, and primary colour all set",
+      ok: brandComplete,
+      required: true,
+    },
+    {
+      label: "MappedIn venue is connected",
+      hint: "Without it, anchors can't deep-link into the map",
+      ok: hasIndoorMap,
+      required: true,
+    },
+    {
+      label: "Campus is published",
+      hint: "Drafts aren't visible to students",
+      ok: isPublished,
+      required: true,
+    },
+    {
+      label: "At least 1 news post",
+      ok: newsCount >= 1,
+    },
+    {
+      label: "At least 3 events scheduled",
+      hint: `Currently ${eventsCount}`,
+      ok: eventsCount >= 3,
+    },
+    {
+      label: "At least 1 club published",
+      ok: clubsCount >= 1,
+    },
+    {
+      label: "At least 1 dining location",
+      ok: diningCount >= 1,
+    },
+    {
+      label: "ICS feed connected",
+      hint: "Optional — but auto-syncing calendars beats manual entry",
+      ok: feedCount >= 1,
+      required: false,
+    },
+    {
+      label: "AI chat enabled",
+      hint: assistantEnabled
+        ? "ANTHROPIC_API_KEY is set"
+        : "Set ANTHROPIC_API_KEY to power natural-language search",
+      ok: assistantEnabled,
+      required: false,
+    },
+  ];
+
+  const passing = checks.filter((c) => c.ok).length;
+  const total = checks.length;
+  const ratio = total > 0 ? passing / total : 0;
+
+  return (
+    <Panel className="mt-8 p-5">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Campus health
+        </h2>
+        <span className="text-xs font-medium text-text-tertiary">
+          {passing} / {total}
+        </span>
+      </div>
+
+      <div
+        aria-hidden
+        className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-surface-2"
+      >
+        <div
+          className="h-full rounded-full bg-accent transition-all"
+          style={{ width: `${Math.round(ratio * 100)}%` }}
+        />
+      </div>
+
+      <ul className="mt-5 grid grid-cols-1 gap-2 md:grid-cols-2">
+        {checks.map((c) => (
+          <li
+            key={c.label}
+            className="flex items-start gap-3 rounded-lg border border-solid border-line-soft p-3"
+          >
+            <span
+              aria-hidden
+              className={
+                c.ok
+                  ? "flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent-soft text-accent"
+                  : c.required === false
+                    ? "flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-surface-2 text-text-tertiary"
+                    : "flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-red-50 text-red-600"
+              }
+            >
+              {c.ok ? (
+                <Check size={12} strokeWidth={2.5} />
+              ) : (
+                <X size={12} strokeWidth={2.5} />
+              )}
+            </span>
+            <div className="min-w-0">
+              <span className="block text-sm font-medium text-text-primary">
+                {c.label}
+              </span>
+              {c.hint ? (
+                <span className="mt-0.5 block text-xs text-text-tertiary">
+                  {c.hint}
+                </span>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/page.tsx
@@ -4,7 +4,9 @@ import { ChevronLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { projectHasContent } from "@/lib/sample-seed";
+import { readEventFeeds } from "@/lib/events";
 import { OnboardingClient } from "./OnboardingClient";
+import { CampusHealth } from "./CampusHealth";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
 
@@ -67,6 +69,27 @@ export default async function OnboardingPage({
   );
   const hasIndoorMap = Boolean(scene.indoorMapId);
 
+  // Per-rail counts for the health checklist. Run in parallel — a
+  // missing model (pending migration) is the same `.catch(() => 0)`
+  // graceful path the public surface uses.
+  const [newsCount, eventsCount, clubsCount, diningCount] = await Promise.all([
+    prisma.newsPost.count({ where: { projectId: mapId } }).catch(() => 0),
+    prisma.eventPost.count({ where: { projectId: mapId } }).catch(() => 0),
+    prisma.club.count({ where: { projectId: mapId } }).catch(() => 0),
+    prisma.diningLocation.count({ where: { projectId: mapId } }).catch(() => 0),
+  ]);
+  const feedCount = readEventFeeds(project.sceneData).length;
+  // Brand-completeness is a stricter check than `hasBranding` (any
+  // one set) — we want all three for the badge to flip.
+  const brandComplete = Boolean(
+    scene.branding?.name &&
+      scene.branding?.logo &&
+      scene.branding?.primaryColor,
+  );
+  // Process-level env — only the server knows. Tells the admin
+  // whether the AI chat is on this deployment.
+  const assistantEnabled = Boolean(process.env.ANTHROPIC_API_KEY);
+
   return (
     <div className="mx-auto max-w-[960px] px-6 py-10">
       <Link
@@ -94,6 +117,18 @@ export default async function OnboardingPage({
         hasBranding={hasBranding}
         hasIndoorMap={hasIndoorMap}
         isPublished={project.isPublished}
+      />
+
+      <CampusHealth
+        brandComplete={brandComplete}
+        hasIndoorMap={hasIndoorMap}
+        isPublished={project.isPublished}
+        newsCount={newsCount}
+        eventsCount={eventsCount}
+        clubsCount={clubsCount}
+        diningCount={diningCount}
+        feedCount={feedCount}
+        assistantEnabled={assistantEnabled}
       />
     </div>
   );

--- a/apps/campus/app/(public)/campus/[token]/events/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/page.tsx
@@ -8,6 +8,9 @@ import {
   formatEventWhen,
   listUpcomingEventsForProject,
 } from "@/lib/events-db";
+import { readEventFeeds, type CampusEvent } from "@/lib/events";
+import { fetchCampusEvents } from "@/lib/events-server";
+import { eventHasDetailPage, mergeEvents } from "@/lib/events-merge";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
 
@@ -81,7 +84,20 @@ export default async function EventsPage({
 
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
-  const events = await listUpcomingEventsForProject(map.id, 50);
+  // DB-backed events + any ICS feeds the admin configured. Same
+  // merge the consumer home uses; defensive `.catch()` on the ICS
+  // fetch so a slow / broken feed doesn't blank the page.
+  const feedUrls = readEventFeeds(map.sceneData);
+  const [dbEvents, icsEvents] = await Promise.all([
+    listUpcomingEventsForProject(map.id, 100),
+    feedUrls.length > 0
+      ? fetchCampusEvents(feedUrls).catch((err): CampusEvent[] => {
+          console.error("[events page] ICS fetch failed", err);
+          return [];
+        })
+      : Promise.resolve<CampusEvent[]>([]),
+  ]);
+  const events = mergeEvents(dbEvents, icsEvents, 100);
 
   return (
     <main data-consumer lang={locale} style={themeStyle}>
@@ -108,10 +124,17 @@ export default async function EventsPage({
           <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
             {events.map((e) => {
               const firstAnchor = e.anchors[0];
+              // DB rows link to their detail page; ICS rows (id contains
+              // `::`) link to the map with the anchor focused.
+              const href = eventHasDetailPage(e.id)
+                ? `/campus/${token}/events/${e.id}${lang}`
+                : firstAnchor?.refId
+                  ? `${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`
+                  : mapHref;
               return (
                 <Link
                   key={e.id}
-                  href={`/campus/${token}/events/${e.id}${lang}`}
+                  href={href}
                   className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
                 >
                   <div
@@ -135,7 +158,7 @@ export default async function EventsPage({
                       {formatEventWhen(e.startsAt)}
                     </span>
                     <p className="line-clamp-2 text-xs leading-relaxed text-[var(--brand-text-muted)]">
-                      {e.description}
+                      {e.blurb}
                     </p>
                     <div className="mt-auto flex flex-wrap items-center gap-2 pt-2 text-xs text-[var(--brand-text-muted)]">
                       {firstAnchor ? (


### PR DESCRIPTION
## What this is

The final v1-polish PR. Two small but visible additions that close the loop on the four content arcs + the ICS feed work — and put us at v1 done.

## What landed

### Campus health checklist

`/org/[orgId]/maps/[mapId]/onboarding` now ends with a "Campus health" panel showing **9 checks**:

| Required | Check |
|---|---|
| ✓ | Branding complete (name + logo + colour) |
| ✓ | MappedIn venue connected |
| ✓ | Campus is published |
|  | ≥1 news post |
|  | ≥3 events scheduled |
|  | ≥1 club published |
|  | ≥1 dining location |
| info | ICS feed connected |
| info | AI chat enabled (`ANTHROPIC_API_KEY` set) |

- Each row: rounded icon — **accent-soft** when ok, **red** when a *required* item fails, **grey** when an *informational* item is off — + label + optional hint.
- Progress bar above shows passing / total.
- Counts come from the same `prisma.<model>.count()` reads the public surface uses, with the same `.catch(() => 0)` graceful path. The env-var check is server-only.
- Thresholds are intentionally low — a *healthy* tenant hits them, not a *complete* one.

### ICS on the public events list

`/campus/[token]/events` now runs the same `readEventFeeds → fetchCampusEvents → mergeEvents` pipeline the consumer home has had since #157. Cards from ICS rows link to the map with the anchor focused (when one's set) instead of a 404 detail page. The one type bug (`e.description` vs `e.blurb`) is fixed in the same change.

## Testing

`tsc --noEmit` clean. `next lint` clean. No new deps, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)