### PR TITLE
fix(campus): onboarding tolerates pending migrations

### DIFF
--- a/apps/campus/lib/sample-seed.ts
+++ b/apps/campus/lib/sample-seed.ts
@@ -477,13 +477,44 @@ export async function seedSampleCampus(
   };
 }
 
-/** Has this project been seeded already? "Anything in any rail" wins. */
+/**
+ * Has this project been seeded already? "Anything in any rail" wins.
+ *
+ * Each `.count()` is guarded with `.catch(() => 0)` so a pending
+ * migration (table missing) treats the project as "nothing seeded
+ * yet" instead of crashing the onboarding page. The real fix when
+ * this hits is still `pnpm prisma migrate deploy`; this is just the
+ * safety net so the dashboard stays usable in the meantime.
+ */
 export async function projectHasContent(projectId: string): Promise<boolean> {
+  const safeCount = async (
+    p: () => Promise<number>,
+    label: string,
+  ): Promise<number> => {
+    try {
+      return await p();
+    } catch (err) {
+      console.error(`[projectHasContent] ${label} count failed`, err);
+      return 0;
+    }
+  };
   const [n, e, c, d] = await Promise.all([
-    prisma.newsPost.count({ where: { projectId } }),
-    prisma.eventPost.count({ where: { projectId } }),
-    prisma.club.count({ where: { projectId } }),
-    prisma.diningLocation.count({ where: { projectId } }),
+    safeCount(
+      () => prisma.newsPost.count({ where: { projectId } }),
+      "news",
+    ),
+    safeCount(
+      () => prisma.eventPost.count({ where: { projectId } }),
+      "events",
+    ),
+    safeCount(
+      () => prisma.club.count({ where: { projectId } }),
+      "clubs",
+    ),
+    safeCount(
+      () => prisma.diningLocation.count({ where: { projectId } }),
+      "dining",
+    ),
   ]);
   return n + e + c + d > 0;
 }


### PR DESCRIPTION
## The bug

Onboarding page 500s with:

\`\`\`
PrismaClientKnownRequestError
Invalid \`prisma.newsPost.count()\` invocation:
The table \`public.NewsPost\` does not exist in the current database.
    at projectHasContent (lib/sample-seed.ts:312:24)
    at OnboardingPage (…/onboarding/page.tsx:62:25)
\`\`\`

Third place we've hit this pattern (after #149 and the detail-page getters). Same root cause: \`prisma migrate deploy\` hasn't run on this DB yet.

## The fix in this PR

\`projectHasContent()\` wraps each of its four \`prisma.<model>.count()\` calls in a \`safeCount\` helper that catches + logs and returns 0. A missing table reads as "nothing seeded" instead of crashing the page. Same safety-net pattern the public home uses for its rail reads.

The seed endpoint itself (\`/api/maps/[mapId]/seed-sample\`) is deliberately *not* caught — there's no useful "0 rows" fallback for an insert against a non-existent table; let the operator see the 500 and run \`migrate deploy\`.

## The real fix you also need

The hotfix is a safety net. The actual missing step is applying the migrations:

\`\`\`bash
cd /Users/prieston/dev/klorad/packages/prisma
pnpm exec prisma migrate deploy
\`\`\`

That picks up every migration in \`packages/prisma/migrations/\` and applies them in timestamp order against your \`DATABASE_URL\`.

## Testing

\`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)