### PR TITLE
feat(campus): ICS sync writes through EventPost — chat sees them

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/IcsFeedsManager.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/IcsFeedsManager.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "react-toastify";
-import { Trash2 } from "lucide-react";
+import { RefreshCw, Trash2 } from "lucide-react";
 import { Button, Field, Input, Panel } from "@klorad/design-system";
 
 interface Props {
@@ -27,6 +27,7 @@ export function IcsFeedsManager({ mapId, initialFeeds }: Props) {
   const [feeds, setFeeds] = useState<string[]>(initialFeeds);
   const [input, setInput] = useState("");
   const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState(false);
 
   const save = async (next: string[]) => {
     setSaving(true);
@@ -79,16 +80,61 @@ export function IcsFeedsManager({ mapId, initialFeeds }: Props) {
     toast.success("Feed removed");
   };
 
+  const syncNow = async () => {
+    if (syncing || feeds.length === 0) return;
+    setSyncing(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/sync-ics`, {
+        method: "POST",
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Sync failed");
+      const r = body.result ?? {};
+      const inserted = r.inserted ?? 0;
+      const updated = r.updated ?? 0;
+      if (inserted === 0 && updated === 0) {
+        toast.info("Synced — no new occurrences.");
+      } else {
+        toast.success(
+          `Synced — ${inserted} new, ${updated} updated.`,
+        );
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   return (
     <Panel className="mt-6 p-5">
-      <div>
-        <h2 className="text-sm font-semibold text-text-primary">
-          ICS feeds
-        </h2>
-        <p className="mt-1 text-xs text-text-tertiary">
-          Paste a Google / Outlook / department calendar URL. Events
-          pull every render and merge with anything you publish below.
-        </p>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-text-primary">
+            ICS feeds
+          </h2>
+          <p className="mt-1 text-xs text-text-tertiary">
+            Paste a Google / Outlook / department calendar URL. Sync
+            writes occurrences into the events store so the chat and
+            home rail see them alongside manual ones.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => void syncNow()}
+          disabled={syncing || feeds.length === 0}
+        >
+          <span className="inline-flex items-center gap-1.5">
+            <RefreshCw
+              size={14}
+              strokeWidth={1.75}
+              className={syncing ? "animate-spin" : ""}
+            />
+            {syncing ? "Syncing…" : "Sync now"}
+          </span>
+        </Button>
       </div>
 
       <div className="mt-4 flex flex-col gap-2">

--- a/apps/campus/app/api/maps/[mapId]/sync-ics/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/sync-ics/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { requireCampusAccess } from "@/lib/authz";
+import { publicCampusTag } from "@/lib/public-campus";
+import { readEventFeeds } from "@/lib/events";
+import { syncIcsForProject } from "@/lib/ics-sync";
+import { prisma } from "@/lib/prisma";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * POST /api/maps/[mapId]/sync-ics
+ *
+ * Pulls every URL in `sceneData.eventFeeds` and upserts each
+ * occurrence into `EventPost` so the chat tools + consumer rail see
+ * them alongside manual events. Same `(projectId, externalId)`
+ * uniqueness means re-running is idempotent.
+ *
+ * Auth: campus write access. Returns the counts the admin UI shows
+ * in a toast.
+ */
+export async function POST(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  // Pull the project's sceneData directly — `getPublicCampusByToken`
+  // is per-token, not per-id, so use a direct read here.
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { sceneData: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const feedUrls = readEventFeeds(project.sceneData);
+  if (feedUrls.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      result: { fetched: 0, inserted: 0, updated: 0, feeds: 0 },
+      note: "No ICS feeds configured.",
+    });
+  }
+
+  try {
+    const result = await syncIcsForProject(mapId, feedUrls);
+    revalidateTag(publicCampusTag(mapId));
+    return NextResponse.json({ ok: true, result });
+  } catch (err) {
+    console.error("[sync-ics]", err);
+    return NextResponse.json(
+      { error: "ICS sync failed" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/apps/campus/lib/ics-sync.ts
+++ b/apps/campus/lib/ics-sync.ts
@@ -1,0 +1,130 @@
+/**
+ * ICS → `EventPost` sync.
+ *
+ * Fetches every feed URL in `sceneData.eventFeeds`, parses occurrences
+ * via the existing `fetchCampusEvents` pipeline, and **upserts** each
+ * into the `EventPost` table keyed on the unique `(projectId,
+ * externalId)` pair. Re-syncing the same feed is idempotent — same
+ * id → update; new id → insert.
+ *
+ * Imported rows carry `source = "ics"` so the admin UI can flag them
+ * as read-only, and so a future cleanup pass could prune events that
+ * fell off the feed if the operator wants that. For Arc 8 we don't
+ * prune — past events naturally exit the consumer rail via the
+ * `endsAt >= now()` filter.
+ */
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { fetchCampusEvents } from "@/lib/events-server";
+import type { CampusEvent } from "@/lib/events";
+
+export interface IcsSyncResult {
+  fetched: number;
+  inserted: number;
+  updated: number;
+  feeds: number;
+}
+
+interface ProjectRef {
+  projectId: string;
+  organizationId: string;
+}
+
+/** One CampusEvent → the upsert-shaped Prisma data. */
+function eventToData(
+  event: CampusEvent,
+  { projectId, organizationId }: ProjectRef,
+) {
+  const refName = event.location?.trim();
+  return {
+    organizationId,
+    projectId,
+    title: event.title,
+    // ICS doesn't carry a description — use the location as a fallback
+    // so the consumer card has something to render. Admins can edit
+    // the row's description and it'll get overwritten on next sync
+    // (the trade-off documented at the top of this file).
+    description: refName ?? "",
+    startsAt: new Date(event.start),
+    endsAt: new Date(event.end),
+    bannerColor: "teal" as const,
+    bannerIcon: "calendar" as const,
+    expectedAttendance: null,
+    organizer: null,
+    registrationUrl: null,
+    imageUrl: null,
+    anchors: (refName
+      ? [{ kind: "building", refId: "", refName }]
+      : []) as unknown as Prisma.InputJsonValue,
+    externalId: event.id,
+    source: "ics",
+  };
+}
+
+/**
+ * Pull every feed for `projectId` and upsert each occurrence.
+ *
+ * Returns counts you can show in the admin toast / log:
+ *   - `fetched`: total occurrences across all feeds (post-expansion)
+ *   - `inserted`: new rows created
+ *   - `updated`: existing rows refreshed
+ */
+export async function syncIcsForProject(
+  projectId: string,
+  feedUrls: string[],
+): Promise<IcsSyncResult> {
+  if (feedUrls.length === 0) {
+    return { fetched: 0, inserted: 0, updated: 0, feeds: 0 };
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    throw new Error(`Project ${projectId} not found`);
+  }
+
+  const events = await fetchCampusEvents(feedUrls);
+  const ref: ProjectRef = {
+    projectId,
+    organizationId: project.organizationId,
+  };
+
+  let inserted = 0;
+  let updated = 0;
+
+  // Sequential upserts — the volume is bounded (events-server caps at
+  // `MAX_EVENTS = 12`), so transaction batching wouldn't pay off. If
+  // the cap is lifted later, a `prisma.$transaction([…])` collected
+  // upsert is the obvious next step.
+  for (const event of events) {
+    const data = eventToData(event, ref);
+    const existing = await prisma.eventPost.findUnique({
+      where: {
+        projectId_externalId: {
+          projectId,
+          externalId: event.id,
+        },
+      },
+      select: { id: true },
+    });
+    if (existing) {
+      await prisma.eventPost.update({
+        where: { id: existing.id },
+        data,
+      });
+      updated += 1;
+    } else {
+      await prisma.eventPost.create({ data });
+      inserted += 1;
+    }
+  }
+
+  return {
+    fetched: events.length,
+    inserted,
+    updated,
+    feeds: feedUrls.length,
+  };
+}

--- a/packages/prisma/migrations/20260528150000_event_post_external_id/migration.sql
+++ b/packages/prisma/migrations/20260528150000_event_post_external_id/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "EventPost" ADD COLUMN "externalId" TEXT;
+ALTER TABLE "EventPost" ADD COLUMN "source" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventPost_projectId_externalId_key" ON "EventPost"("projectId", "externalId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -456,11 +456,21 @@ model EventPost {
   /// Vanity "expected attendance" — admin-set. See campus-consumer-pivot.
   expectedAttendance Int?
   anchors         Json        @default("[]")
+  /// External id from the source feed — `<feedUrl>::<isoStart>` for ICS rows,
+  /// null for admin-authored ones. Used by the sync job to upsert idempotently.
+  externalId      String?
+  /// Where the row came from — "ics" / "manual" / null (legacy = manual).
+  source          String?
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   project      Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  /// Postgres allows multiple NULLs in a unique constraint, so this
+  /// uniques the (project, externalId) pair only for non-null rows —
+  /// exactly the "no double-import" semantics the sync wants.
+  @@unique([projectId, externalId])
 
   @@index([projectId, startsAt])
   @@index([organizationId])


### PR DESCRIPTION
## What this is

PR 2 of 6 — lifts the "chat tools only see DB events" limitation we noted on the ICS sync PR. ICS-feed events now persist into `EventPost`, so `query_events` includes them, the bilingual pipeline can localise them, and the home rail ranks them with everything else.

## Schema

```
EventPost.externalId  String?       // `<feedUrl>::<isoStart>` for ICS, null for manual
EventPost.source       String?      // "ics" / "manual" / null
@@unique([projectId, externalId])
```

Postgres ignores NULLs in unique constraints, so the unique enforces "no double-import" without blocking manual rows. Migration: `20260528150000_event_post_external_id`.

## Sync

`lib/ics-sync.ts` — `syncIcsForProject(projectId, feedUrls)` runs the existing `fetchCampusEvents` pipeline and for each occurrence:
- `findUnique({ projectId_externalId })` → `update` or `create`.
- Idempotent. Re-running is a no-op apart from refreshing changed fields.
- Returns `{ fetched, inserted, updated, feeds }`.

## API

`POST /api/maps/[mapId]/sync-ics` — `requireCampusAccess("write")`, reads `sceneData.eventFeeds`, syncs, bumps the public cache tag.

## Admin

`IcsFeedsManager` gets a *Sync now* button (top-right, secondary variant). RefreshCw spins while in-flight. Toast surfaces the counts: *"Synced — 3 new, 14 updated."* Disabled when no feeds are configured.

## Trade-off

Imported rows are **fully replaced** on each sync — admin edits to an imported event's description or banner get overwritten on the next run. The `source` column flags them so a future "lock from sync" toggle is one boolean flip.

## Testing

`tsc --noEmit` clean. `next lint` clean. One migration; existing `EventPost` rows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)