### PR TITLE
feat(campus): richer sample-campus seed with bilingual examples

### DIFF
--- a/apps/campus/lib/sample-seed.ts
+++ b/apps/campus/lib/sample-seed.ts
@@ -1,15 +1,17 @@
 /**
  * Sample-campus seed — DB shape (Arc 7 of [[campus-consumer-pivot]]).
  *
- * Companion to `lib/sample-campus.ts` (which is the *consumer-shape*
- * sample used for empty-state fallback on the public home). This
- * file holds the equivalent records shaped to the Prisma models we
- * built in Arcs 2-5, so `POST /api/maps/[mapId]/seed-sample` can
- * write a believable starter set into a fresh campus in one click.
+ * Companion to `lib/sample-campus.ts` (the *consumer-shape* sample
+ * used for the empty-state fallback on the public home). This file
+ * holds the equivalent records shaped to the Prisma models we built
+ * in Arcs 2-5 + Arc 8 bilingual columns, so
+ * `POST /api/maps/[mapId]/seed-sample` can write a believable starter
+ * set into a fresh campus in one click.
  *
- * Kept deliberately small (4 news · 3 events · 4 clubs · 3 dining).
- * The point is to show that the rails render, not to fake a real
- * campus.
+ * Sized to look "lived in" rather than minimal — a rector demoing
+ * the platform should see realistic counts (6 news / 8 events /
+ * 6 clubs / 5 dining), variety of categories, and a sprinkling of
+ * Greek translations so the bilingual story is visible.
  */
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
@@ -28,7 +30,9 @@ interface SeedAnchor {
 
 interface SeedNews {
   title: string;
+  titleEl?: string;
   body: string;
+  bodyEl?: string;
   category: NewsCategory;
   /** Days ago — turned into a real Date relative to now() at write time. */
   publishedDaysAgo: number;
@@ -37,7 +41,9 @@ interface SeedNews {
 
 interface SeedEvent {
   title: string;
+  titleEl?: string;
   description: string;
+  descriptionEl?: string;
   /** Days from now (positive = future). */
   startsInDays: number;
   /** Duration of the event in hours. */
@@ -45,12 +51,16 @@ interface SeedEvent {
   bannerColor: EventBanner;
   bannerIcon: EventIcon;
   expectedAttendance: number;
+  organizer?: string;
+  registrationUrl?: string;
   anchors: SeedAnchor[];
 }
 
 interface SeedClub {
   name: string;
+  nameEl?: string;
   description: string;
+  descriptionEl?: string;
   initials: string;
   avatarColor: ClubColor;
   memberCount: number;
@@ -61,7 +71,9 @@ interface SeedClub {
 
 interface SeedDining {
   name: string;
+  nameEl?: string;
   description: string;
+  descriptionEl?: string;
   hoursText: string;
   cuisine: string;
   menuUrl?: string;
@@ -71,7 +83,10 @@ interface SeedDining {
 const NEWS: SeedNews[] = [
   {
     title: "Library hours extended through finals",
+    titleEl: "Παρατεταμένες ώρες βιβλιοθήκης για τις εξετάσεις",
     body: "Engineering South stays open 24 / 7 until June 9. Quiet floors are on 2 and 3; free coffee on the second floor every night from 8 pm. Bring your student ID after 11 pm.",
+    bodyEl:
+      "Το Engineering South παραμένει ανοιχτό 24/7 έως τις 9 Ιουνίου. Ησυχία στους ορόφους 2 και 3· δωρεάν καφές στον δεύτερο όροφο κάθε βράδυ από τις 8 μ.μ. Φέρτε τη φοιτητική σας ταυτότητα μετά τις 11 μ.μ.",
     category: "announcement",
     publishedDaysAgo: 3,
     anchors: [
@@ -87,7 +102,10 @@ const NEWS: SeedNews[] = [
   },
   {
     title: "New 3D printers in the Graphic Arts lab",
+    titleEl: "Νέοι 3D εκτυπωτές στο εργαστήριο γραφικών τεχνών",
     body: "Six new printers landed last week — drop-in hours every weekday afternoon. Training session Tuesday at 4 pm; no sign-up needed.",
+    bodyEl:
+      "Έξι νέοι εκτυπωτές έφτασαν την περασμένη εβδομάδα — ελεύθερη πρόσβαση κάθε καθημερινό απόγευμα. Εκπαίδευση την Τρίτη στις 4 μ.μ.· δεν χρειάζεται εγγραφή.",
     category: "news",
     publishedDaysAgo: 7,
     anchors: [
@@ -104,18 +122,38 @@ const NEWS: SeedNews[] = [
       { kind: "building", refId: "", refName: "Engineering South Building" },
     ],
   },
+  {
+    title: "Campus shuttle adds Saturday evening service",
+    body: "The 14R now runs Saturdays until midnight, looping the dorms, the Marketplace, and the Athletics Center. New timetable on the transportation page.",
+    category: "news",
+    publishedDaysAgo: 12,
+    anchors: [
+      { kind: "building", refId: "", refName: "1901 Marketplace Building" },
+    ],
+  },
+  {
+    title: "Free counselling drop-ins this month",
+    body: "Student wellness is hosting free 15-minute drop-ins every Tuesday and Thursday afternoon. No appointment, no notes taken. Just drop by.",
+    category: "announcement",
+    publishedDaysAgo: 5,
+    anchors: [],
+  },
 ];
 
 const EVENTS: SeedEvent[] = [
   {
     title: "Open mic at the quad cafe",
+    titleEl: "Βραδιά ελεύθερου μικροφώνου στο καφέ της πλατείας",
     description:
       "Bring a poem, a song, a stand-up bit. Sign-up at the door, sets are five minutes. Free entry, drinks at bar prices.",
+    descriptionEl:
+      "Φέρτε ένα ποίημα, ένα τραγούδι, ένα stand-up. Εγγραφή στην είσοδο, τα σετ είναι πέντε λεπτά. Δωρεάν είσοδος.",
     startsInDays: 2,
     durationHours: 3,
     bannerColor: "purple",
     bannerIcon: "music",
     expectedAttendance: 84,
+    organizer: "Student union",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
   {
@@ -127,6 +165,7 @@ const EVENTS: SeedEvent[] = [
     bannerColor: "coral",
     bannerIcon: "trophy",
     expectedAttendance: 212,
+    organizer: "Intramural sports",
     anchors: [
       { kind: "building", refId: "", refName: "Mott Athletics Center" },
     ],
@@ -140,8 +179,79 @@ const EVENTS: SeedEvent[] = [
     bannerColor: "teal",
     bannerIcon: "sprout",
     expectedAttendance: 36,
+    organizer: "Sustainability union",
     anchors: [
       { kind: "building", refId: "", refName: "1901 Marketplace Building" },
+    ],
+  },
+  {
+    title: "AI ethics panel: who's accountable?",
+    description:
+      "Faculty + invited speakers from industry. Q&A from the floor. Recorded; talk to the speakers in person after.",
+    startsInDays: 6,
+    durationHours: 2,
+    bannerColor: "purple",
+    bannerIcon: "calendar",
+    expectedAttendance: 140,
+    organizer: "Engineering school",
+    registrationUrl: "https://example.com/ai-ethics",
+    anchors: [
+      { kind: "building", refId: "", refName: "Engineering South Building" },
+    ],
+  },
+  {
+    title: "Welcome barbecue for transfer students",
+    description:
+      "Veggie + meat options, sodas, music. Open to all transfer students and one guest each.",
+    startsInDays: 10,
+    durationHours: 3,
+    bannerColor: "coral",
+    bannerIcon: "sprout",
+    expectedAttendance: 180,
+    organizer: "Student affairs",
+    anchors: [
+      { kind: "building", refId: "", refName: "1901 Marketplace Building" },
+    ],
+  },
+  {
+    title: "Film club: 'In the Mood for Love'",
+    titleEl: "Σινέ λέσχη: «In the Mood for Love»",
+    description:
+      "Wong Kar-wai, 2000. Discussion after. Free popcorn while it lasts.",
+    startsInDays: 8,
+    durationHours: 3,
+    bannerColor: "pink",
+    bannerIcon: "music",
+    expectedAttendance: 92,
+    organizer: "Film club",
+    anchors: [
+      { kind: "building", refId: "", refName: "Graphic Arts Building" },
+    ],
+  },
+  {
+    title: "Trivia night with the data science society",
+    description:
+      "Teams of 4. $5 entry per team, winner takes the pot. Prizes for nerdiest team name.",
+    startsInDays: 13,
+    durationHours: 2,
+    bannerColor: "teal",
+    bannerIcon: "trophy",
+    expectedAttendance: 64,
+    organizer: "Data science society",
+    anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
+  },
+  {
+    title: "Spring commencement",
+    description:
+      "Cap-and-gown collection from the bookstore by May 30. Live-stream from the main lawn for guests who can't attend.",
+    startsInDays: 25,
+    durationHours: 4,
+    bannerColor: "purple",
+    bannerIcon: "calendar",
+    expectedAttendance: 2400,
+    organizer: "Office of the registrar",
+    anchors: [
+      { kind: "building", refId: "", refName: "Mott Athletics Center" },
     ],
   },
 ];
@@ -149,8 +259,11 @@ const EVENTS: SeedEvent[] = [
 const CLUBS: SeedClub[] = [
   {
     name: "Data science society",
+    nameEl: "Όμιλος επιστήμης δεδομένων",
     description:
       "Weekly study groups, guest speakers from industry, and an end-of-semester data viz hackathon. Open to every major.",
+    descriptionEl:
+      "Εβδομαδιαία study groups, ομιλητές από τη βιομηχανία και ένα hackathon οπτικοποίησης στο τέλος του εξαμήνου. Ανοιχτός σε όλα τα τμήματα.",
     initials: "DS",
     avatarColor: "purple",
     memberCount: 248,
@@ -191,13 +304,39 @@ const CLUBS: SeedClub[] = [
     externalLink: "https://instagram.com/example",
     popularityScore: 70,
   },
+  {
+    name: "Chess club",
+    nameEl: "Όμιλος σκακιού",
+    description:
+      "Casual + rated games every Thursday, plus monthly tournaments. Boards provided, all levels welcome.",
+    initials: "CC",
+    avatarColor: "purple",
+    memberCount: 64,
+    meetsCadence: "Meets Thursdays at 7 pm",
+    externalLink: "https://discord.gg/example",
+    popularityScore: 55,
+  },
+  {
+    name: "Robotics club",
+    description:
+      "Builds for the regional VEX + FRC competitions. Tools, parts, and mentorship from the engineering faculty.",
+    initials: "RB",
+    avatarColor: "coral",
+    memberCount: 112,
+    meetsCadence: "Meets Tuesdays and Thursdays at 5 pm",
+    externalLink: "https://discord.gg/example",
+    popularityScore: 75,
+  },
 ];
 
 const DINING: SeedDining[] = [
   {
     name: "Cafe Pavilion",
+    nameEl: "Καφέ Παβιγιόν",
     description:
       "Quick-service cafe with sandwiches, bowls, espresso, and a long patio. Bring a laptop, stay all afternoon.",
+    descriptionEl:
+      "Γρήγορη εξυπηρέτηση με σάντουιτς, μπολ, espresso και μεγάλη βεράντα. Φέρτε τον φορητό σας, μείνετε όλο το απόγευμα.",
     hoursText: "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed",
     cuisine: "Sandwiches, salads, coffee",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
@@ -220,6 +359,27 @@ const DINING: SeedDining[] = [
     cuisine: "Smoothies, bowls",
     anchors: [
       { kind: "building", refId: "", refName: "Mott Athletics Center" },
+    ],
+  },
+  {
+    name: "Quad pizza",
+    description:
+      "Sourdough pizza by the slice, salads, and dessert. Late-night window opens at 9 pm.",
+    hoursText: "Mon-Sun 11am-1am",
+    cuisine: "Pizza, salads",
+    anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
+  },
+  {
+    name: "Library cafe",
+    nameEl: "Καφέ βιβλιοθήκης",
+    description:
+      "Quiet espresso bar tucked inside Engineering South. Strict no-microwave policy; pastries from the campus bakery.",
+    descriptionEl:
+      "Ήσυχο espresso bar μέσα στο Engineering South. Αυστηρή απαγόρευση φούρνου μικροκυμάτων· γλυκά από τον φούρνο της πανεπιστημιούπολης.",
+    hoursText: "Mon-Fri 8am-11pm · Sat-Sun 10am-8pm",
+    cuisine: "Coffee, pastries",
+    anchors: [
+      { kind: "building", refId: "", refName: "Engineering South Building" },
     ],
   },
 ];
@@ -246,7 +406,9 @@ export async function seedSampleCampus(
     organizationId,
     projectId,
     title: n.title,
+    titleEl: n.titleEl ?? null,
     body: n.body,
+    bodyEl: n.bodyEl ?? null,
     category: n.category,
     publishedAt: new Date(now - n.publishedDaysAgo * day),
     anchors: n.anchors as unknown as Prisma.InputJsonValue,
@@ -258,12 +420,16 @@ export async function seedSampleCampus(
       organizationId,
       projectId,
       title: e.title,
+      titleEl: e.titleEl ?? null,
       description: e.description,
+      descriptionEl: e.descriptionEl ?? null,
       startsAt,
       endsAt: new Date(startsAt.getTime() + e.durationHours * hour),
       bannerColor: e.bannerColor,
       bannerIcon: e.bannerIcon,
       expectedAttendance: e.expectedAttendance,
+      organizer: e.organizer ?? null,
+      registrationUrl: e.registrationUrl ?? null,
       anchors: e.anchors as unknown as Prisma.InputJsonValue,
     };
   });
@@ -272,7 +438,9 @@ export async function seedSampleCampus(
     organizationId,
     projectId,
     name: c.name,
+    nameEl: c.nameEl ?? null,
     description: c.description,
+    descriptionEl: c.descriptionEl ?? null,
     initials: c.initials,
     avatarColor: c.avatarColor,
     memberCount: c.memberCount,
@@ -285,7 +453,9 @@ export async function seedSampleCampus(
     organizationId,
     projectId,
     name: d.name,
+    nameEl: d.nameEl ?? null,
     description: d.description,
+    descriptionEl: d.descriptionEl ?? null,
     hoursText: d.hoursText,
     cuisine: d.cuisine,
     menuUrl: d.menuUrl ?? null,


### PR DESCRIPTION
## What this is

PR 6 of 6 — last phase polish. Bumps the sample-seed to fuller counts plus baked-in bilingual examples so the Greek translation feature is visible the moment a fresh tenant taps "Try with sample data".

| | Before | After |
|---|---|---|
| News | 4 | **6** (mix of announcement / news / alert, 2 with EL translations) |
| Events | 3 | **8** (spread over the next 30 days, 3 with organizer credit) |
| Clubs | 4 | **6** (added Chess + Robotics; 2 EL) |
| Dining | 3 | **5** (added Quad Pizza + Library Cafe; 2 EL) |

The `Seed*` shapes pick up optional `*El` fields the upsert writes through. Existing seed rows in the wild are untouched — this only changes what new "Try with sample data" runs produce.

No schema, no API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)