### PR TITLE
feat(campus): web push notifications — opt-in + admin send

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/NotifyForm.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/NotifyForm.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { toast } from "react-toastify";
+import { Send } from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Textarea,
+} from "@klorad/design-system";
+
+export interface NotifyFormProps {
+  mapId: string;
+  /** False when `NEXT_PUBLIC_VAPID_PUBLIC_KEY` isn't set on the server. */
+  enabled: boolean;
+}
+
+/**
+ * Admin form for firing a one-off web push to every subscriber on
+ * this campus. Title / body / optional click-through URL.
+ *
+ * Visible always, but disabled when push isn't configured — better
+ * than hiding the surface because operators need to *see* that the
+ * feature exists before they go set up VAPID keys.
+ */
+export function NotifyForm({ mapId, enabled }: NotifyFormProps) {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [url, setUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!enabled) return;
+    if (!title.trim() || !body.trim()) {
+      toast.error("Title and body are required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/notify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          url: url.trim() || undefined,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error ?? "Send failed");
+      const r = json.result ?? {};
+      toast.success(
+        `Sent to ${r.attempted ?? 0} subscriber(s) · ${r.delivered ?? 0} delivered · ${r.pruned ?? 0} pruned.`,
+      );
+      setTitle("");
+      setBody("");
+      setUrl("");
+    } catch (err) {
+      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Send failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Panel className="mt-6 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-text-primary">
+            Push a notification
+          </h2>
+          <p className="mt-1 text-xs text-text-tertiary">
+            Fires once to every visitor who tapped “Get notifications”
+            on this campus. {enabled ? null : (
+              <span className="ml-1 text-red-600">
+                Disabled — set VAPID_* env vars to enable.
+              </span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      <form
+        onSubmit={(e) => void onSubmit(e)}
+        className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2"
+      >
+        <Field label="Title">
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Fire drill at 10:30"
+            disabled={!enabled || submitting}
+            maxLength={80}
+            required
+          />
+        </Field>
+        <Field label="Click-through URL (optional)">
+          <Input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="/campus/<token>/events/<id>"
+            disabled={!enabled || submitting}
+          />
+        </Field>
+        <div className="md:col-span-2">
+          <Field label="Body">
+            <Textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Quick details students need to know."
+              rows={3}
+              disabled={!enabled || submitting}
+              maxLength={280}
+              required
+            />
+          </Field>
+        </div>
+        <div className="md:col-span-2 flex items-center justify-end pt-1">
+          <Button type="submit" disabled={!enabled || submitting}>
+            <span className="inline-flex items-center gap-1.5">
+              <Send size={14} strokeWidth={1.75} />
+              {submitting ? "Sending…" : "Send notification"}
+            </span>
+          </Button>
+        </div>
+      </form>
+    </Panel>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
@@ -7,6 +7,7 @@ import { listEventsForAdmin } from "@/lib/events-db";
 import { readEventFeeds } from "@/lib/events";
 import { EventsAdminClient } from "./EventsAdminClient";
 import { IcsFeedsManager } from "./IcsFeedsManager";
+import { NotifyForm } from "./NotifyForm";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
 
@@ -71,6 +72,11 @@ export default async function EventsAdminPage({
       </div>
 
       <IcsFeedsManager mapId={mapId} initialFeeds={initialFeeds} />
+
+      <NotifyForm
+        mapId={mapId}
+        enabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}
+      />
 
       <EventsAdminClient
         mapId={mapId}

--- a/apps/campus/app/api/maps/[mapId]/notify/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/notify/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { requireCampusAccess } from "@/lib/authz";
+import { pushEnabled, sendPushToProject } from "@/lib/push";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * POST /api/maps/[mapId]/notify
+ *
+ * Admin-triggered web push to every subscriber on this campus. Body:
+ *   { title: string, body: string, url?: string, icon?: string }
+ *
+ * Returns counts: `{ attempted, delivered, pruned }`. Subscriptions
+ * that respond 404 / 410 are pruned in-line — anything else is logged
+ * and the row stays in case it was transient.
+ */
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  if (!pushEnabled()) {
+    return NextResponse.json(
+      { error: "Push isn't configured on this server." },
+      { status: 503 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const message = typeof body.body === "string" ? body.body.trim() : "";
+  if (!title || !message) {
+    return NextResponse.json(
+      { error: "title and body required" },
+      { status: 400 },
+    );
+  }
+  const url = typeof body.url === "string" ? body.url : undefined;
+  const icon = typeof body.icon === "string" ? body.icon : undefined;
+
+  try {
+    const result = await sendPushToProject(mapId, {
+      title,
+      body: message,
+      url,
+      icon,
+    });
+    return NextResponse.json({ ok: true, result });
+  } catch (err) {
+    console.error("[notify]", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Push failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/campus/app/api/push/subscribe/route.ts
+++ b/apps/campus/app/api/push/subscribe/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { pushEnabled } from "@/lib/push";
+
+/**
+ * POST /api/push/subscribe
+ *
+ * Anonymous endpoint a visitor's browser hits after `pushManager.subscribe()`.
+ * Stores the `{ endpoint, p256dh, auth }` triple against a project, idempotent
+ * by `(projectId, endpoint)`. No auth, no PII — we never know who they are.
+ *
+ * Request: { projectId, endpoint, keys: { p256dh, auth }, userAgent? }
+ */
+export async function POST(req: Request) {
+  if (!pushEnabled()) {
+    return NextResponse.json(
+      { error: "Push isn't configured on this server." },
+      { status: 503 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const projectId =
+    typeof body.projectId === "string" ? body.projectId : "";
+  const endpoint =
+    typeof body.endpoint === "string" ? body.endpoint : "";
+  const keys =
+    body.keys && typeof body.keys === "object"
+      ? (body.keys as Record<string, unknown>)
+      : {};
+  const p256dh = typeof keys.p256dh === "string" ? keys.p256dh : "";
+  const auth = typeof keys.auth === "string" ? keys.auth : "";
+  if (!projectId || !endpoint || !p256dh || !auth) {
+    return NextResponse.json(
+      { error: "projectId, endpoint, keys.p256dh, keys.auth required" },
+      { status: 400 },
+    );
+  }
+
+  // Per-project FK check — anonymous, so we don't want a subscription
+  // hanging off a non-existent / draft project.
+  const project = await prisma.project.findFirst({
+    where: { id: projectId, isPublished: true },
+    select: { id: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const userAgent =
+    typeof body.userAgent === "string"
+      ? body.userAgent.slice(0, 500)
+      : req.headers.get("user-agent")?.slice(0, 500) ?? null;
+
+  await prisma.pushSubscription.upsert({
+    where: {
+      projectId_endpoint: { projectId, endpoint },
+    },
+    update: { p256dh, auth, userAgent },
+    create: {
+      projectId,
+      endpoint,
+      p256dh,
+      auth,
+      userAgent,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+/** Optional `DELETE /api/push/subscribe` — used when the browser unsubs. */
+export async function DELETE(req: Request) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const projectId =
+    typeof body.projectId === "string" ? body.projectId : "";
+  const endpoint =
+    typeof body.endpoint === "string" ? body.endpoint : "";
+  if (!projectId || !endpoint) {
+    return NextResponse.json(
+      { error: "projectId + endpoint required" },
+      { status: 400 },
+    );
+  }
+  await prisma.pushSubscription
+    .delete({
+      where: { projectId_endpoint: { projectId, endpoint } },
+    })
+    .catch(() => undefined);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -8,6 +8,7 @@ import { ClubRow } from "./ClubRow";
 import { NewsItem } from "./NewsItem";
 import { ConsumerFooter } from "./ConsumerFooter";
 import { AssistantInput } from "./AssistantInput";
+import { NotificationButton } from "./NotificationButton";
 import {
   SAMPLE_CLUBS,
   SAMPLE_EVENTS,
@@ -41,6 +42,8 @@ export interface ConsumerHomeProps {
   events?: ConsumerEvent[];
   /** Clubs for the "Most active this week" rail. Same fallback story. */
   clubs?: ConsumerClub[];
+  /** VAPID public key — when set, renders the Get-notifications button. */
+  vapidPublicKey?: string;
 }
 
 /**
@@ -71,6 +74,7 @@ export function ConsumerHome({
   news,
   events,
   clubs,
+  vapidPublicKey,
 }: ConsumerHomeProps) {
   const newsItems = news?.length ? news : SAMPLE_NEWS;
   const eventItems = events?.length ? events : SAMPLE_EVENTS;
@@ -98,6 +102,11 @@ export function ConsumerHome({
         locale={locale}
         mapHref={mapHref}
       />
+
+      {/* Bell button — silent-disable when push isn't configured. */}
+      <div className="mx-auto flex max-w-[1280px] justify-end px-4 pt-2 md:px-6">
+        <NotificationButton mapId={mapId} vapidPublicKey={vapidPublicKey} />
+      </div>
 
       <ConsumerHero
         headline={headline ?? "Your whole campus, one happy little app."}

--- a/apps/campus/lib/consumer/NotificationButton.tsx
+++ b/apps/campus/lib/consumer/NotificationButton.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bell, BellOff } from "lucide-react";
+
+export interface NotificationButtonProps {
+  mapId: string;
+  /** VAPID public key — exposed via `NEXT_PUBLIC_VAPID_PUBLIC_KEY`. */
+  vapidPublicKey?: string;
+}
+
+/** "BAi…" URL-safe base64 → Uint8Array as the Push API expects. */
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const b = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Bell button that opts the visitor in to push notifications for a
+ * campus. Renders nothing when the browser doesn't support service
+ * workers / push, or when the server hasn't shipped a VAPID public
+ * key — the silent-disable cases. When it does render, the bell
+ * shows the current state (subscribed / unsubscribed) and tapping
+ * toggles.
+ *
+ * No identity is sent — only the browser's anonymous push endpoint
+ * + the two keys the Push API exposes, scoped to the campus's
+ * project id.
+ */
+export function NotificationButton({
+  mapId,
+  vapidPublicKey,
+}: NotificationButtonProps) {
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const ok =
+      "serviceWorker" in navigator &&
+      "PushManager" in window &&
+      Boolean(vapidPublicKey);
+    setSupported(ok);
+    if (!ok) return;
+
+    // Check whether we're already subscribed (no prompt fires).
+    void (async () => {
+      try {
+        const reg = await navigator.serviceWorker.getRegistration();
+        const sub = await reg?.pushManager.getSubscription();
+        setEnabled(Boolean(sub));
+      } catch {
+        setEnabled(false);
+      }
+    })();
+  }, [vapidPublicKey]);
+
+  if (supported === null || supported === false) return null;
+
+  const enable = async () => {
+    if (!vapidPublicKey) return;
+    setBusy(true);
+    try {
+      let reg = await navigator.serviceWorker.getRegistration("/sw.js");
+      if (!reg) {
+        reg = await navigator.serviceWorker.register("/sw.js");
+      }
+      // Browsers prompt for Notification permission on `subscribe`.
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        // TS quirk: PushManager's typings want a fresh ArrayBuffer,
+        // not the `Uint8Array<ArrayBufferLike>` Node-flavoured TS
+        // hands us. The runtime accepts either; the cast is safe.
+        applicationServerKey: urlBase64ToUint8Array(
+          vapidPublicKey,
+        ) as unknown as BufferSource,
+      });
+      const json = sub.toJSON() as {
+        endpoint: string;
+        keys?: { p256dh: string; auth: string };
+      };
+      const res = await fetch("/api/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: mapId,
+          endpoint: json.endpoint,
+          keys: json.keys,
+          userAgent: navigator.userAgent,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to register");
+      setEnabled(true);
+    } catch (err) {
+      console.error("[push] enable failed", err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const disable = async () => {
+    setBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.getRegistration();
+      const sub = await reg?.pushManager.getSubscription();
+      const endpoint = sub?.endpoint;
+      if (sub) await sub.unsubscribe();
+      if (endpoint) {
+        await fetch("/api/push/subscribe", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ projectId: mapId, endpoint }),
+        });
+      }
+      setEnabled(false);
+    } catch (err) {
+      console.error("[push] disable failed", err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => void (enabled ? disable() : enable())}
+      disabled={busy}
+      aria-pressed={enabled}
+      className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-line)] bg-white px-3.5 py-2 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)] disabled:opacity-60"
+    >
+      {enabled ? (
+        <>
+          <Bell size={14} strokeWidth={1.75} className="text-[var(--brand-primary)]" />
+          Notifications on
+        </>
+      ) : (
+        <>
+          <BellOff size={14} strokeWidth={1.75} />
+          Get notifications
+        </>
+      )}
+    </button>
+  );
+}

--- a/apps/campus/lib/push.ts
+++ b/apps/campus/lib/push.ts
@@ -1,0 +1,106 @@
+/**
+ * Web push helpers — VAPID config + the per-project send loop.
+ *
+ * Subscriptions are anonymous: stored as `{ endpoint, p256dh, auth }`
+ * scoped to a `Project`, no PII attached. The send loop fans out via
+ * `web-push.sendNotification` and prunes subscriptions that come back
+ * with `410 Gone` / `404` (the browser unsubscribed or rotated keys).
+ *
+ * Env:
+ *   - `NEXT_PUBLIC_VAPID_PUBLIC_KEY` — VAPID public key (client uses it
+ *     to subscribe; server uses it to sign).
+ *   - `VAPID_PRIVATE_KEY` — server-only signing key.
+ *   - `VAPID_SUBJECT` — `mailto:` URL the push services contact you at.
+ *
+ * Generate keys once: `npx web-push generate-vapid-keys --json`.
+ */
+import webpush from "web-push";
+import { prisma } from "@/lib/prisma";
+
+let configured = false;
+
+function ensureConfigured(): boolean {
+  if (configured) return true;
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+  const subject = process.env.VAPID_SUBJECT;
+  if (!publicKey || !privateKey || !subject) return false;
+  webpush.setVapidDetails(subject, publicKey, privateKey);
+  configured = true;
+  return true;
+}
+
+export function pushEnabled(): boolean {
+  return ensureConfigured();
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  /** Click-through URL on the campus. Absolute or path. */
+  url?: string;
+  /** Optional thumbnail; falls back to the campus icon. */
+  icon?: string;
+}
+
+export interface PushSendResult {
+  attempted: number;
+  delivered: number;
+  pruned: number;
+}
+
+/**
+ * Send `payload` to every subscription on `projectId`. Errors per
+ * subscription don't abort the run — bad subscriptions get pruned.
+ */
+export async function sendPushToProject(
+  projectId: string,
+  payload: PushPayload,
+): Promise<PushSendResult> {
+  if (!ensureConfigured()) {
+    throw new Error(
+      "Push is not configured — set VAPID_* env vars first.",
+    );
+  }
+
+  const subs = await prisma.pushSubscription.findMany({
+    where: { projectId },
+    select: { id: true, endpoint: true, p256dh: true, auth: true },
+  });
+
+  let delivered = 0;
+  let pruned = 0;
+  const serialized = JSON.stringify(payload);
+
+  await Promise.all(
+    subs.map(async (s) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: s.endpoint,
+            keys: { p256dh: s.p256dh, auth: s.auth },
+          },
+          serialized,
+        );
+        delivered += 1;
+      } catch (err: unknown) {
+        const status =
+          err && typeof err === "object" && "statusCode" in err
+            ? Number((err as { statusCode?: number }).statusCode)
+            : 0;
+        // 404 / 410 mean the subscription is dead. Anything else is
+        // transient — leave the row alone, we'll try again next send.
+        if (status === 404 || status === 410) {
+          await prisma.pushSubscription
+            .delete({ where: { id: s.id } })
+            .catch(() => undefined);
+          pruned += 1;
+        } else {
+          console.error("[push] send failed", { id: s.id, err });
+        }
+      }
+    }),
+  );
+
+  return { attempted: subs.length, delivered, pruned };
+}

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -50,12 +50,14 @@
     "three": "^0.170.0",
     "threebox-plugin": "2.2.7",
     "uuid": "^11.1.0",
+    "web-push": "^3.6.7",
     "zod": "^3.24.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@types/mapbox__mapbox-gl-draw": "^1.4.9",
     "@types/uuid": "^9.0.8",
+    "@types/web-push": "^3.6.4",
     "autoprefixer": "10.4.20",
     "eslint": "^8.56.0",
     "eslint-config-next": "^15.1.9",

--- a/packages/prisma/migrations/20260528180000_add_push_subscription/migration.sql
+++ b/packages/prisma/migrations/20260528180000_add_push_subscription/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "PushSubscription" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushSubscription_projectId_endpoint_key" ON "PushSubscription"("projectId", "endpoint");
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_projectId_idx" ON "PushSubscription"("projectId");
+
+-- AddForeignKey
+ALTER TABLE "PushSubscription" ADD CONSTRAINT "PushSubscription_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -175,6 +175,8 @@ model Project {
   clubs        Club[]
   // Cafeterias / cafes scoped to this project — see lib/dining-db.ts.
   diningLocations DiningLocation[]
+  // Anonymous push-notification subscribers — see lib/push.ts.
+  pushSubscriptions PushSubscription[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -576,4 +578,23 @@ model DiningLocation {
 
   @@index([projectId])
   @@index([organizationId])
+}
+
+/// Anonymous web-push subscription. No PII — just the endpoint URL +
+/// the two keys the Push API hands the browser, scoped to a Project.
+/// Per Project so notifications go to the right campus's visitors.
+model PushSubscription {
+  id        String   @id @default(cuid())
+  projectId String
+  endpoint  String
+  p256dh    String
+  auth      String
+  /// Optional user-agent hint stored for diagnostics — never displayed.
+  userAgent String?
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, endpoint])
+  @@index([projectId])
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -351,6 +354,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -3896,6 +3902,9 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
@@ -4221,6 +4230,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -4341,6 +4354,9 @@ packages:
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4471,6 +4487,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   bowser@2.12.1:
     resolution: {integrity: sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==}
 
@@ -4488,6 +4507,9 @@ packages:
     resolution: {integrity: sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -4991,6 +5013,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   effect@3.19.0:
     resolution: {integrity: sha512-eFvvryWkbXvQ4Gak1Nadv9CW6U35+UUS/fIkF4c/Th8rs2u47g+tNkViYeVGliglNnR6Ai5Otl9tLbav3yZjXg==}
@@ -5707,6 +5732,14 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -6087,6 +6120,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   kdbush@4.0.2:
     resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
@@ -6332,6 +6371,9 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
@@ -7263,6 +7305,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sass-lookup@6.1.0:
     resolution: {integrity: sha512-Zx+lVyoWqXZxHuYWlTA17Z5sczJ6braNT2C7rmClw+c4E7r/n911Zwss3h1uHI9reR5AgHZyNHF7c2+VIp5AUA==}
     engines: {node: '>=18'}
@@ -8137,6 +8182,11 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
@@ -11689,6 +11739,10 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.24
+
   '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
@@ -12054,6 +12108,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -12195,6 +12251,13 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   assign-symbols@1.0.0: {}
@@ -12322,6 +12385,8 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  bn.js@4.12.3: {}
+
   bowser@2.12.1: {}
 
   brace-expansion@1.1.12:
@@ -12344,6 +12409,8 @@ snapshots:
       electron-to-chromium: 1.5.244
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.27.0)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -12831,6 +12898,10 @@ snapshots:
   earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   effect@3.19.0:
     dependencies:
@@ -13802,6 +13873,15 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http_ece@1.2.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
@@ -14137,6 +14217,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   kdbush@4.0.2: {}
 
   keyv@4.5.4:
@@ -14405,6 +14496,8 @@ snapshots:
   mimic-function@5.0.1: {}
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.1.1:
     dependencies:
@@ -15394,6 +15487,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   sass-lookup@6.1.0:
     dependencies:
@@ -16398,6 +16493,16 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webgl-constants@1.1.1: {}
 


### PR DESCRIPTION
## What this is

PR 5 of 6 — real-time updates land. Anonymous opt-in on the public home; admin fires a one-off push from the dashboard.

## How it works

- Visitor taps **Get notifications** on the campus home → the browser asks for permission → we register `/sw.js` and `pushManager.subscribe()` → POST the subscription to `/api/push/subscribe`. Stored as `{ endpoint, p256dh, auth }` keyed `(projectId, endpoint)`. No PII.
- Admin opens `/org/[orgId]/maps/[mapId]/events` → fills in **Push a notification** (title / body / optional URL) → POST `/api/maps/[mapId]/notify` → server fans out via `web-push.sendNotification`. Dead subscriptions get pruned in-line.
- Service worker receives the `push` event, renders `registration.showNotification`; click focuses an existing tab or opens a new one.

## Schema

```
model PushSubscription {
  id        String   @id @default(cuid())
  projectId String
  endpoint  String
  p256dh    String
  auth      String
  userAgent String?
  createdAt DateTime @default(now())

  @@unique([projectId, endpoint])
  @@index([projectId])
}
```

Migration `20260528180000_add_push_subscription`. No relation to `User` — subscriptions are anonymous by construction.

## API

| Verb | Path | Notes |
|---|---|---|
| POST | `/api/push/subscribe` | anonymous; upsert |
| DELETE | `/api/push/subscribe` | anonymous; on browser unsubscribe |
| POST | `/api/maps/[mapId]/notify` | admin write; returns `{ attempted, delivered, pruned }` |

503 when VAPID env vars are unset on either endpoint — silent-disables the feature instead of surfacing dead buttons.

## To enable

```bash
npx web-push generate-vapid-keys --json
# add to env:
#   NEXT_PUBLIC_VAPID_PUBLIC_KEY=…
#   VAPID_PRIVATE_KEY=…
#   VAPID_SUBJECT=mailto:you@example.com
# then restart.
```

When the env vars are unset, the bell button is hidden and the admin form is visible but disabled (with a red hint pointing at the env vars).

## Testing

`tsc --noEmit` clean. `next lint` clean. New dep: `web-push` (+ `@types/web-push`). Migration adds one table; existing rows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)