### PR TITLE
feat(storage): one-shot CORS apply script for DigitalOcean Spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "audits:advisory": "pnpm --filter @klorad/dev-audits audits:advisory",
     "audits:light": "pnpm --filter @klorad/dev-audits audits:light",
     "prisma:generate": "pnpm --filter @klorad/prisma generate",
+    "spaces:set-cors": "node --env-file=apps/campus/.env.local --env-file-if-exists=apps/campus/.env --import tsx packages/storage/scripts/set-cors.ts",
     "prisma:migrate:dev": "./scripts/migrate.sh dev",
     "prisma:migrate:deploy": "./scripts/migrate.sh deploy",
     "vercel:build:editor": "pnpm prisma:generate && pnpm --filter @klorad/prisma prisma migrate deploy && pnpm clean && pnpm build:packages && cd apps/editor && pnpm build",

--- a/packages/storage/scripts/set-cors.ts
+++ b/packages/storage/scripts/set-cors.ts
@@ -1,0 +1,97 @@
+/**
+ * One-shot script to apply the CORS policy on a DigitalOcean Space
+ * so browsers can PUT directly to it from the campus dashboard.
+ *
+ * The presigned-URL upload flow signs a PUT request server-side and
+ * hands it to the browser, which then sends the PUT straight to
+ * `<bucket>.<region>.digitaloceanspaces.com`. DO Spaces will only
+ * include `Access-Control-Allow-Origin` on that response if the
+ * bucket has a CORS rule matching the request's `Origin` — without
+ * one, every upload fails with a CORS error in the console.
+ *
+ * Reads the same env vars `@klorad/storage` already needs:
+ *   DO_SPACES_REGION
+ *   DO_SPACES_ENDPOINT
+ *   DO_SPACES_BUCKET
+ *   DO_SPACES_KEY
+ *   DO_SPACES_SECRET
+ *
+ * Origins are read from `KLORAD_CORS_ORIGINS` (comma-separated), or
+ * default to the production + local dev hosts campus uses today.
+ *
+ * Usage from repo root, with the env vars exported or sourced from
+ * `apps/campus/.env`:
+ *
+ *   pnpm spaces:set-cors
+ *
+ * or with explicit origins:
+ *
+ *   KLORAD_CORS_ORIGINS="https://campus.klorad.com,http://localhost:3003" \
+ *     pnpm spaces:set-cors
+ *
+ * Idempotent — running it again replaces the existing CORS rules
+ * with whatever is in this script.
+ */
+
+import {
+  PutBucketCorsCommand,
+  S3Client,
+  type CORSRule,
+} from "@aws-sdk/client-s3";
+import { storageConfigFromEnv } from "../src/server";
+
+const DEFAULT_ORIGINS = [
+  "https://campus.klorad.com",
+  "http://localhost:3003",
+];
+
+function parseOrigins(): string[] {
+  const raw = process.env.KLORAD_CORS_ORIGINS;
+  if (!raw) return DEFAULT_ORIGINS;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+async function main() {
+  const cfg = storageConfigFromEnv();
+  const origins = parseOrigins();
+  const client = new S3Client({
+    region: cfg.region,
+    endpoint: cfg.endpoint,
+    credentials: {
+      accessKeyId: cfg.accessKeyId,
+      secretAccessKey: cfg.secretAccessKey,
+    },
+  });
+
+  // One rule is enough — Spaces supports up to 100, but we only
+  // need PUT/GET/HEAD for the browser direct-upload flow. The
+  // wildcard `AllowedHeaders` covers every `x-amz-*` header the
+  // AWS SDK adds (checksums, ACL, signed-headers list).
+  const rule: CORSRule = {
+    AllowedOrigins: origins,
+    AllowedMethods: ["PUT", "GET", "HEAD"],
+    AllowedHeaders: ["*"],
+    ExposeHeaders: ["ETag"],
+    MaxAgeSeconds: 3000,
+  };
+
+  await client.send(
+    new PutBucketCorsCommand({
+      Bucket: cfg.bucket,
+      CORSConfiguration: { CORSRules: [rule] },
+    }),
+  );
+
+  console.log(
+    `✅ CORS applied to s3://${cfg.bucket} for origins: ${origins.join(", ")}`,
+  );
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`❌ Failed to set CORS: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## The bug

Hero / logo / thumbnail uploads from the campus dashboard are failing in production with:

\`\`\`
Access to XMLHttpRequest at 'https://prieston-prod.fra1.digitaloceanspaces.com/...'
from origin 'https://campus.klorad.com' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
\`\`\`

\`@klorad/storage\` hands the browser a presigned PUT URL; the browser then uploads *directly* to \`<bucket>.<region>.digitaloceanspaces.com\`. DO Spaces only adds \`Access-Control-Allow-Origin\` on that response if the bucket has a CORS rule matching the request's \`Origin\`. We never set one — so every direct upload fails.

## The fix

A reusable script + pnpm command:

- **\`packages/storage/scripts/set-cors.ts\`** — reads the same env vars \`storageConfigFromEnv\` already needs (\`DO_SPACES_*\`), then sends a single \`PutBucketCorsCommand\`. The rule allows \`PUT / GET / HEAD\` from the configured origins, \`AllowedHeaders: ['*']\` (covers every \`x-amz-*\` header the AWS SDK adds — checksums, ACL, signed-headers list), exposes \`ETag\`. Idempotent: re-running replaces the rules in place.
- **\`pnpm spaces:set-cors\`** at the root — invokes the script with \`apps/campus/.env.local\` + \`apps/campus/.env\` auto-loaded via Node 20+'s native \`--env-file\` flag. No extra deps.

Default origins:
\`\`\`
https://campus.klorad.com
http://localhost:3003
\`\`\`

Override with \`KLORAD_CORS_ORIGINS=\"https://a.com,https://b.com\"\` for staging or per-tenant custom domains.

## Already run

The script has been applied to the \`prieston-prod\` bucket against both default origins — production uploads should work the moment this is merged (the script change itself doesn't gate the fix; the bucket is already correct).

The PR adds the tooling so the fix is reproducible: a fresh staging Space, a new region, or a CORS reset all need is one \`pnpm spaces:set-cors\` away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)