### PR TITLE
feat(campus): events/clubs/dining hybrid migration + Vercel build fix

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ExternalLink, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
+import { detectLocale } from "@/app/lib/i18n-core";
 import { listTopClubsForProject } from "@/lib/clubs-db";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { SegmentedTabs } from "@/lib/consumer/SegmentedTabs";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+import { ClubsListClient } from "@/lib/consumer/ClubsListClient";
 
 type Params = Promise<{ token: string }>;
 
@@ -20,13 +19,6 @@ interface CampusBranding {
 function isValidHex(value: string | undefined): value is string {
   return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
 }
-
-const AVATAR_BG: Record<string, string> = {
-  purple: "var(--brand-primary-fill)",
-  coral: "var(--brand-accent-warm)",
-  teal: "var(--brand-accent-cool)",
-  pink: "var(--brand-accent-complement)",
-};
 
 export async function generateMetadata({
   params,
@@ -103,91 +95,13 @@ export default async function ClubsPage({
           activity.
         </p>
 
-        {clubs.length === 0 ? (
-          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
-            No clubs published yet.
-          </div>
-        ) : (
-          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-            {clubs.map((c) => {
-              const name = pickLocalized(c.name, c.nameEl, locale);
-              const description = pickLocalized(
-                c.description,
-                c.descriptionEl,
-                locale,
-              );
-              return (
-              <article
-                key={c.id}
-                className="flex flex-col gap-3 rounded-2xl border border-[var(--brand-line)] bg-white p-5"
-              >
-                <div className="flex items-center gap-3">
-                  {c.imageUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={c.imageUrl}
-                      alt=""
-                      className="h-12 w-12 rounded-xl object-cover"
-                    />
-                  ) : (
-                    <span
-                      aria-hidden
-                      className="flex h-12 w-12 items-center justify-center rounded-xl text-sm font-medium text-white"
-                      style={{ backgroundColor: AVATAR_BG[c.avatarColor] }}
-                    >
-                      {c.initials}
-                    </span>
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <Link
-                      href={`/campus/${token}/clubs/${c.id}${lang}`}
-                      className="block truncate text-base font-medium text-[var(--brand-text)] transition-colors hover:text-[var(--brand-primary)]"
-                    >
-                      {name}
-                    </Link>
-                    <p className="mt-0.5 truncate text-xs text-[var(--brand-text-muted)]">
-                      {c.memberCount} members
-                      {c.meetsCadence ? ` · ${c.meetsCadence}` : ""}
-                    </p>
-                  </div>
-                </div>
-
-                <p className="line-clamp-3 text-sm leading-relaxed text-[var(--brand-text)]">
-                  {description}
-                </p>
-
-                {c.anchors[0] ? (
-                  <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]">
-                    <MapPin size={12} strokeWidth={1.75} />
-                    {c.anchors[0].refName}
-                  </span>
-                ) : null}
-
-                <div className="mt-auto flex items-center gap-2 pt-2">
-                  <Link
-                    href={`/campus/${token}/clubs/${c.id}${lang}`}
-                    className="rounded-full border border-[var(--brand-line)] bg-white px-3 py-1.5 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
-                  >
-                    Details
-                  </Link>
-                  {c.externalLink ? (
-                    <a
-                      href={c.externalLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
-                      style={{ backgroundColor: "var(--brand-primary)" }}
-                    >
-                      <ExternalLink size={12} strokeWidth={1.75} />
-                      View
-                    </a>
-                  ) : null}
-                </div>
-              </article>
-              );
-            })}
-          </div>
-        )}
+        <ClubsListClient
+          token={token}
+          locale={locale}
+          lang={lang}
+          initialClubs={clubs}
+          emptyCopy="No clubs published yet."
+        />
       </section>
 
       <ConsumerFooter campusName={campusName} />

--- a/apps/campus/app/(public)/campus/[token]/dining/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/dining/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Clock, ExternalLink, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
+import { detectLocale } from "@/app/lib/i18n-core";
 import { listDiningForProject } from "@/lib/dining-db";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { SegmentedTabs } from "@/lib/consumer/SegmentedTabs";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
+import { DiningListClient } from "@/lib/consumer/DiningListClient";
 
 type Params = Promise<{ token: string }>;
 
@@ -96,100 +95,13 @@ export default async function DiningPage({
           Where to eat on campus.
         </p>
 
-        {locations.length === 0 ? (
-          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
-            No dining published yet.
-          </div>
-        ) : (
-          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2">
-            {locations.map((l) => {
-              const firstAnchor = l.anchors[0];
-              const name = pickLocalized(l.name, l.nameEl, locale);
-              const description = pickLocalized(
-                l.description,
-                l.descriptionEl,
-                locale,
-              );
-              return (
-                <article
-                  key={l.id}
-                  className="flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white"
-                >
-                  {l.imageUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={l.imageUrl}
-                      alt=""
-                      className="block aspect-[16/9] w-full object-cover"
-                    />
-                  ) : (
-                    <div
-                      aria-hidden
-                      className="aspect-[16/9] w-full"
-                      style={{
-                        background:
-                          "linear-gradient(135deg, var(--brand-primary-bg) 0%, var(--brand-primary-soft) 100%)",
-                      }}
-                    />
-                  )}
-                  <div className="flex flex-1 flex-col gap-3 p-5">
-                    <div>
-                      <h2 className="text-lg font-medium text-[var(--brand-text)]">
-                        {name}
-                      </h2>
-                      {l.cuisine ? (
-                        <p className="mt-0.5 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
-                          {l.cuisine}
-                        </p>
-                      ) : null}
-                    </div>
-
-                    <p className="text-sm leading-relaxed text-[var(--brand-text)]">
-                      {description}
-                    </p>
-
-                    {l.hoursText ? (
-                      <p className="inline-flex items-center gap-1.5 text-xs text-[var(--brand-text-muted)]">
-                        <Clock size={14} strokeWidth={1.75} />
-                        {l.hoursText}
-                      </p>
-                    ) : null}
-
-                    <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
-                      {firstAnchor ? (
-                        firstAnchor.refId ? (
-                          <Link
-                            href={`${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`}
-                            className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
-                          >
-                            <MapPin size={14} strokeWidth={1.75} />
-                            {firstAnchor.refName}
-                          </Link>
-                        ) : (
-                          <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]">
-                            <MapPin size={14} strokeWidth={1.75} />
-                            {firstAnchor.refName}
-                          </span>
-                        )
-                      ) : null}
-                      {l.menuUrl ? (
-                        <a
-                          href={l.menuUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--brand-line)] bg-white px-3 py-1 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
-                        >
-                          <ExternalLink size={14} strokeWidth={1.75} />
-                          View menu
-                        </a>
-                      ) : null}
-                    </div>
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-        )}
+        <DiningListClient
+          token={token}
+          locale={locale}
+          mapHref={mapHref}
+          initialLocations={locations}
+          emptyCopy="No dining published yet."
+        />
       </section>
 
       <ConsumerFooter campusName={campusName} />

--- a/apps/campus/app/(public)/campus/[token]/events/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/page.tsx
@@ -1,20 +1,16 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Calendar, Compass, MapPin } from "lucide-react";
+import { Compass } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
-import {
-  formatEventWhen,
-  listUpcomingEventsForProject,
-} from "@/lib/events-db";
+import { detectLocale } from "@/app/lib/i18n-core";
+import { listUpcomingEventsForProject } from "@/lib/events-db";
 import { readEventFeeds, type CampusEvent } from "@/lib/events";
 import { fetchCampusEvents } from "@/lib/events-server";
-import { eventHasDetailPage, mergeEvents } from "@/lib/events-merge";
 import { ConsumerNav } from "@/lib/consumer/ConsumerNav";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
 import { SegmentedTabs } from "@/lib/consumer/SegmentedTabs";
-import { stripedBanner } from "@/lib/consumer/bannerPattern";
+import { EventsListClient } from "@/lib/consumer/EventsListClient";
 
 type Params = Promise<{ token: string }>;
 
@@ -27,13 +23,6 @@ interface CampusBranding {
 function isValidHex(value: string | undefined): value is string {
   return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
 }
-
-const BANNER_BG: Record<string, string> = {
-  purple: "var(--brand-primary-fill)",
-  coral: "var(--brand-accent-warm)",
-  teal: "var(--brand-accent-cool)",
-  pink: "var(--brand-accent-complement)",
-};
 
 export async function generateMetadata({
   params,
@@ -86,9 +75,10 @@ export default async function EventsPage({
 
   const lang = `?lang=${locale}`;
   const mapHref = `/campus/${token}/map${lang}`;
-  // DB-backed events + any ICS feeds the admin configured. Same
-  // merge the consumer home uses; defensive `.catch()` on the ICS
-  // fetch so a slow / broken feed doesn't blank the page.
+  // DB-backed events + any ICS feeds the admin configured. The DB
+  // rows are seeded into SWR's cache via `EventsListClient`'s
+  // `initialDbEvents`; ICS rows stay server-side (slow external
+  // fetch) and are merged on every client render.
   const feedUrls = readEventFeeds(map.sceneData);
   const [dbEvents, icsEvents] = await Promise.all([
     listUpcomingEventsForProject(map.id, 100),
@@ -99,14 +89,6 @@ export default async function EventsPage({
         })
       : Promise.resolve<CampusEvent[]>([]),
   ]);
-  // Localise the DB rows before they meet `mergeEvents`. ICS rows
-  // have no EL columns to pick from; they stay as-is.
-  const dbEventsLocalised = dbEvents.map((e) => ({
-    ...e,
-    title: pickLocalized(e.title, e.titleEl, locale),
-    description: pickLocalized(e.description, e.descriptionEl, locale),
-  }));
-  const events = mergeEvents(dbEventsLocalised, icsEvents, 100);
 
   return (
     <main data-consumer lang={locale} style={themeStyle}>
@@ -131,70 +113,15 @@ export default async function EventsPage({
           What’s happening this week and beyond on campus.
         </p>
 
-        {events.length === 0 ? (
-          <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
-            No events published yet.
-          </div>
-        ) : (
-          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-            {events.map((e) => {
-              const firstAnchor = e.anchors[0];
-              // DB rows link to their detail page; ICS rows (id contains
-              // `::`) link to the map with the anchor focused.
-              const href = eventHasDetailPage(e.id)
-                ? `/campus/${token}/events/${e.id}${lang}`
-                : firstAnchor?.refId
-                  ? `${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`
-                  : mapHref;
-              const accent =
-                BANNER_BG[e.bannerColor] ?? "var(--brand-primary-fill)";
-              return (
-                <Link
-                  key={e.id}
-                  href={href}
-                  className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
-                >
-                  <div
-                    className="flex h-20 items-end justify-start p-4"
-                    style={stripedBanner(accent)}
-                  >
-                    <Calendar
-                      size={24}
-                      strokeWidth={1.5}
-                      style={{ color: accent }}
-                      aria-hidden
-                    />
-                  </div>
-                  <div className="flex flex-1 flex-col gap-2 p-5">
-                    <h2 className="text-base font-medium text-[var(--brand-text)]">
-                      {e.title}
-                    </h2>
-                    <span className="text-xs text-[var(--brand-text-muted)]">
-                      {formatEventWhen(e.startsAt)}
-                    </span>
-                    <p className="line-clamp-2 text-xs leading-relaxed text-[var(--brand-text-muted)]">
-                      {e.blurb}
-                    </p>
-                    <div className="mt-auto flex flex-wrap items-center gap-2 pt-2 text-xs text-[var(--brand-text-muted)]">
-                      {firstAnchor ? (
-                        <span className="inline-flex items-center gap-1">
-                          <MapPin size={14} strokeWidth={1.75} />
-                          {firstAnchor.refName}
-                        </span>
-                      ) : null}
-                      {firstAnchor?.refId ? (
-                        <span className="ml-auto inline-flex items-center gap-1 text-[var(--brand-primary)] group-hover:underline">
-                          <Compass size={14} strokeWidth={1.75} />
-                          Directions
-                        </span>
-                      ) : null}
-                    </div>
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-        )}
+        <EventsListClient
+          token={token}
+          locale={locale}
+          lang={lang}
+          mapHref={mapHref}
+          initialDbEvents={dbEvents}
+          icsEvents={icsEvents}
+          emptyCopy="No events published yet."
+        />
 
         <Link
           href={mapHref}

--- a/apps/campus/lib/consumer/ClubsListClient.tsx
+++ b/apps/campus/lib/consumer/ClubsListClient.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink, MapPin } from "lucide-react";
+import { pickLocalized, type Locale } from "@/app/lib/i18n-core";
+import type { Club } from "@/lib/clubs-db";
+import { useCampusClubs } from "@/lib/swr/useCampusClubs";
+import { ClubsListSkeleton } from "./ClubsListSkeleton";
+
+const AVATAR_BG: Record<string, string> = {
+  purple: "var(--brand-primary-fill)",
+  coral: "var(--brand-accent-warm)",
+  teal: "var(--brand-accent-cool)",
+  pink: "var(--brand-accent-complement)",
+};
+
+interface Props {
+  token: string;
+  locale: Locale;
+  lang: string;
+  initialClubs: Club[];
+  emptyCopy: string;
+}
+
+/**
+ * Client renderer for the clubs grid. SWR keeps the list fresh on
+ * focus / reconnect / cache miss; SSR seeds the cache via
+ * `fallbackData` so the first paint is real content. The skeleton
+ * shows only when the cache is genuinely cold.
+ */
+export function ClubsListClient({
+  token,
+  locale,
+  lang,
+  initialClubs,
+  emptyCopy,
+}: Props) {
+  const { clubs, isLoading } = useCampusClubs(token, initialClubs);
+
+  if (isLoading && clubs.length === 0) {
+    return <ClubsListSkeleton rows={6} />;
+  }
+
+  if (clubs.length === 0) {
+    return (
+      <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+        {emptyCopy}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+      {clubs.map((c) => {
+        const name = pickLocalized(c.name, c.nameEl, locale);
+        const description = pickLocalized(
+          c.description,
+          c.descriptionEl,
+          locale,
+        );
+        return (
+          <article
+            key={c.id}
+            className="flex flex-col gap-3 rounded-2xl border border-[var(--brand-line)] bg-white p-5"
+          >
+            <div className="flex items-center gap-3">
+              {c.imageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={c.imageUrl}
+                  alt=""
+                  className="h-12 w-12 rounded-xl object-cover"
+                />
+              ) : (
+                <span
+                  aria-hidden
+                  className="flex h-12 w-12 items-center justify-center rounded-xl text-sm font-medium text-white"
+                  style={{ backgroundColor: AVATAR_BG[c.avatarColor] }}
+                >
+                  {c.initials}
+                </span>
+              )}
+              <div className="min-w-0 flex-1">
+                <Link
+                  href={`/campus/${token}/clubs/${c.id}${lang}`}
+                  className="block truncate text-base font-medium text-[var(--brand-text)] transition-colors hover:text-[var(--brand-primary)]"
+                >
+                  {name}
+                </Link>
+                <p className="mt-0.5 truncate text-xs text-[var(--brand-text-muted)]">
+                  {c.memberCount} members
+                  {c.meetsCadence ? ` · ${c.meetsCadence}` : ""}
+                </p>
+              </div>
+            </div>
+
+            <p className="line-clamp-3 text-sm leading-relaxed text-[var(--brand-text)]">
+              {description}
+            </p>
+
+            {c.anchors[0] ? (
+              <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]">
+                <MapPin size={12} strokeWidth={1.75} />
+                {c.anchors[0].refName}
+              </span>
+            ) : null}
+
+            <div className="mt-auto flex items-center gap-2 pt-2">
+              <Link
+                href={`/campus/${token}/clubs/${c.id}${lang}`}
+                className="rounded-full border border-[var(--brand-line)] bg-white px-3 py-1.5 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
+              >
+                Details
+              </Link>
+              {c.externalLink ? (
+                <a
+                  href={c.externalLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                  style={{ backgroundColor: "var(--brand-primary)" }}
+                >
+                  <ExternalLink size={12} strokeWidth={1.75} />
+                  View
+                </a>
+              ) : null}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/DiningListClient.tsx
+++ b/apps/campus/lib/consumer/DiningListClient.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { Clock, ExternalLink, MapPin } from "lucide-react";
+import { pickLocalized, type Locale } from "@/app/lib/i18n-core";
+import type { DiningLocation } from "@/lib/dining-db";
+import { useCampusDining } from "@/lib/swr/useCampusDining";
+import { DiningListSkeleton } from "./DiningListSkeleton";
+
+interface Props {
+  token: string;
+  locale: Locale;
+  mapHref: string;
+  initialLocations: DiningLocation[];
+  emptyCopy: string;
+}
+
+/**
+ * Client renderer for the dining grid. SWR keeps the list fresh
+ * across navigations; SSR seeds the cache via `fallbackData`.
+ */
+export function DiningListClient({
+  token,
+  locale,
+  mapHref,
+  initialLocations,
+  emptyCopy,
+}: Props) {
+  const { dining, isLoading } = useCampusDining(token, initialLocations);
+
+  if (isLoading && dining.length === 0) {
+    return <DiningListSkeleton rows={4} />;
+  }
+
+  if (dining.length === 0) {
+    return (
+      <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+        {emptyCopy}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2">
+      {dining.map((l) => {
+        const firstAnchor = l.anchors[0];
+        const name = pickLocalized(l.name, l.nameEl, locale);
+        const description = pickLocalized(
+          l.description,
+          l.descriptionEl,
+          locale,
+        );
+        return (
+          <article
+            key={l.id}
+            className="flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white"
+          >
+            {l.imageUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={l.imageUrl}
+                alt=""
+                className="block aspect-[16/9] w-full object-cover"
+              />
+            ) : (
+              <div
+                aria-hidden
+                className="aspect-[16/9] w-full"
+                style={{
+                  background:
+                    "linear-gradient(135deg, var(--brand-primary-bg) 0%, var(--brand-primary-soft) 100%)",
+                }}
+              />
+            )}
+            <div className="flex flex-1 flex-col gap-3 p-5">
+              <div>
+                <h2 className="text-lg font-medium text-[var(--brand-text)]">
+                  {name}
+                </h2>
+                {l.cuisine ? (
+                  <p className="mt-0.5 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
+                    {l.cuisine}
+                  </p>
+                ) : null}
+              </div>
+
+              <p className="text-sm leading-relaxed text-[var(--brand-text)]">
+                {description}
+              </p>
+
+              {l.hoursText ? (
+                <p className="inline-flex items-center gap-1.5 text-xs text-[var(--brand-text-muted)]">
+                  <Clock size={14} strokeWidth={1.75} />
+                  {l.hoursText}
+                </p>
+              ) : null}
+
+              <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
+                {firstAnchor ? (
+                  firstAnchor.refId ? (
+                    <Link
+                      href={`${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`}
+                      className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)] transition-opacity hover:opacity-80"
+                    >
+                      <MapPin size={14} strokeWidth={1.75} />
+                      {firstAnchor.refName}
+                    </Link>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-primary-bg)] px-3 py-1 text-xs font-medium text-[var(--brand-primary)]">
+                      <MapPin size={14} strokeWidth={1.75} />
+                      {firstAnchor.refName}
+                    </span>
+                  )
+                ) : null}
+                {l.menuUrl ? (
+                  <a
+                    href={l.menuUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--brand-line)] bg-white px-3 py-1 text-xs font-medium text-[var(--brand-text)] transition-colors hover:border-[var(--brand-primary)]"
+                  >
+                    <ExternalLink size={14} strokeWidth={1.75} />
+                    View menu
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/EventsListClient.tsx
+++ b/apps/campus/lib/consumer/EventsListClient.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { Calendar, Compass, MapPin } from "lucide-react";
+import { pickLocalized, type Locale } from "@/app/lib/i18n-core";
+import {
+  type EventPost,
+  formatEventWhen,
+} from "@/lib/events-db";
+import type { CampusEvent } from "@/lib/events";
+import { eventHasDetailPage, mergeEvents } from "@/lib/events-merge";
+import type { ConsumerEvent } from "@/lib/consumer/types";
+import { useCampusEvents } from "@/lib/swr/useCampusEvents";
+import { stripedBanner } from "@/lib/consumer/bannerPattern";
+import { EventsListSkeleton } from "./EventsListSkeleton";
+
+const BANNER_BG: Record<string, string> = {
+  purple: "var(--brand-primary-fill)",
+  coral: "var(--brand-accent-warm)",
+  teal: "var(--brand-accent-cool)",
+  pink: "var(--brand-accent-complement)",
+};
+
+interface Props {
+  token: string;
+  locale: Locale;
+  lang: string;
+  mapHref: string;
+  /** Server-rendered initial DB events — SWR seeds with this so
+   *  the first paint never shows a skeleton. */
+  initialDbEvents: EventPost[];
+  /** ICS-feed events fetched server-side once per request; the
+   *  client doesn't re-fetch them (they're slow + external). */
+  icsEvents: CampusEvent[];
+  /** Empty-state copy. */
+  emptyCopy: string;
+}
+
+/**
+ * Client renderer for the events list. SWR keeps the DB side of
+ * the merge fresh across navigations; ICS events come in as a
+ * static prop. The merged list is recomputed in a memo so a SWR
+ * revalidation only swaps the affected rows. First paint shows
+ * real content via `fallbackData`; the skeleton only renders on
+ * a genuinely cold cache (rare since SSR seeds it).
+ */
+export function EventsListClient({
+  token,
+  locale,
+  lang,
+  mapHref,
+  initialDbEvents,
+  icsEvents,
+  emptyCopy,
+}: Props) {
+  const { events: dbEvents, isLoading } = useCampusEvents(
+    token,
+    initialDbEvents,
+  );
+
+  const merged: ConsumerEvent[] = useMemo(() => {
+    const localised = dbEvents.map((e) => ({
+      ...e,
+      title: pickLocalized(e.title, e.titleEl, locale),
+      description: pickLocalized(e.description, e.descriptionEl, locale),
+    }));
+    return mergeEvents(localised, icsEvents, 100);
+  }, [dbEvents, icsEvents, locale]);
+
+  if (isLoading && merged.length === 0) {
+    return <EventsListSkeleton rows={6} />;
+  }
+
+  if (merged.length === 0) {
+    return (
+      <div className="mt-10 rounded-2xl border border-[var(--brand-line)] bg-white p-8 text-center text-sm text-[var(--brand-text-muted)]">
+        {emptyCopy}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+      {merged.map((e) => {
+        const firstAnchor = e.anchors[0];
+        const href = eventHasDetailPage(e.id)
+          ? `/campus/${token}/events/${e.id}${lang}`
+          : firstAnchor?.refId
+            ? `${mapHref}&space=${encodeURIComponent(firstAnchor.refId)}`
+            : mapHref;
+        const accent =
+          BANNER_BG[e.bannerColor] ?? "var(--brand-primary-fill)";
+        return (
+          <Link
+            key={e.id}
+            href={href}
+            className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
+          >
+            <div
+              className="flex h-20 items-end justify-start p-4"
+              style={stripedBanner(accent)}
+            >
+              <Calendar
+                size={24}
+                strokeWidth={1.5}
+                style={{ color: accent }}
+                aria-hidden
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-2 p-5">
+              <h2 className="text-base font-medium text-[var(--brand-text)]">
+                {e.title}
+              </h2>
+              <span className="text-xs text-[var(--brand-text-muted)]">
+                {formatEventWhen(e.startsAt)}
+              </span>
+              <p className="line-clamp-2 text-xs leading-relaxed text-[var(--brand-text-muted)]">
+                {e.blurb}
+              </p>
+              <div className="mt-auto flex flex-wrap items-center gap-2 pt-2 text-xs text-[var(--brand-text-muted)]">
+                {firstAnchor ? (
+                  <span className="inline-flex items-center gap-1">
+                    <MapPin size={14} strokeWidth={1.75} />
+                    {firstAnchor.refName}
+                  </span>
+                ) : null}
+                {firstAnchor?.refId ? (
+                  <span className="ml-auto inline-flex items-center gap-1 text-[var(--brand-primary)] group-hover:underline">
+                    <Compass size={14} strokeWidth={1.75} />
+                    Directions
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -9,12 +9,12 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development NEXT_TELEMETRY_DISABLED=1 next dev -p 3003",
-    "build": "pnpm db:deploy && next build",
+    "build": "next build",
     "start": "next start -p 3003",
     "lint": "next lint --fix --dir app",
-    "db:deploy": "prisma migrate deploy --schema ../../packages/prisma/schema.prisma",
-    "db:generate": "prisma generate --schema ../../packages/prisma/schema.prisma",
-    "db:migrate": "prisma migrate dev --schema ../../packages/prisma/schema.prisma"
+    "db:deploy": "pnpm --filter @klorad/prisma prisma migrate deploy",
+    "db:generate": "pnpm --filter @klorad/prisma generate",
+    "db:migrate": "pnpm --filter @klorad/prisma prisma migrate dev"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.98.0",


### PR DESCRIPTION
Follow-up to PR #169 (already merged). Two commits that were pushed to the same branch after the merge.

## What's in

### `fix(campus): drop prisma migrate from \`next build\`; let CI orchestrate`
The campus \`build\` script ran \`pnpm db:deploy\` ahead of \`next build\`. That worked locally because pnpm hoists \`prisma\` into \`node_modules/.bin\`, but Vercel's stricter install puts the CLI inside the \`@klorad/prisma\` workspace's bin only — so the deploy failed with \`prisma: command not found\`.

Fix:
- Drop \`pnpm db:deploy &&\` from the campus build script. Migrations are already run by \`vercel:build:campus\` (the root command Vercel invokes) before it shells into \`apps/campus && pnpm build\`.
- Rewrote \`db:deploy\` / \`db:generate\` / \`db:migrate\` to proxy to \`@klorad/prisma\` via \`pnpm --filter\` so manual local runs (\`pnpm -C apps/campus db:deploy\`) keep working under either pnpm install mode.

### \`feat(campus): migrate events / clubs / dining to hybrid SSR + SWR\`
Rolls the news pilot pattern (shipped in #169) out to the three remaining explore surfaces using the API routes + hooks + skeletons that landed alongside it.

| Surface | Client renderer | What it does |
|---|---|---|
| **Events** | \`EventsListClient\` | Takes initial DB events (SWR-seeded) + ICS events (static). Localises DB rows, then \`mergeEvents\` with ICS in a memo so a SWR revalidation only swaps the affected rows. Skeleton on cold cache. |
| **Clubs** | \`ClubsListClient\` | Straight SWR over the clubs response. Identical pattern, no merge complexity. |
| **Dining** | \`DiningListClient\` | Same shape, plus the gradient-image fallback inside the card. |

Server pages drop the inline JSX + local \`BANNER_BG\` / \`AVATAR_BG\` maps (now centralised inside the client renderers) and keep the SSR data fetch + ICS merge upstream of the client mount. First paint is real content via \`fallbackData\`; navigations within the SPA session pop straight from the SWR cache; backgrounds revalidate on focus / reconnect.

## Result

Every consumer list (news, events, clubs, dining) now feels native: navigate between tabs and data is instant from cache, with a background refetch on focus. The skeletons only render on a genuinely cold cache (rare since SSR seeds it on first paint).

## Testing

\`tsc --noEmit\` clean. \`next lint\` clean. \`pnpm audits:light\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)