### PR TITLE
feat(campus): BYOK Anthropic key + consumer-route polish

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/AiKeyPanel.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/AiKeyPanel.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { Bot, Eye, EyeOff, RotateCw, Trash2 } from "lucide-react";
+import { Button, Field, Input, Panel } from "@klorad/design-system";
+
+interface Props {
+  mapId: string;
+}
+
+interface Status {
+  hasKey: boolean;
+  masked: string | null;
+  secretsEnabled: boolean;
+}
+
+/**
+ * AI Assistant settings panel.
+ *
+ * Lets a campus admin paste their own Anthropic API key. The key is
+ * encrypted at rest (`SECRETS_KEY`-derived AES-256-GCM via
+ * `lib/secrets.ts`) and never returned to the client in plaintext —
+ * only a masked slug for display.
+ *
+ * Empty + the platform `ANTHROPIC_API_KEY` is set → chat uses the
+ * platform key. Both set → the campus key wins.
+ *
+ * Test button hits Claude Haiku with a 1-token call so the admin
+ * knows the key works *before* a student tries it.
+ */
+export function AiKeyPanel({ mapId }: Props) {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [draft, setDraft] = useState("");
+  const [reveal, setReveal] = useState(false);
+  const [busy, setBusy] = useState<"save" | "test" | "remove" | null>(null);
+
+  useEffect(() => {
+    void fetch(`/api/maps/${mapId}/ai-settings`)
+      .then((r) => r.json())
+      .then((s: Status) => setStatus(s))
+      .catch(() => undefined);
+  }, [mapId]);
+
+  const save = async () => {
+    const apiKey = draft.trim();
+    if (!apiKey) {
+      toast.error("Paste a key first.");
+      return;
+    }
+    setBusy("save");
+    try {
+      const res = await fetch(`/api/maps/${mapId}/ai-settings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Save failed");
+      setStatus({
+        hasKey: body.hasKey,
+        masked: body.masked,
+        secretsEnabled: true,
+      });
+      setDraft("");
+      setReveal(false);
+      toast.success("Key saved");
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const test = async () => {
+    setBusy("test");
+    try {
+      const res = await fetch(`/api/maps/${mapId}/ai-settings/test`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(draft.trim() ? { apiKey: draft.trim() } : {}),
+      });
+      const body = (await res.json()) as {
+        ok: boolean;
+        error?: string;
+      };
+      if (body.ok) toast.success("Key works.");
+      else toast.error(body.error ?? "Key failed.");
+    } catch (e) {
+      console.error(e);
+      toast.error("Test failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const remove = async () => {
+    if (!confirm("Remove the stored key? The chat will fall back to the platform key.")) {
+      return;
+    }
+    setBusy("remove");
+    try {
+      const res = await fetch(`/api/maps/${mapId}/ai-settings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: null }),
+      });
+      if (!res.ok) throw new Error("Remove failed");
+      setStatus({ hasKey: false, masked: null, secretsEnabled: status?.secretsEnabled ?? false });
+      toast.success("Key removed");
+    } catch (e) {
+      console.error(e);
+      toast.error("Remove failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Panel className="rounded-2xl p-6">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent">
+          <Bot size={18} strokeWidth={1.75} />
+        </span>
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary">
+            Anthropic API key
+          </h3>
+          <p className="mt-1 text-sm text-text-secondary">
+            Powers the campus assistant. Usage and cost stay scoped to
+            this campus — the key only leaves your browser to be
+            encrypted at rest. Get one at{" "}
+            <a
+              href="https://console.anthropic.com/settings/keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline"
+            >
+              console.anthropic.com
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+
+      {status === null ? (
+        <p className="mt-4 text-xs text-text-tertiary">Loading…</p>
+      ) : (
+        <>
+          {!status.secretsEnabled ? (
+            <p className="mt-4 rounded-lg bg-red-50 p-3 text-xs text-red-600">
+              <code className="font-mono">SECRETS_KEY</code> isn’t set
+              on the server — saving a key is disabled. Generate one
+              with{" "}
+              <code className="font-mono">openssl rand -hex 32</code>{" "}
+              and add it to <code>.env.local</code>, then restart.
+            </p>
+          ) : null}
+
+          {status.hasKey && status.masked ? (
+            <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-solid border-line-soft bg-surface-2 px-3 py-2.5">
+              <span className="flex items-center gap-2 font-mono text-xs text-text-secondary">
+                <Bot size={14} strokeWidth={1.75} className="text-accent" />
+                {status.masked}
+              </span>
+              <button
+                type="button"
+                onClick={() => void remove()}
+                disabled={busy !== null}
+                className="inline-flex items-center gap-1 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-1 hover:text-red-600 disabled:opacity-40"
+                aria-label="Remove key"
+              >
+                <Trash2 size={14} strokeWidth={1.75} />
+              </button>
+            </div>
+          ) : null}
+
+          <Field
+            label={status.hasKey ? "Replace with a new key" : "Add a key"}
+            className="mt-4"
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type={reveal ? "text" : "password"}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="sk-ant-…"
+                disabled={!status.secretsEnabled || busy !== null}
+                autoComplete="off"
+                className="flex-1 font-mono"
+              />
+              <button
+                type="button"
+                onClick={() => setReveal((r) => !r)}
+                aria-label={reveal ? "Hide" : "Reveal"}
+                className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-solid border-line-soft text-text-tertiary transition-colors hover:border-accent hover:text-accent"
+              >
+                {reveal ? (
+                  <EyeOff size={14} strokeWidth={1.75} />
+                ) : (
+                  <Eye size={14} strokeWidth={1.75} />
+                )}
+              </button>
+            </div>
+          </Field>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              onClick={() => void save()}
+              disabled={!status.secretsEnabled || !draft.trim() || busy !== null}
+            >
+              {busy === "save" ? "Saving…" : "Save key"}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => void test()}
+              disabled={busy !== null || (!draft.trim() && !status.hasKey)}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <RotateCw
+                  size={14}
+                  strokeWidth={1.75}
+                  className={busy === "test" ? "animate-spin" : ""}
+                />
+                {busy === "test" ? "Testing…" : "Test"}
+              </span>
+            </Button>
+          </div>
+        </>
+      )}
+    </Panel>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/SettingsTab.tsx
@@ -10,6 +10,7 @@ import { Button, Field, IconButton, Input, Panel, Textarea } from "@klorad/desig
 import type { Branding, SceneData } from "@klorad/api";
 import MembersPanel from "./MembersPanel";
 import HomePagePanel from "./HomePagePanel";
+import { AiKeyPanel } from "./AiKeyPanel";
 
 interface Props {
   orgId: string;
@@ -218,6 +219,10 @@ export default function SettingsTab({ orgId, mapId, map }: Props) {
             {savingIndoor ? "Saving…" : "Save indoor map"}
           </Button>
         </Panel>
+      </Section>
+
+      <Section title="AI assistant">
+        <AiKeyPanel mapId={mapId} />
       </Section>
 
       <Section title="Sharing">

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -3,6 +3,7 @@ import { getPublicCampusByToken } from "@/lib/public-campus";
 import { venueForIndoorMap } from "@/lib/mappedin/config";
 import { MappedinViewer } from "@/lib/mappedin/MappedinViewer";
 import { detectLocale } from "@/app/lib/i18n-core";
+import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import PublicViewerClient from "../PublicViewerClient";
 import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
 
@@ -42,7 +43,7 @@ export default async function CampusMapPage({
 
   const scene = (map.sceneData ?? null) as {
     indoorMapId?: string;
-    branding?: { primaryColor?: string; name?: string };
+    branding?: { primaryColor?: string; name?: string; logo?: string };
   } | null;
   const indoorMapId = scene?.indoorMapId;
   const accentColor =
@@ -51,20 +52,29 @@ export default async function CampusMapPage({
       ? scene.branding.primaryColor
       : undefined;
   const campusName = scene?.branding?.name || map.title;
+  const logoUrl = scene?.branding?.logo;
 
   if (indoorMapId) {
     return (
-      <main data-mappedin className="h-screen w-full">
-        <MappedinViewer
-          venue={venueForIndoorMap(indoorMapId)}
-          focusSpaceId={focusSpaceId}
-          locale={locale}
-          homeHref={`/campus/${token}?lang=${locale}`}
-          accentColor={accentColor}
-          projectId={map.id}
+      <main data-mappedin className="flex h-screen w-full flex-col">
+        <ConsumerNav
           campusName={campusName}
-          showWelcome
+          logoUrl={logoUrl}
+          token={token}
+          locale={locale}
         />
+        <div className="min-h-0 flex-1">
+          <MappedinViewer
+            venue={venueForIndoorMap(indoorMapId)}
+            focusSpaceId={focusSpaceId}
+            locale={locale}
+            homeHref={`/campus/${token}?lang=${locale}`}
+            accentColor={accentColor}
+            projectId={map.id}
+            campusName={campusName}
+            showWelcome
+          />
+        </div>
       </main>
     );
   }

--- a/apps/campus/app/api/assistant/route.ts
+++ b/apps/campus/app/api/assistant/route.ts
@@ -8,6 +8,34 @@ import {
   type ToolContext,
 } from "@/lib/assistant/tools";
 import { checkRateLimit, clientIp } from "@/lib/assistant/rate-limit";
+import { prisma } from "@/lib/prisma";
+import { decryptSecret, secretsEnabled } from "@/lib/secrets";
+
+/**
+ * Resolve the API key for a chat turn — per-campus stored key first,
+ * server-wide `ANTHROPIC_API_KEY` second. The campus key lives
+ * encrypted in `Project.anthropicApiKeyEncrypted`; decrypt failures
+ * (rotated SECRETS_KEY, stale ciphertext) fall through to the env
+ * var so the chat stays usable.
+ */
+async function resolveAnthropicKey(
+  mapId: string,
+): Promise<string | undefined> {
+  if (secretsEnabled()) {
+    try {
+      const project = await prisma.project.findUnique({
+        where: { id: mapId },
+        select: { anthropicApiKeyEncrypted: true },
+      });
+      if (project?.anthropicApiKeyEncrypted) {
+        return decryptSecret(project.anthropicApiKeyEncrypted);
+      }
+    } catch (err) {
+      console.error("[assistant] per-campus key lookup failed", err);
+    }
+  }
+  return process.env.ANTHROPIC_API_KEY ?? undefined;
+}
 
 interface AssistantTurn {
   role: "user" | "assistant";
@@ -243,7 +271,10 @@ export async function POST(req: Request) {
   }
 
   const spaces = Array.isArray(body.spaces) ? body.spaces : [];
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  // Per-campus BYOK first, platform key second. Each chat turn does
+  // one extra Project read by id (cuid lookup, fast); per-tenant key
+  // means usage + cost scope to the right buyer.
+  const apiKey = await resolveAnthropicKey(body.mapId);
 
   // No key → keep the basic regex parser alive. The chat input is
   // still visible everywhere; without a key it only handles the

--- a/apps/campus/app/api/maps/[mapId]/ai-settings/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/ai-settings/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import {
+  decryptSecret,
+  encryptSecret,
+  maskSecret,
+  secretsEnabled,
+} from "@/lib/secrets";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * GET /api/maps/[mapId]/ai-settings
+ *
+ * Returns the status of the campus's AI configuration. Never returns
+ * the plaintext key — only `{ hasKey, masked, secretsEnabled }`.
+ *
+ *   - `hasKey`: a key is stored for this campus.
+ *   - `masked`: display-safe slug ("sk-ant-…••••8f2c") when present.
+ *   - `secretsEnabled`: whether `SECRETS_KEY` is configured on the
+ *     server — if false, write attempts will 503.
+ */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { anthropicApiKeyEncrypted: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let masked: string | null = null;
+  if (project.anthropicApiKeyEncrypted && secretsEnabled()) {
+    try {
+      masked = maskSecret(decryptSecret(project.anthropicApiKeyEncrypted));
+    } catch (err) {
+      console.error("[ai-settings] decrypt failed", err);
+    }
+  }
+
+  return NextResponse.json({
+    hasKey: Boolean(project.anthropicApiKeyEncrypted),
+    masked,
+    secretsEnabled: secretsEnabled(),
+  });
+}
+
+/**
+ * PATCH /api/maps/[mapId]/ai-settings
+ *
+ * Body: `{ apiKey: string | null }`.
+ *   - String → validates the prefix, encrypts, stores.
+ *   - `null` → clears the stored key, campus falls back to env.
+ *
+ * 503 when `SECRETS_KEY` isn't configured server-side — refuses
+ * rather than silently storing plaintext.
+ */
+export async function PATCH(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // Clear flow.
+  if (body.apiKey === null) {
+    await prisma.project.update({
+      where: { id: mapId },
+      data: { anthropicApiKeyEncrypted: null },
+    });
+    return NextResponse.json({ ok: true, hasKey: false, masked: null });
+  }
+
+  // Set / update flow.
+  if (!secretsEnabled()) {
+    return NextResponse.json(
+      {
+        error:
+          "SECRETS_KEY isn't set on the server — needed to encrypt at-rest secrets.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "apiKey is required" },
+      { status: 400 },
+    );
+  }
+  if (!apiKey.startsWith("sk-ant-")) {
+    return NextResponse.json(
+      { error: "Anthropic keys start with sk-ant-" },
+      { status: 400 },
+    );
+  }
+
+  const encrypted = encryptSecret(apiKey);
+  await prisma.project.update({
+    where: { id: mapId },
+    data: { anthropicApiKeyEncrypted: encrypted },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    hasKey: true,
+    masked: maskSecret(apiKey),
+  });
+}

--- a/apps/campus/app/api/maps/[mapId]/ai-settings/test/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/ai-settings/test/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import { decryptSecret, secretsEnabled } from "@/lib/secrets";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * POST /api/maps/[mapId]/ai-settings/test
+ *
+ * Hits Claude Haiku with a 1-token max budget to confirm an API key
+ * actually works. Body: `{ apiKey?: string }`.
+ *   - With `apiKey`: tests the supplied key (used before Save so
+ *     the admin can paste-and-test without committing).
+ *   - Without: tests the stored key.
+ *
+ * Returns `{ ok: true }` or `{ ok: false, error }` — the latter is
+ * still HTTP 200 so the client can show inline feedback without
+ * tripping fetch-error handling.
+ */
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    // Empty body is fine — falls through to the stored-key path.
+  }
+
+  let apiKey =
+    typeof body.apiKey === "string" && body.apiKey.trim().length > 0
+      ? body.apiKey.trim()
+      : "";
+
+  if (!apiKey) {
+    if (!secretsEnabled()) {
+      return NextResponse.json(
+        { ok: false, error: "SECRETS_KEY isn't set on the server." },
+        { status: 200 },
+      );
+    }
+    const project = await prisma.project.findUnique({
+      where: { id: mapId },
+      select: { anthropicApiKeyEncrypted: true },
+    });
+    if (!project?.anthropicApiKeyEncrypted) {
+      return NextResponse.json(
+        { ok: false, error: "No key stored yet." },
+        { status: 200 },
+      );
+    }
+    try {
+      apiKey = decryptSecret(project.anthropicApiKeyEncrypted);
+    } catch {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Stored ciphertext didn't decrypt — was SECRETS_KEY rotated?",
+        },
+        { status: 200 },
+      );
+    }
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+    await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 1,
+      messages: [{ role: "user", content: "ping" }],
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Anthropic call failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 200 });
+  }
+}

--- a/apps/campus/app/global.css
+++ b/apps/campus/app/global.css
@@ -25,6 +25,13 @@ body {
   font-family: "Inter", system-ui, sans-serif;
 }
 
+/* Reserve the vertical scrollbar lane on every page so navigating
+   between a tall scrolling route (home, events) and a no-scroll one
+   (the map) doesn't reflow the nav by the scrollbar's width. */
+html {
+  scrollbar-gutter: stable;
+}
+
 .mapboxgl-map {
   width: 100%;
   height: 100%;

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -116,8 +116,6 @@ export function ConsumerHome({
         }
         primaryHref={mapHref}
         primaryLabel="Get started — it's free"
-        secondaryHref={`/campus/${token}/tour${lang}`}
-        secondaryLabel="Watch the tour"
         mapHref={mapHref}
         mapThumbnailUrl={mapThumbnailUrl}
       />

--- a/apps/campus/lib/consumer/ConsumerNav.tsx
+++ b/apps/campus/lib/consumer/ConsumerNav.tsx
@@ -39,11 +39,10 @@ export function ConsumerNav({
     { label: "Clubs", href: `/campus/${token}/clubs${lang}` },
     { label: "Dining", href: `/campus/${token}/dining${lang}` },
     { label: "News", href: `/campus/${token}/news${lang}` },
-    { label: "Help", href: `/campus/${token}/help${lang}` },
   ];
 
   return (
-    <header className="sticky top-0 z-20 border-b border-[var(--brand-line)] bg-white">
+    <header className="sticky top-0 z-20 bg-white">
       <div className="mx-auto flex h-14 max-w-[1280px] items-center justify-between gap-4 px-4 md:px-6">
         <Link
           href={`/campus/${token}${lang}`}

--- a/apps/campus/lib/mappedin/MappedinViewer.tsx
+++ b/apps/campus/lib/mappedin/MappedinViewer.tsx
@@ -314,9 +314,21 @@ export const MappedinViewer = forwardRef<
         setStatus("ready");
       } catch (e) {
         if (cancelled) return;
-        setError(
-          e instanceof Error ? e.message : "Failed to load the indoor map",
-        );
+        // The MappedIn SDK uses internal AbortControllers — when the
+        // effect cleanup tears the viewer down mid-load (StrictMode in
+        // dev, soft-nav in prod), the in-flight fetch for sprite.json /
+        // map tiles rejects with an AbortError. We've already returned
+        // on `cancelled` above for the truly-stale path; if we land here
+        // with an abort we still want to swallow it instead of showing
+        // a load-failure card to the visitor.
+        const msg = e instanceof Error ? e.message : "";
+        if (
+          (e instanceof Error && e.name === "AbortError") ||
+          /aborted|signal is aborted/i.test(msg)
+        ) {
+          return;
+        }
+        setError(msg || "Failed to load the indoor map");
         setStatus("error");
       }
     })();

--- a/apps/campus/lib/secrets.ts
+++ b/apps/campus/lib/secrets.ts
@@ -1,0 +1,80 @@
+/**
+ * Symmetric encryption for at-rest secrets (BYOK Anthropic keys etc.).
+ *
+ * AES-256-GCM via `node:crypto` — authenticated, IV per ciphertext.
+ * The 32-byte key is sourced from `SECRETS_KEY`:
+ *   - 64 hex chars → used as-is.
+ *   - anything else → run through scrypt to derive 32 bytes.
+ *
+ * Format: `${iv}.${tag}.${ciphertext}`, all base64. The dot separator
+ * is safe because base64 never contains `.`.
+ */
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scryptSync,
+} from "node:crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_BYTES = 12;
+const KEY_BYTES = 32;
+const SCRYPT_SALT = "klorad-secrets-v1";
+
+function getKey(): Buffer {
+  const raw = process.env.SECRETS_KEY;
+  if (!raw) {
+    throw new Error(
+      "SECRETS_KEY env var not set — required to encrypt at-rest secrets.",
+    );
+  }
+  if (/^[0-9a-f]{64}$/i.test(raw)) return Buffer.from(raw, "hex");
+  return scryptSync(raw, SCRYPT_SALT, KEY_BYTES);
+}
+
+/** True when `SECRETS_KEY` is configured — callers can gate the UI on this. */
+export function secretsEnabled(): boolean {
+  return Boolean(process.env.SECRETS_KEY);
+}
+
+/** Encrypt a UTF-8 string. Throws if `SECRETS_KEY` isn't set. */
+export function encryptSecret(plaintext: string): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGO, getKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return [
+    iv.toString("base64"),
+    tag.toString("base64"),
+    ciphertext.toString("base64"),
+  ].join(".");
+}
+
+/** Decrypt a blob from `encryptSecret`. Throws on tampering / bad key. */
+export function decryptSecret(blob: string): string {
+  const [ivB64, tagB64, ctB64] = blob.split(".");
+  if (!ivB64 || !tagB64 || !ctB64) {
+    throw new Error("Invalid ciphertext blob");
+  }
+  const iv = Buffer.from(ivB64, "base64");
+  const tag = Buffer.from(tagB64, "base64");
+  const ct = Buffer.from(ctB64, "base64");
+  const decipher = createDecipheriv(ALGO, getKey(), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString(
+    "utf8",
+  );
+}
+
+/**
+ * Display-safe representation of a secret — first 7 chars (catches
+ * the `sk-ant-` prefix), then `…`, then four bullets, then last 4
+ * chars. Never returned over the wire alongside the real value.
+ */
+export function maskSecret(value: string): string {
+  if (value.length <= 8) return "•".repeat(value.length);
+  return `${value.slice(0, 7)}…••••${value.slice(-4)}`;
+}

--- a/packages/prisma/migrations/20260528210000_add_project_anthropic_key/migration.sql
+++ b/packages/prisma/migrations/20260528210000_add_project_anthropic_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "anthropicApiKeyEncrypted" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -158,6 +158,11 @@ model Project {
   // thumbnail URL for the project preview image
   thumbnail      String?
   thumbnailSize  BigInt? // File size in bytes (for storage calculation)
+  /// Per-campus Anthropic API key — AES-256-GCM ciphertext from
+  /// lib/secrets.ts. Server reads + decrypts on every /api/assistant
+  /// call; falls back to the platform `ANTHROPIC_API_KEY` env var
+  /// when null. Never returned to the client — see ai-settings API.
+  anthropicApiKeyEncrypted String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 


### PR DESCRIPTION
Two commits, one branch — the BYOK feature and a small polish bundle that makes the consumer routes feel like one app instead of disjoint surfaces.

## Commit 1 — BYOK Anthropic key in campus settings

Per-campus Anthropic API key in the dashboard, instead of (or alongside) the platform env var. Usage + cost scope to the buyer — an org with three campuses can use three different keys, or share one via env.

| Layer | What |
|---|---|
| **Storage** | New `Project.anthropicApiKeyEncrypted` column. AES-256-GCM ciphertext from `lib/secrets.ts`, keyed off `SECRETS_KEY` (32 hex bytes or a passphrase via scrypt). Plaintext never goes to the DB or comes back to the client. |
| **Resolution** | `/api/assistant` calls `resolveAnthropicKey(mapId)`: campus key first, then `process.env.ANTHROPIC_API_KEY`, then regex fallback. Decrypt failure → falls through (graceful key rotation). |
| **UI** | New "AI assistant" section in the campus Settings tab. Masked display (`sk-ant-…••••8f2c`), password-input with reveal eye, Save / Test / Remove. |
| **Test** | `POST /ai-settings/test` hits Claude Haiku with `max_tokens: 1`. Body `{ apiKey? }` lets the admin test a draft *before* saving. |

Server-side requirement:

```bash
openssl rand -hex 32   # → SECRETS_KEY
# add to apps/campus/.env.local, restart
```

Without `SECRETS_KEY` the panel renders + reads but disables Save with a red callout pointing at the command above. The platform `ANTHROPIC_API_KEY` env path keeps working regardless.

Migration `20260528210000_add_project_anthropic_key` — one nullable column.

## Commit 2 — Consumer-route consistency + map chrome

Five small polish fixes:

- **Dead-CTA cleanup.** Removed the "Watch the tour" hero CTA (`/campus/[token]/tour` doesn't exist; virtual tour is a pending arc) and the "Help" nav entry (`/campus/[token]/help` doesn't exist either).
- **Map gets the ConsumerNav.** Previously the map route bypassed the nav, so jumping from Home → Map → Events broke the illusion of one app. Now mounted in a flex column, viewer fills `min-h-0 flex-1`. SceneData also exposes `branding.logo` so the campus logo follows you into the map.
- **Scrollbar gutter.** `html { scrollbar-gutter: stable }` so navigating from a scrolling route (home, events) to the no-scroll map doesn't shift the nav by the scrollbar's width.
- **Drop the nav hairline.** The `border-b` on `ConsumerNav` was invisible on white-on-white pages but read as a stark black line where the white nav met the dark MappedIn canvas. Removing it makes the seam clean on every route.
- **MappedIn AbortError swallow.** SDK uses internal AbortControllers; React StrictMode and fast soft-navs can land us in the catch with `signal is aborted`. Guarded so a torn-down viewer never flashes a "Failed to load" card.

## Testing

`tsc --noEmit` clean across both commits. `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)