### PR TITLE
chore(campus): auto-apply Prisma migrations on build

### DIFF
--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -9,9 +9,12 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development NEXT_TELEMETRY_DISABLED=1 next dev -p 3003",
-    "build": "next build",
+    "build": "pnpm db:deploy && next build",
     "start": "next start -p 3003",
-    "lint": "next lint --fix --dir app"
+    "lint": "next lint --fix --dir app",
+    "db:deploy": "prisma migrate deploy --schema ../../packages/prisma/schema.prisma",
+    "db:generate": "prisma generate --schema ../../packages/prisma/schema.prisma",
+    "db:migrate": "prisma migrate dev --schema ../../packages/prisma/schema.prisma"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.98.0",


### PR DESCRIPTION
## Why

Third time we've hit \"table does not exist\" in production this week:

- #149 — public home reads
- the three detail-page \`get*()\` wrappers
- #165 — onboarding's \`projectHasContent()\`

Each time the underlying issue was the same: \`prisma migrate deploy\` hadn't been run. The right move now is to stop relying on operator memory and bake it into the build itself.

## What changed

\`apps/campus/package.json\` scripts:

\`\`\`json
\"build\":       \"pnpm db:deploy && next build\",
\"db:deploy\":   \"prisma migrate deploy --schema ../../packages/prisma/schema.prisma\",
\"db:generate\": \"prisma generate --schema ../../packages/prisma/schema.prisma\",
\"db:migrate\":  \"prisma migrate dev --schema ../../packages/prisma/schema.prisma\"
\`\`\`

The cross-monorepo \`--schema\` flag is the glue — works whether someone runs it from \`apps/campus\` directly or via \`pnpm --filter @klorad/campus build\`. The DB env vars come from \`apps/campus/.env\` / \`.env.local\`, exactly where Next.js already reads them.

## Local dev story

- One-shot apply: \`pnpm db:deploy\` (production-style)
- Create-from-schema-change: \`pnpm db:migrate\` (interactive)
- Regenerate types after a remote pull: \`pnpm db:generate\`

## CI / Vercel / Render

\`pnpm build\` now applies migrations first, every time. No more \"table not found\" 500s on deploy.

## Testing

Verified by running \`pnpm db:deploy\` — \"No pending migrations to apply\" (already up to date). No code changes, just scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)