### PR TITLE
feat(campus): bilingual content fields — EN + EL per row

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
@@ -42,7 +42,9 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   const [clubs, setClubs] = useState<Club[]>(initialClubs);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState("");
+  const [nameEl, setNameEl] = useState("");
   const [description, setDescription] = useState("");
+  const [descriptionEl, setDescriptionEl] = useState("");
   const [initialsOverride, setInitialsOverride] = useState("");
   const [avatarColor, setAvatarColor] = useState<ClubColor>("purple");
   const [memberCount, setMemberCount] = useState("");
@@ -71,7 +73,9 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   const reset = () => {
     setEditingId(null);
     setName("");
+    setNameEl("");
     setDescription("");
+    setDescriptionEl("");
     setInitialsOverride("");
     setAvatarColor("purple");
     setMemberCount("");
@@ -84,7 +88,9 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   const startEdit = (club: Club) => {
     setEditingId(club.id);
     setName(club.name);
+    setNameEl(club.nameEl ?? "");
     setDescription(club.description);
+    setDescriptionEl(club.descriptionEl ?? "");
     setInitialsOverride(club.initials);
     setAvatarColor(club.avatarColor);
     setMemberCount(String(club.memberCount));
@@ -114,7 +120,9 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
+          nameEl: nameEl.trim() || "",
           description: description.trim(),
+          descriptionEl: descriptionEl.trim() || "",
           initials: initialsOverride.trim() || undefined,
           avatarColor,
           memberCount: memberCount.trim()
@@ -266,6 +274,14 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
             />
           </Field>
 
+          <Field label="Name (Greek, optional)">
+            <Input
+              value={nameEl}
+              onChange={(e) => setNameEl(e.target.value)}
+              placeholder="Όμιλος επιστήμης δεδομένων"
+            />
+          </Field>
+
           <Field label="Description">
             <Textarea
               value={description}
@@ -273,6 +289,15 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
               placeholder="What the club does."
               rows={4}
               required
+            />
+          </Field>
+
+          <Field label="Description (Greek, optional)">
+            <Textarea
+              value={descriptionEl}
+              onChange={(e) => setDescriptionEl(e.target.value)}
+              placeholder="Τι κάνει ο όμιλος."
+              rows={4}
             />
           </Field>
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -38,7 +38,9 @@ export function DiningAdminClient({
   const [locations, setLocations] = useState<DiningLocation[]>(initialLocations);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState("");
+  const [nameEl, setNameEl] = useState("");
   const [description, setDescription] = useState("");
+  const [descriptionEl, setDescriptionEl] = useState("");
   const [hoursText, setHoursText] = useState("");
   const [cuisine, setCuisine] = useState("");
   const [menuUrl, setMenuUrl] = useState("");
@@ -63,7 +65,9 @@ export function DiningAdminClient({
   const reset = () => {
     setEditingId(null);
     setName("");
+    setNameEl("");
     setDescription("");
+    setDescriptionEl("");
     setHoursText("");
     setCuisine("");
     setMenuUrl("");
@@ -74,7 +78,9 @@ export function DiningAdminClient({
   const startEdit = (location: DiningLocation) => {
     setEditingId(location.id);
     setName(location.name);
+    setNameEl(location.nameEl ?? "");
     setDescription(location.description);
+    setDescriptionEl(location.descriptionEl ?? "");
     setHoursText(location.hoursText ?? "");
     setCuisine(location.cuisine ?? "");
     setMenuUrl(location.menuUrl ?? "");
@@ -109,7 +115,9 @@ export function DiningAdminClient({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: name.trim(),
+          nameEl: nameEl.trim() || "",
           description: description.trim(),
+          descriptionEl: descriptionEl.trim() || "",
           hoursText: hoursText.trim() || undefined,
           cuisine: cuisine.trim() || undefined,
           menuUrl: menuUrl.trim() || undefined,
@@ -255,6 +263,14 @@ export function DiningAdminClient({
             />
           </Field>
 
+          <Field label="Name (Greek, optional)">
+            <Input
+              value={nameEl}
+              onChange={(e) => setNameEl(e.target.value)}
+              placeholder="Παβιγιόν καφέ"
+            />
+          </Field>
+
           <Field label="Description">
             <Textarea
               value={description}
@@ -262,6 +278,15 @@ export function DiningAdminClient({
               placeholder="Quick-service cafe with sandwiches, coffee, and bowls."
               rows={3}
               required
+            />
+          </Field>
+
+          <Field label="Description (Greek, optional)">
+            <Textarea
+              value={descriptionEl}
+              onChange={(e) => setDescriptionEl(e.target.value)}
+              placeholder="Καφετέρια με σάντουιτς, καφέ και μπολ."
+              rows={3}
             />
           </Field>
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -66,7 +66,9 @@ export function EventsAdminClient({
   const [events, setEvents] = useState<EventPost[]>(initialEvents);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
+  const [titleEl, setTitleEl] = useState("");
   const [description, setDescription] = useState("");
+  const [descriptionEl, setDescriptionEl] = useState("");
   const [startsAt, setStartsAt] = useState(plusHoursLocal(24));
   const [endsAt, setEndsAt] = useState(plusHoursLocal(26));
   const [bannerColor, setBannerColor] = useState<EventBanner>("purple");
@@ -95,7 +97,9 @@ export function EventsAdminClient({
   const reset = () => {
     setEditingId(null);
     setTitle("");
+    setTitleEl("");
     setDescription("");
+    setDescriptionEl("");
     setStartsAt(plusHoursLocal(24));
     setEndsAt(plusHoursLocal(26));
     setBannerColor("purple");
@@ -118,7 +122,9 @@ export function EventsAdminClient({
   const startEdit = (event: EventPost) => {
     setEditingId(event.id);
     setTitle(event.title);
+    setTitleEl(event.titleEl ?? "");
     setDescription(event.description);
+    setDescriptionEl(event.descriptionEl ?? "");
     setStartsAt(isoToLocal(event.startsAt));
     setEndsAt(isoToLocal(event.endsAt));
     setBannerColor(event.bannerColor);
@@ -159,7 +165,9 @@ export function EventsAdminClient({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: title.trim(),
+          titleEl: titleEl.trim() || "",
           description: description.trim(),
+          descriptionEl: descriptionEl.trim() || "",
           startsAt: new Date(startsAt).toISOString(),
           endsAt: new Date(endsAt).toISOString(),
           bannerColor,
@@ -311,6 +319,14 @@ export function EventsAdminClient({
             />
           </Field>
 
+          <Field label="Title (Greek, optional)">
+            <Input
+              value={titleEl}
+              onChange={(e) => setTitleEl(e.target.value)}
+              placeholder="Βραδιά ελεύθερου μικροφώνου"
+            />
+          </Field>
+
           <Field label="Description">
             <Textarea
               value={description}
@@ -318,6 +334,15 @@ export function EventsAdminClient({
               placeholder="What students need to know."
               rows={4}
               required
+            />
+          </Field>
+
+          <Field label="Description (Greek, optional)">
+            <Textarea
+              value={descriptionEl}
+              onChange={(e) => setDescriptionEl(e.target.value)}
+              placeholder="Τι πρέπει να ξέρουν οι φοιτητές."
+              rows={4}
             />
           </Field>
 

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -56,7 +56,9 @@ export function NewsAdminClient({
   /** Non-null when the form is editing an existing post. */
   const [editingId, setEditingId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
+  const [titleEl, setTitleEl] = useState("");
   const [body, setBody] = useState("");
+  const [bodyEl, setBodyEl] = useState("");
   const [category, setCategory] = useState<NewsCategory>("announcement");
   const [publishedAt, setPublishedAt] = useState(todayISODate());
   const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
@@ -80,7 +82,9 @@ export function NewsAdminClient({
   const reset = () => {
     setEditingId(null);
     setTitle("");
+    setTitleEl("");
     setBody("");
+    setBodyEl("");
     setCategory("announcement");
     setPublishedAt(todayISODate());
     setAnchor(EMPTY_ANCHOR);
@@ -91,7 +95,9 @@ export function NewsAdminClient({
   const startEdit = (post: NewsPost) => {
     setEditingId(post.id);
     setTitle(post.title);
+    setTitleEl(post.titleEl ?? "");
     setBody(post.body);
+    setBodyEl(post.bodyEl ?? "");
     setCategory(post.category);
     setPublishedAt(post.publishedAt.slice(0, 10));
     setAnchor(
@@ -123,7 +129,9 @@ export function NewsAdminClient({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: title.trim(),
+          titleEl: titleEl.trim() || "",
           body: body.trim(),
+          bodyEl: bodyEl.trim() || "",
           category,
           // Datetime-local input gives a local-zone string; turn it
           // into a UTC ISO so the server stores a clean instant.
@@ -270,6 +278,14 @@ export function NewsAdminClient({
             />
           </Field>
 
+          <Field label="Title (Greek, optional)">
+            <Input
+              value={titleEl}
+              onChange={(e) => setTitleEl(e.target.value)}
+              placeholder="Παρατεταμένες ώρες βιβλιοθήκης"
+            />
+          </Field>
+
           <Field label="Body">
             <Textarea
               value={body}
@@ -277,6 +293,15 @@ export function NewsAdminClient({
               placeholder="What students need to know."
               rows={5}
               required
+            />
+          </Field>
+
+          <Field label="Body (Greek, optional)">
+            <Textarea
+              value={bodyEl}
+              onChange={(e) => setBodyEl(e.target.value)}
+              placeholder="Τι πρέπει να ξέρουν οι φοιτητές."
+              rows={5}
             />
           </Field>
 

--- a/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ChevronLeft, ExternalLink, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
 import { getClub } from "@/lib/clubs-db";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
@@ -80,6 +80,12 @@ export default async function ClubDetailPage({
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
   const avatarBg = AVATAR_HEX[club.avatarColor] ?? AVATAR_HEX.purple;
+  const name = pickLocalized(club.name, club.nameEl, locale);
+  const description = pickLocalized(
+    club.description,
+    club.descriptionEl,
+    locale,
+  );
 
   return (
     <main data-consumer lang={locale} style={themeStyle}>
@@ -118,7 +124,7 @@ export default async function ClubDetailPage({
           )}
           <div>
             <h1 className="text-2xl font-medium text-[var(--brand-text)] md:text-3xl">
-              {club.name}
+              {name}
             </h1>
             <p className="mt-1 text-sm text-[var(--brand-text-muted)]">
               {club.memberCount} members
@@ -153,7 +159,7 @@ export default async function ClubDetailPage({
         ) : null}
 
         <div className="mt-8 whitespace-pre-wrap text-base leading-relaxed text-[var(--brand-text)]">
-          {club.description}
+          {description}
         </div>
 
         {club.externalLink ? (

--- a/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ExternalLink, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
 import { listTopClubsForProject } from "@/lib/clubs-db";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
@@ -102,7 +102,14 @@ export default async function ClubsPage({
           </div>
         ) : (
           <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-            {clubs.map((c) => (
+            {clubs.map((c) => {
+              const name = pickLocalized(c.name, c.nameEl, locale);
+              const description = pickLocalized(
+                c.description,
+                c.descriptionEl,
+                locale,
+              );
+              return (
               <article
                 key={c.id}
                 className="flex flex-col gap-3 rounded-2xl border border-[var(--brand-line)] bg-white p-5"
@@ -129,7 +136,7 @@ export default async function ClubsPage({
                       href={`/campus/${token}/clubs/${c.id}${lang}`}
                       className="block truncate text-base font-medium text-[var(--brand-text)] transition-colors hover:text-[var(--brand-primary)]"
                     >
-                      {c.name}
+                      {name}
                     </Link>
                     <p className="mt-0.5 truncate text-xs text-[var(--brand-text-muted)]">
                       {c.memberCount} members
@@ -139,7 +146,7 @@ export default async function ClubsPage({
                 </div>
 
                 <p className="line-clamp-3 text-sm leading-relaxed text-[var(--brand-text)]">
-                  {c.description}
+                  {description}
                 </p>
 
                 {c.anchors[0] ? (
@@ -170,7 +177,8 @@ export default async function ClubsPage({
                   ) : null}
                 </div>
               </article>
-            ))}
+              );
+            })}
           </div>
         )}
       </section>

--- a/apps/campus/app/(public)/campus/[token]/dining/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/dining/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Clock, ExternalLink, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
 import { listDiningForProject } from "@/lib/dining-db";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
@@ -97,6 +97,12 @@ export default async function DiningPage({
           <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2">
             {locations.map((l) => {
               const firstAnchor = l.anchors[0];
+              const name = pickLocalized(l.name, l.nameEl, locale);
+              const description = pickLocalized(
+                l.description,
+                l.descriptionEl,
+                locale,
+              );
               return (
                 <article
                   key={l.id}
@@ -122,7 +128,7 @@ export default async function DiningPage({
                   <div className="flex flex-1 flex-col gap-3 p-5">
                     <div>
                       <h2 className="text-lg font-medium text-[var(--brand-text)]">
-                        {l.name}
+                        {name}
                       </h2>
                       {l.cuisine ? (
                         <p className="mt-0.5 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
@@ -132,7 +138,7 @@ export default async function DiningPage({
                     </div>
 
                     <p className="text-sm leading-relaxed text-[var(--brand-text)]">
-                      {l.description}
+                      {description}
                     </p>
 
                     {l.hoursText ? (

--- a/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ChevronLeft, MapPin, Compass, ExternalLink } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
 import {
   formatEventWhen,
   getEventPost,
@@ -83,6 +83,12 @@ export default async function EventDetailPage({
 
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
+  const title = pickLocalized(event.title, event.titleEl, locale);
+  const description = pickLocalized(
+    event.description,
+    event.descriptionEl,
+    locale,
+  );
   const firstAnchor = event.anchors[0];
   // Anchor with a refId → drop onto the map focused on that space.
   // Without a refId we still link to the map (the visitor can search).
@@ -120,7 +126,7 @@ export default async function EventDetailPage({
         ) : null}
 
         <h1 className="mt-8 text-3xl font-medium leading-tight text-[var(--brand-text)] md:text-4xl">
-          {event.title}
+          {title}
         </h1>
 
         <p className="mt-3 text-sm text-[var(--brand-text-muted)]">
@@ -157,7 +163,7 @@ export default async function EventDetailPage({
         ) : null}
 
         <div className="mt-8 whitespace-pre-wrap text-base leading-relaxed text-[var(--brand-text)]">
-          {event.description}
+          {description}
         </div>
 
         <div className="mt-8 flex flex-wrap gap-3">

--- a/apps/campus/app/(public)/campus/[token]/events/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Calendar, Compass, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
 import {
   formatEventWhen,
   listUpcomingEventsForProject,
@@ -97,7 +97,14 @@ export default async function EventsPage({
         })
       : Promise.resolve<CampusEvent[]>([]),
   ]);
-  const events = mergeEvents(dbEvents, icsEvents, 100);
+  // Localise the DB rows before they meet `mergeEvents`. ICS rows
+  // have no EL columns to pick from; they stay as-is.
+  const dbEventsLocalised = dbEvents.map((e) => ({
+    ...e,
+    title: pickLocalized(e.title, e.titleEl, locale),
+    description: pickLocalized(e.description, e.descriptionEl, locale),
+  }));
+  const events = mergeEvents(dbEventsLocalised, icsEvents, 100);
 
   return (
     <main data-consumer lang={locale} style={themeStyle}>

--- a/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ChevronLeft, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
 import {
   formatNewsDate,
   getNewsPost,
@@ -88,6 +88,8 @@ export default async function NewsDetailPage({
 
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
+  const title = pickLocalized(post.title, post.titleEl, locale);
+  const body = pickLocalized(post.body, post.bodyEl, locale);
 
   return (
     <main data-consumer lang={locale} style={themeStyle}>
@@ -112,7 +114,7 @@ export default async function NewsDetailPage({
         </p>
 
         <h1 className="mt-2 text-3xl font-medium leading-tight text-[var(--brand-text)] md:text-4xl">
-          {post.title}
+          {title}
         </h1>
 
         {post.anchors.length > 0 ? (
@@ -152,7 +154,7 @@ export default async function NewsDetailPage({
         ) : null}
 
         <div className="mt-8 whitespace-pre-wrap text-base leading-relaxed text-[var(--brand-text)]">
-          {post.body}
+          {body}
         </div>
       </article>
 

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
 import { readHomePage } from "@/lib/home-page";
-import { detectLocale, pickText } from "@/app/lib/i18n-core";
+import { detectLocale, pickLocalized, pickText } from "@/app/lib/i18n-core";
 import { readPosts } from "@/lib/posts";
 import { listNewsForProject, type NewsPost } from "@/lib/news";
 import {
@@ -133,18 +133,25 @@ export default async function CampusHomePage({
   ]);
   const legacyPosts = readPosts(map.sceneData);
   const news: ConsumerNews[] = [
-    ...dbPosts.map((p) => ({
-      id: p.id,
-      title: p.title,
-      excerpt: p.body.length > 200 ? `${p.body.slice(0, 197)}…` : p.body,
-      category: p.category,
-      publishedAt: p.publishedAt,
-      anchors: p.anchors.map((a) => ({
-        kind: a.kind,
-        refId: a.refId,
-        refName: a.refName,
-      })),
-    })),
+    ...dbPosts.map((p) => {
+      const title = pickLocalized(p.title, p.titleEl, locale);
+      const bodyLocalised = pickLocalized(p.body, p.bodyEl, locale);
+      return {
+        id: p.id,
+        title,
+        excerpt:
+          bodyLocalised.length > 200
+            ? `${bodyLocalised.slice(0, 197)}…`
+            : bodyLocalised,
+        category: p.category,
+        publishedAt: p.publishedAt,
+        anchors: p.anchors.map((a) => ({
+          kind: a.kind,
+          refId: a.refId,
+          refName: a.refName,
+        })),
+      };
+    }),
     ...legacyPosts.map((p) => {
       const title = pickText(p.title, locale) || "";
       const bodyText = pickText(p.body, locale) || "";
@@ -182,7 +189,7 @@ export default async function CampusHomePage({
   // still click through to the club's detail page in-app.
   const clubs: ConsumerClub[] = dbClubs.map((c) => ({
     id: c.id,
-    name: c.name,
+    name: pickLocalized(c.name, c.nameEl, locale),
     initials: c.initials,
     avatarColor: c.avatarColor,
     memberCount: c.memberCount,
@@ -193,7 +200,14 @@ export default async function CampusHomePage({
   // Merge DB events + ICS-feed events into one list — soonest first,
   // dupes (same title + minute) collapsed. `eventPostToConsumer` and
   // `icsToConsumer` share the mapping logic in `events-merge.ts`.
-  const events = mergeEvents(dbEvents, icsEvents, 24);
+  // Localise titles + blurbs on the DB rows before they meet
+  // `mergeEvents`. ICS rows have no EL columns to pick from.
+  const dbEventsLocalised = dbEvents.map((e) => ({
+    ...e,
+    title: pickLocalized(e.title, e.titleEl, locale),
+    description: pickLocalized(e.description, e.descriptionEl, locale),
+  }));
+  const events = mergeEvents(dbEventsLocalised, icsEvents, 24);
 
   return (
     <ConsumerHome

--- a/apps/campus/app/api/clubs/[id]/route.ts
+++ b/apps/campus/app/api/clubs/[id]/route.ts
@@ -72,6 +72,19 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     }
     data.description = v;
   }
+  if (body.nameEl !== undefined) {
+    data.nameEl =
+      typeof body.nameEl === "string" && body.nameEl.trim().length > 0
+        ? body.nameEl.trim()
+        : null;
+  }
+  if (body.descriptionEl !== undefined) {
+    data.descriptionEl =
+      typeof body.descriptionEl === "string" &&
+      body.descriptionEl.trim().length > 0
+        ? body.descriptionEl.trim()
+        : null;
+  }
   if (typeof body.initials === "string" && body.initials.trim().length > 0) {
     data.initials = body.initials.trim().slice(0, 3).toUpperCase();
   }

--- a/apps/campus/app/api/dining/[id]/route.ts
+++ b/apps/campus/app/api/dining/[id]/route.ts
@@ -70,6 +70,19 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     }
     data.description = v;
   }
+  if (body.nameEl !== undefined) {
+    data.nameEl =
+      typeof body.nameEl === "string" && body.nameEl.trim().length > 0
+        ? body.nameEl.trim()
+        : null;
+  }
+  if (body.descriptionEl !== undefined) {
+    data.descriptionEl =
+      typeof body.descriptionEl === "string" &&
+      body.descriptionEl.trim().length > 0
+        ? body.descriptionEl.trim()
+        : null;
+  }
   if (body.hoursText !== undefined) {
     data.hoursText =
       typeof body.hoursText === "string" && body.hoursText.length > 0

--- a/apps/campus/app/api/events/[id]/route.ts
+++ b/apps/campus/app/api/events/[id]/route.ts
@@ -82,6 +82,19 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     }
     data.description = v;
   }
+  if (body.titleEl !== undefined) {
+    data.titleEl =
+      typeof body.titleEl === "string" && body.titleEl.trim().length > 0
+        ? body.titleEl.trim()
+        : null;
+  }
+  if (body.descriptionEl !== undefined) {
+    data.descriptionEl =
+      typeof body.descriptionEl === "string" &&
+      body.descriptionEl.trim().length > 0
+        ? body.descriptionEl.trim()
+        : null;
+  }
 
   // Validate start/end together so we never accept end < start.
   const newStart = parseDate(body.startsAt) ?? existing.startsAt;

--- a/apps/campus/app/api/maps/[mapId]/clubs/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/clubs/route.ts
@@ -58,6 +58,15 @@ export async function POST(req: Request, { params }: { params: Params }) {
       { status: 400 },
     );
   }
+  const nameEl =
+    typeof body.nameEl === "string" && body.nameEl.trim().length > 0
+      ? body.nameEl.trim()
+      : null;
+  const descriptionEl =
+    typeof body.descriptionEl === "string" &&
+    body.descriptionEl.trim().length > 0
+      ? body.descriptionEl.trim()
+      : null;
 
   const initials =
     typeof body.initials === "string" && body.initials.trim().length > 0
@@ -90,7 +99,9 @@ export async function POST(req: Request, { params }: { params: Params }) {
       organizationId: project.organizationId,
       projectId: mapId,
       name,
+      nameEl,
       description,
+      descriptionEl,
       initials,
       avatarColor,
       memberCount,

--- a/apps/campus/app/api/maps/[mapId]/dining/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/dining/route.ts
@@ -52,6 +52,15 @@ export async function POST(req: Request, { params }: { params: Params }) {
       { status: 400 },
     );
   }
+  const nameEl =
+    typeof body.nameEl === "string" && body.nameEl.trim().length > 0
+      ? body.nameEl.trim()
+      : null;
+  const descriptionEl =
+    typeof body.descriptionEl === "string" &&
+    body.descriptionEl.trim().length > 0
+      ? body.descriptionEl.trim()
+      : null;
 
   const project = await prisma.project.findUnique({
     where: { id: mapId },
@@ -66,7 +75,9 @@ export async function POST(req: Request, { params }: { params: Params }) {
       organizationId: project.organizationId,
       projectId: mapId,
       name,
+      nameEl,
       description,
+      descriptionEl,
       hoursText:
         typeof body.hoursText === "string" && body.hoursText.trim().length > 0
           ? body.hoursText.trim()

--- a/apps/campus/app/api/maps/[mapId]/events/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/events/route.ts
@@ -62,6 +62,15 @@ export async function POST(req: Request, { params }: { params: Params }) {
     typeof body.title === "string" ? body.title.trim() : "";
   const description =
     typeof body.description === "string" ? body.description.trim() : "";
+  const titleEl =
+    typeof body.titleEl === "string" && body.titleEl.trim().length > 0
+      ? body.titleEl.trim()
+      : null;
+  const descriptionEl =
+    typeof body.descriptionEl === "string" &&
+    body.descriptionEl.trim().length > 0
+      ? body.descriptionEl.trim()
+      : null;
   const startsAt = parseDate(body.startsAt);
   const endsAt = parseDate(body.endsAt);
 
@@ -108,7 +117,9 @@ export async function POST(req: Request, { params }: { params: Params }) {
       organizationId: project.organizationId,
       projectId: mapId,
       title,
+      titleEl,
       description,
+      descriptionEl,
       startsAt,
       endsAt,
       bannerColor,

--- a/apps/campus/app/api/maps/[mapId]/news/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/news/route.ts
@@ -79,6 +79,14 @@ export async function POST(req: Request, { params }: { params: Params }) {
       { status: 400 },
     );
   }
+  const titleEl =
+    typeof body.titleEl === "string" && body.titleEl.trim().length > 0
+      ? body.titleEl.trim()
+      : null;
+  const bodyEl =
+    typeof body.bodyEl === "string" && body.bodyEl.trim().length > 0
+      ? body.bodyEl.trim()
+      : null;
 
   const category: NewsCategory = VALID_CATEGORIES.includes(
     body.category as NewsCategory,
@@ -102,7 +110,9 @@ export async function POST(req: Request, { params }: { params: Params }) {
       organizationId: project.organizationId,
       projectId: mapId,
       title,
+      titleEl,
       body: post,
+      bodyEl,
       category,
       publishedAt,
       expiresAt,

--- a/apps/campus/app/api/news/[id]/route.ts
+++ b/apps/campus/app/api/news/[id]/route.ts
@@ -85,6 +85,19 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     }
     data.body = v;
   }
+  // Bilingual fields. Send `""` to clear; omit to leave as-is.
+  if (body.titleEl !== undefined) {
+    data.titleEl =
+      typeof body.titleEl === "string" && body.titleEl.trim().length > 0
+        ? body.titleEl.trim()
+        : null;
+  }
+  if (body.bodyEl !== undefined) {
+    data.bodyEl =
+      typeof body.bodyEl === "string" && body.bodyEl.trim().length > 0
+        ? body.bodyEl.trim()
+        : null;
+  }
   if (VALID_CATEGORIES.includes(body.category as NewsCategory)) {
     data.category = body.category as NewsCategory;
   }

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -305,3 +305,22 @@ export function pickText(
   if (typeof value === "string") return value;
   return value[locale] || value.en || value.el || "";
 }
+
+/**
+ * Two-column localised text picker.
+ *
+ * The Arc 8 bilingual columns on `NewsPost`, `EventPost`, `Club`,
+ * and `DiningLocation` store EN and EL in separate columns
+ * (e.g. `title` + `titleEl`). This helper picks the right one for
+ * the visitor's locale and falls back to EN whenever the EL
+ * translation is empty — so a post with only English still shows
+ * up to a Greek visitor.
+ */
+export function pickLocalized(
+  en: string,
+  el: string | null | undefined,
+  locale: Locale,
+): string {
+  if (locale === "el" && el && el.trim().length > 0) return el;
+  return en;
+}

--- a/apps/campus/lib/clubs-db.ts
+++ b/apps/campus/lib/clubs-db.ts
@@ -21,7 +21,11 @@ export interface Club {
   id: string;
   projectId: string;
   name: string;
+  /** Greek translation, optional. */
+  nameEl: string | null;
   description: string;
+  /** Greek translation, optional. */
+  descriptionEl: string | null;
   initials: string;
   avatarColor: ClubColor;
   memberCount: number;
@@ -48,7 +52,9 @@ function fromPrisma(row: PrismaClub): Club {
     id: row.id,
     projectId: row.projectId,
     name: row.name,
+    nameEl: row.nameEl,
     description: row.description,
+    descriptionEl: row.descriptionEl,
     initials: row.initials,
     avatarColor: row.avatarColor,
     memberCount: row.memberCount,

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -14,6 +14,8 @@ import {
   SAMPLE_NEWS,
 } from "../sample-campus";
 import type { ConsumerClub, ConsumerEvent, ConsumerNews } from "./types";
+// (no import changes needed below; localisation happens in `page.tsx`
+// when DB rows are mapped to the consumer shape — see [[Arc 8 bilingual]].)
 
 export interface ConsumerHomeProps {
   token: string;

--- a/apps/campus/lib/dining-db.ts
+++ b/apps/campus/lib/dining-db.ts
@@ -19,7 +19,11 @@ export interface DiningLocation {
   id: string;
   projectId: string;
   name: string;
+  /** Greek translation, optional. */
+  nameEl: string | null;
   description: string;
+  /** Greek translation, optional. */
+  descriptionEl: string | null;
   hoursText: string | null;
   cuisine: string | null;
   menuUrl: string | null;
@@ -43,7 +47,9 @@ function fromPrisma(row: PrismaDining): DiningLocation {
     id: row.id,
     projectId: row.projectId,
     name: row.name,
+    nameEl: row.nameEl,
     description: row.description,
+    descriptionEl: row.descriptionEl,
     hoursText: row.hoursText,
     cuisine: row.cuisine,
     menuUrl: row.menuUrl,

--- a/apps/campus/lib/events-db.ts
+++ b/apps/campus/lib/events-db.ts
@@ -24,7 +24,11 @@ export interface EventPost {
   id: string;
   projectId: string;
   title: string;
+  /** Greek translation, optional. */
+  titleEl: string | null;
   description: string;
+  /** Greek translation, optional. */
+  descriptionEl: string | null;
   imageUrl: string | null;
   startsAt: string;
   endsAt: string;
@@ -52,7 +56,9 @@ function fromPrisma(row: PrismaEventPost): EventPost {
     id: row.id,
     projectId: row.projectId,
     title: row.title,
+    titleEl: row.titleEl,
     description: row.description,
+    descriptionEl: row.descriptionEl,
     imageUrl: row.imageUrl,
     startsAt: row.startsAt.toISOString(),
     endsAt: row.endsAt.toISOString(),

--- a/apps/campus/lib/news.ts
+++ b/apps/campus/lib/news.ts
@@ -28,7 +28,11 @@ export interface NewsPost {
   id: string;
   projectId: string;
   title: string;
+  /** Greek translation, optional. */
+  titleEl: string | null;
   body: string;
+  /** Greek translation, optional. */
+  bodyEl: string | null;
   imageUrl: string | null;
   category: NewsCategory;
   publishedAt: string;
@@ -55,7 +59,9 @@ function fromPrisma(row: PrismaNewsPost): NewsPost {
     id: row.id,
     projectId: row.projectId,
     title: row.title,
+    titleEl: row.titleEl,
     body: row.body,
+    bodyEl: row.bodyEl,
     imageUrl: row.imageUrl,
     category: row.category,
     publishedAt: row.publishedAt.toISOString(),

--- a/packages/prisma/migrations/20260528120000_add_bilingual_fields/migration.sql
+++ b/packages/prisma/migrations/20260528120000_add_bilingual_fields/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "NewsPost" ADD COLUMN "titleEl" TEXT;
+ALTER TABLE "NewsPost" ADD COLUMN "bodyEl" TEXT;
+
+-- AlterTable
+ALTER TABLE "EventPost" ADD COLUMN "titleEl" TEXT;
+ALTER TABLE "EventPost" ADD COLUMN "descriptionEl" TEXT;
+
+-- AlterTable
+ALTER TABLE "Club" ADD COLUMN "nameEl" TEXT;
+ALTER TABLE "Club" ADD COLUMN "descriptionEl" TEXT;
+
+-- AlterTable
+ALTER TABLE "DiningLocation" ADD COLUMN "nameEl" TEXT;
+ALTER TABLE "DiningLocation" ADD COLUMN "descriptionEl" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -410,7 +410,11 @@ model NewsPost {
   organizationId String
   projectId      String
   title          String
+  /// Greek translation, optional. When unset the public surface falls back to `title`.
+  titleEl        String?
   body           String       @db.Text
+  /// Greek translation of `body`, optional.
+  bodyEl         String?      @db.Text
   imageUrl       String?
   category       NewsCategory @default(announcement)
   publishedAt    DateTime     @default(now())
@@ -443,7 +447,11 @@ model EventPost {
   organizationId  String
   projectId       String
   title           String
+  /// Greek translation of `title`, optional.
+  titleEl         String?
   description     String      @db.Text
+  /// Greek translation of `description`, optional.
+  descriptionEl   String?     @db.Text
   imageUrl        String?
   startsAt        DateTime
   endsAt          DateTime
@@ -490,7 +498,11 @@ model Club {
   organizationId  String
   projectId       String
   name            String
+  /// Greek translation of `name`, optional.
+  nameEl          String?
   description     String     @db.Text
+  /// Greek translation of `description`, optional.
+  descriptionEl   String?    @db.Text
   /// Two-letter avatar, e.g. "DS" for Data Science Society.
   initials        String
   avatarColor     ClubColor  @default(purple)
@@ -532,7 +544,11 @@ model DiningLocation {
   organizationId  String
   projectId       String
   name            String
+  /// Greek translation of `name`, optional.
+  nameEl          String?
   description     String   @db.Text
+  /// Greek translation of `description`, optional.
+  descriptionEl   String?  @db.Text
   /// Free text — "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed".
   /// Structured day/time ranges + "open now" badge are a follow-up.
   hoursText       String?


### PR DESCRIPTION
## What this is

PR 1 of 6 — brings bilingual content back. Each text column on the four content models gets a sibling `*El` column for the Greek translation; the public surface picks the right one for the visitor's locale and falls back to EN when EL is empty.

## Schema

```
NewsPost.titleEl, NewsPost.bodyEl
EventPost.titleEl, EventPost.descriptionEl
Club.nameEl, Club.descriptionEl
DiningLocation.nameEl, DiningLocation.descriptionEl
```

All nullable. No backfill — existing rows keep EN-only content and read fine. Migration: `20260528120000_add_bilingual_fields` (4 ALTER TABLEs, 8 columns).

## i18n helper

`pickLocalized(en, el, locale)` in `app/lib/i18n-core.ts` — two-column equivalent of the legacy `pickText`.

## API

POST + PATCH on all four models accept the new fields. Optional on create; on edit send `""` to clear, omit to leave as-is.

## Admin

Each of the four authoring clients gets a Greek input right after its English sibling. `startEdit` rehydrates EL values; `reset` clears them.

## Public

`pickLocalized` at every render site — consumer home rails, the four list pages, the three detail pages (news, events, clubs). DB rows feed `mergeEvents` after being localised so the home rail reads in EL when the visitor's locale is EL.

## What's not in scope (intentional)

- Campus name / branding (those live in `sceneData`, handled by the home-page builder).
- Anchor `refName` (future arc).
- `meetsCadence` / `hoursText` / `cuisine` — free-text fields admins rarely translate.
- Sample-seed rewrite — stays EN-only.

## Testing

`tsc --noEmit` clean. `next lint` clean. Run `prisma migrate deploy` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)