### PR TITLE
feat(campus): PWA shell — installable per-tenant + offline + caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ storybook-static/
 **/public/workbox-*.js
 **/public/sw.js.map
 **/public/workbox-*.js.map
+# Campus's sw.js is hand-rolled (push delivery + PWA caching), not
+# generated — keep it tracked.
+!apps/campus/public/sw.js

--- a/apps/campus/app/(public)/campus/[token]/layout.tsx
+++ b/apps/campus/app/(public)/campus/[token]/layout.tsx
@@ -1,10 +1,63 @@
 import type { ReactNode } from "react";
+import type { Metadata, Viewport } from "next";
 import { getPublicCampusByToken } from "@/lib/public-campus";
 import { CampusBottomNav } from "@/lib/consumer/CampusBottomNav";
 import { deriveCampusPalette, paletteToCssVars } from "@/lib/palette";
 import { SWRProvider } from "@/lib/swr/SWRProvider";
+import { ServiceWorkerRegistrar } from "@/lib/consumer/ServiceWorkerRegistrar";
+import { InstallPrompt } from "@/lib/consumer/InstallPrompt";
 
 type Params = Promise<{ token: string }>;
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+/**
+ * Per-tenant `<head>` metadata — point each campus at its own
+ * `manifest.webmanifest` route so the install prompt picks up the
+ * campus's name, icon, and theme colour.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  return {
+    manifest: `/campus/${token}/manifest.webmanifest`,
+    appleWebApp: {
+      capable: true,
+      statusBarStyle: "default",
+      title: map?.title ?? "Campus",
+    },
+  };
+}
+
+/**
+ * Per-tenant viewport — `themeColor` tints the mobile browser
+ * chrome (status bar / address bar) so the campus's brand reaches
+ * past the page boundary. In Next 15 this lives on `viewport`,
+ * not `metadata`.
+ */
+export async function generateViewport({
+  params,
+}: {
+  params: Params;
+}): Promise<Viewport> {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  const scene = (map?.sceneData ?? null) as {
+    branding?: { primaryColor?: string };
+  } | null;
+  const themeColor = isValidHex(scene?.branding?.primaryColor)
+    ? scene!.branding!.primaryColor!
+    : "#534ab7";
+  return {
+    themeColor,
+  };
+}
 
 /**
  * Shared layout for every `/campus/[token]` route — mounts the
@@ -18,6 +71,12 @@ type Params = Promise<{ token: string }>;
  * per-tenant accent colour up here. That gives **both** the page
  * content and the bottom nav the same `--brand-primary`, so the
  * active pill stays on-brand for every campus.
+ *
+ * PWA wiring lives here too — `ServiceWorkerRegistrar` installs
+ * `/sw.js` on the first visit, and `InstallPrompt` surfaces the
+ * native install card when the browser fires `beforeinstallprompt`.
+ * Both are no-ops on desktop / unsupported browsers, so there's no
+ * cost when they can't help.
  */
 export default async function CampusPublicLayout({
   children,
@@ -44,6 +103,8 @@ export default async function CampusPublicLayout({
       <div style={themeStyle}>
         {children}
         <CampusBottomNav token={token} />
+        <InstallPrompt />
+        <ServiceWorkerRegistrar />
       </div>
     </SWRProvider>
   );

--- a/apps/campus/app/(public)/campus/[token]/manifest.webmanifest/route.ts
+++ b/apps/campus/app/(public)/campus/[token]/manifest.webmanifest/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { getPublicCampusByToken } from "@/lib/public-campus";
+
+type Params = Promise<{ token: string }>;
+
+interface CampusBranding {
+  name?: string;
+  logo?: string;
+  primaryColor?: string;
+}
+
+function isValidHex(value: string | undefined): value is string {
+  return !!value && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max - 1).trimEnd() + "…";
+}
+
+/**
+ * Per-tenant Web App Manifest. Each `/campus/[token]` route gets its
+ * own manifest URL so the install prompt picks up the campus's
+ * branding (name + theme colour + logo), the home screen icon points
+ * back at *that* campus, and the standalone start URL drops the
+ * visitor on the campus's home — not Klorad's.
+ *
+ * Anonymous public lookup — same cached call the home page makes —
+ * so this route doesn't add a DB hit per install. The 404 fall
+ * through means an unknown token won't pollute the cache with a
+ * generic manifest.
+ *
+ * `scope` is set to the campus subtree so the SW only intercepts
+ * navigations inside that tenant; jumping to another tenant exits
+ * the installed app surface.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+) {
+  const { token } = await params;
+  const map = await getPublicCampusByToken(token);
+  if (!map) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const branding = scene.branding ?? {};
+  const name = branding.name || map.title || "Campus";
+  const themeColor = isValidHex(branding.primaryColor)
+    ? branding.primaryColor
+    : "#534ab7";
+
+  // Browsers want at least one 192×192-or-larger icon for the install
+  // prompt. The campus logo (if uploaded) is usually a good fit; we
+  // declare `sizes: "any"` so the browser doesn't second-guess us
+  // when the upload isn't a perfect square. Always include the Klorad
+  // favicon (302×302) as a fallback so installability holds even
+  // before the rector uploads a logo.
+  const icons: Array<{
+    src: string;
+    sizes: string;
+    type?: string;
+    purpose?: string;
+  }> = [];
+  if (branding.logo) {
+    icons.push({
+      src: branding.logo,
+      sizes: "any",
+      purpose: "any",
+    });
+  }
+  icons.push({
+    src: "/klorad-favicon.png",
+    sizes: "302x302",
+    type: "image/png",
+    purpose: "any",
+  });
+
+  const manifest = {
+    name,
+    short_name: truncate(name, 12),
+    description: map.description || `${name} — campus map and life`,
+    start_url: `/campus/${token}`,
+    scope: `/campus/${token}/`,
+    display: "standalone",
+    orientation: "portrait",
+    theme_color: themeColor,
+    background_color: "#ffffff",
+    icons,
+    lang: "en",
+    categories: ["education", "navigation", "utilities"],
+  };
+
+  return NextResponse.json(manifest, {
+    headers: {
+      "Content-Type": "application/manifest+json; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/apps/campus/app/offline/page.tsx
+++ b/apps/campus/app/offline/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Offline",
+  description: "You're offline — reconnect to continue.",
+  robots: { index: false, follow: false },
+};
+
+// Static at build time. The SW caches the resulting HTML at install
+// and serves it when a navigation fails. No per-request data.
+export const dynamic = "force-static";
+
+/**
+ * Offline fallback served by the SW when a campus navigation can't
+ * reach the network and isn't already cached. Kept brand-neutral on
+ * purpose — the SW caches one copy at install, before it knows which
+ * tenant's `/campus/[token]` the visitor will later open, so
+ * per-tenant branding isn't available here.
+ *
+ * Auto-recovers: the inline script reloads when `online` fires, so
+ * the visitor lands back on the page they wanted without thinking
+ * about which URL it was.
+ */
+export default function OfflinePage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+        background: "#f7f7f8",
+        color: "#1a1a1a",
+        fontFamily:
+          "Inter, ui-sans-serif, system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <main
+        style={{
+          maxWidth: 420,
+          textAlign: "center",
+          background: "#fff",
+          borderRadius: 16,
+          padding: "32px 28px",
+          boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+        }}
+      >
+        <div
+          aria-hidden
+          style={{
+            width: 56,
+            height: 56,
+            margin: "0 auto 16px",
+            borderRadius: "50%",
+            background: "#eef0f6",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 28,
+          }}
+        >
+          ⚡
+        </div>
+        <h1 style={{ fontSize: 20, fontWeight: 600, margin: "0 0 8px" }}>
+          You&rsquo;re offline
+        </h1>
+        <p
+          style={{
+            fontSize: 14,
+            lineHeight: 1.5,
+            color: "#6b6b6b",
+            margin: "0 0 20px",
+          }}
+        >
+          We&rsquo;ll reload as soon as you&rsquo;re back. You can also try
+          again now.
+        </p>
+        <button
+          type="button"
+          id="offline-retry"
+          style={{
+            display: "inline-block",
+            padding: "10px 18px",
+            borderRadius: 999,
+            background: "#1a1a1a",
+            color: "#fff",
+            fontSize: 14,
+            fontWeight: 500,
+            border: "none",
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          Try again
+        </button>
+      </main>
+      <script
+        dangerouslySetInnerHTML={{
+          __html:
+            "addEventListener('online',function(){location.reload()});" +
+            "var b=document.getElementById('offline-retry');" +
+            "if(b)b.addEventListener('click',function(){location.reload()});",
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/InstallPrompt.tsx
+++ b/apps/campus/lib/consumer/InstallPrompt.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Download, X } from "lucide-react";
+
+const DISMISS_KEY = "klorad-campus-install-dismissed-at";
+// How long to suppress the prompt after the visitor dismisses it.
+// One install card is enough — we don't want to nag people back into
+// the conversion path on every visit.
+const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
+/**
+ * The `beforeinstallprompt` event Chromium fires when the page meets
+ * PWA install criteria. The platform's type defs don't include it,
+ * so we model it here. `prompt()` returns when the visitor picks
+ * an option in the native sheet; `userChoice` resolves to the
+ * outcome.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+/**
+ * Floating "Install app" card that surfaces when the browser tells
+ * us the site is installable. Renders nothing until then — no
+ * placeholder, no layout reservation — so non-PWA browsers never see
+ * it. Once shown, dismissing it hides the card for 14 days; an
+ * accepted install hides it permanently for that browser.
+ *
+ * Sits above the bottom nav (`bottom-20`) on mobile so it doesn't
+ * cover the four primary tabs.
+ */
+export function InstallPrompt() {
+  const [event, setEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = localStorage.getItem(DISMISS_KEY);
+      if (raw) {
+        const ts = Number.parseInt(raw, 10);
+        if (Number.isFinite(ts) && Date.now() - ts < DISMISS_TTL_MS) {
+          return;
+        }
+      }
+    } catch {
+      // Private mode / storage disabled — fall through and show the
+      // prompt anyway. The browser still respects the install state.
+    }
+
+    const onBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      setEvent(e as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+    const onInstalled = () => {
+      setEvent(null);
+      setVisible(false);
+      try {
+        localStorage.setItem(DISMISS_KEY, String(Date.now()));
+      } catch {
+        // Storage failures are non-fatal — the browser tracks the
+        // installed state itself, so the prompt won't re-fire.
+      }
+    };
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    window.addEventListener("appinstalled", onInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  if (!visible || !event) return null;
+
+  const install = async () => {
+    try {
+      await event.prompt();
+      await event.userChoice;
+    } finally {
+      setEvent(null);
+      setVisible(false);
+    }
+  };
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    } catch {
+      // See above — storage failures are non-fatal.
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Install this campus app"
+      className="fixed inset-x-3 bottom-20 z-40 mx-auto flex max-w-sm items-center gap-3 rounded-2xl border border-[var(--brand-line,#e6e6ea)] bg-white px-4 py-3 shadow-lg md:bottom-4 md:left-auto md:right-4"
+    >
+      <div
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+        style={{ background: "var(--brand-primary-bg, #f1eef9)" }}
+        aria-hidden
+      >
+        <Download
+          size={18}
+          strokeWidth={1.75}
+          style={{ color: "var(--brand-primary, #534ab7)" }}
+        />
+      </div>
+      <div className="flex-1 text-sm">
+        <p className="font-medium text-[var(--brand-text,#1a1a1a)]">
+          Install this campus
+        </p>
+        <p className="text-xs text-[var(--brand-text-muted,#6b6b6b)]">
+          Add to your home screen — opens like a native app.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={install}
+        className="rounded-full px-3 py-1.5 text-xs font-medium text-white"
+        style={{ background: "var(--brand-primary, #534ab7)" }}
+      >
+        Install
+      </button>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        className="rounded-full p-1 text-[var(--brand-text-muted,#6b6b6b)] hover:bg-[var(--brand-primary-bg,#f1eef9)]"
+      >
+        <X size={16} strokeWidth={1.75} />
+      </button>
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/ServiceWorkerRegistrar.tsx
+++ b/apps/campus/lib/consumer/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers `/sw.js` on every campus public page so the visitor's
+ * very first navigation installs the PWA shell — offline fallback,
+ * route caching, push delivery — without waiting for a
+ * "Get notifications" tap.
+ *
+ * Renders nothing. Idempotent: the browser dedupes registrations by
+ * scope, so re-registering on each page mount is a cheap no-op.
+ * Skipped in development and on browsers without service workers.
+ */
+export function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+    // Next swaps modules around during HMR; the SW would steal the
+    // page out from under it. Only register on real loads.
+    if (process.env.NODE_ENV !== "production") return;
+    navigator.serviceWorker.register("/sw.js").catch(() => {
+      // Registration failures are non-fatal — the app still works,
+      // it just won't be installable / offline-capable for this
+      // visit. Browsers log the actual cause to the console for us.
+    });
+  }, []);
+
+  return null;
+}

--- a/apps/campus/public/sw.js
+++ b/apps/campus/public/sw.js
@@ -1,0 +1,194 @@
+/* eslint-disable no-restricted-globals */
+/**
+ * Campus service worker — web-push delivery + PWA offline shell.
+ *
+ * Two responsibilities:
+ *
+ * 1. **Push notifications** (original responsibility): receives push
+ *    events, surfaces them, focuses or opens the right tab on click.
+ *
+ * 2. **PWA caching** (added with the PWA shell arc): caches the
+ *    offline fallback at install, then services fetches with
+ *    strategies tuned per route family:
+ *
+ *      - `/_next/static/...`            — cache-first, immutable
+ *      - `/api/campus/.../{news,...}`   — stale-while-revalidate
+ *      - `/campus/*` navigations        — network-first, fall back
+ *                                          to cache, then to the
+ *                                          `/offline` shell
+ *      - everything else                — passthrough
+ *
+ * Registered once from `ServiceWorkerRegistrar` mounted in the
+ * campus public layout, so it's installed on the visitor's first
+ * page view (no `Get notifications` tap required).
+ *
+ * Cache key versioning: bump `CACHE_VERSION` on any breaking change
+ * to the strategies below. `activate` sweeps caches whose names
+ * don't start with the current version prefix.
+ */
+
+const CACHE_VERSION = "v1";
+const CACHE_STATIC = `klorad-campus-${CACHE_VERSION}-static`;
+const CACHE_PAGES = `klorad-campus-${CACHE_VERSION}-pages`;
+const CACHE_DATA = `klorad-campus-${CACHE_VERSION}-data`;
+const OFFLINE_URL = "/offline";
+
+// Pages worth precaching so the very first offline visit has
+// *something* to show. The offline shell is mandatory; everything
+// else is best-effort (a single failed fetch must not abort install).
+const PRECACHE_URLS = [OFFLINE_URL];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE_PAGES);
+      await Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache
+            .add(new Request(url, { cache: "reload" }))
+            .catch(() => undefined),
+        ),
+      );
+      // Take control immediately so the first notification doesn't
+      // wait for a reload (kept from the original push-only SW).
+      await self.skipWaiting();
+    })(),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      const prefix = `klorad-campus-${CACHE_VERSION}-`;
+      await Promise.all(
+        keys
+          .filter((k) => k.startsWith("klorad-campus-") && !k.startsWith(prefix))
+          .map((k) => caches.delete(k)),
+      );
+      await self.clients.claim();
+    })(),
+  );
+});
+
+/**
+ * Cache-first: serve from cache when present, otherwise fetch, cache
+ * the response, and return it. Used for immutable hashed assets.
+ */
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  if (response.ok) cache.put(request, response.clone());
+  return response;
+}
+
+/**
+ * Stale-while-revalidate: return the cached copy immediately (if
+ * any), kick off a background fetch to refresh the cache. Used for
+ * the SWR API JSON endpoints — the browser's own SWR keeps the UI
+ * fresh; we just shave another round-trip off cold visits.
+ */
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  const network = fetch(request)
+    .then((response) => {
+      if (response.ok) cache.put(request, response.clone());
+      return response;
+    })
+    .catch(() => null);
+  return cached || (await network) || Response.error();
+}
+
+/**
+ * Network-first for navigations: try the network, cache the success,
+ * fall back to a cached copy, fall back to the offline shell. The
+ * shell renders something useful (campus branding + "you're offline"
+ * copy) instead of the browser's default offline page.
+ */
+async function networkFirstPage(request) {
+  const cache = await caches.open(CACHE_PAGES);
+  try {
+    const response = await fetch(request);
+    if (response.ok) cache.put(request, response.clone());
+    return response;
+  } catch {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    const offline = await cache.match(OFFLINE_URL);
+    if (offline) return offline;
+    return Response.error();
+  }
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+
+  // Same-origin only — we never want to intercept third-party
+  // requests (DO Spaces uploads, MappedIn tiles, fonts CDN, …).
+  if (url.origin !== self.location.origin) return;
+
+  // Hashed Next assets — content-addressed, safe to cache forever.
+  if (url.pathname.startsWith("/_next/static/")) {
+    event.respondWith(cacheFirst(request, CACHE_STATIC));
+    return;
+  }
+
+  // Public consumer API: news / events / clubs / dining JSON.
+  if (/^\/api\/campus\/[^/]+\/(news|events|clubs|dining)/.test(url.pathname)) {
+    event.respondWith(staleWhileRevalidate(request, CACHE_DATA));
+    return;
+  }
+
+  // Navigation requests (full document loads) inside the consumer
+  // surface. Anything else is left to the network — we don't want
+  // to silently cache admin API calls, auth round-trips, etc.
+  if (
+    request.mode === "navigate" &&
+    (url.pathname === "/offline" || url.pathname.startsWith("/campus/"))
+  ) {
+    event.respondWith(networkFirstPage(request));
+    return;
+  }
+});
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+  let payload = {};
+  try {
+    payload = event.data.json();
+  } catch (err) {
+    payload = { title: "Campus update", body: event.data.text() };
+  }
+  const title = payload.title || "Campus update";
+  const options = {
+    body: payload.body || "",
+    icon: payload.icon || "/favicon.ico",
+    badge: payload.icon || "/favicon.ico",
+    data: { url: payload.url || "/" },
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || "/";
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientsArr) => {
+        // Focus an open tab on the target if one exists.
+        for (const client of clientsArr) {
+          if (client.url.includes(target) && "focus" in client) {
+            return client.focus();
+          }
+        }
+        return self.clients.openWindow(target);
+      }),
+  );
+});


### PR DESCRIPTION
Every \`/campus/[token]\` is now a real PWA. Visitors can install any campus to their home screen, and the worker keeps the app usable when the network drops — without pulling in next-pwa / Serwist or rewriting the existing push handler.

## What ships

**\`public/sw.js\`** — the existing 58-line push worker extended with PWA caching. Three caches keyed by \`CACHE_VERSION\` (swept on activate):

| cache | strategy | used for |
|---|---|---|
| \`...-v1-static\` | cache-first | \`/_next/static/*\` — content-addressed, safe forever |
| \`...-v1-pages\` | network-first → cache → \`/offline\` | \`/campus/*\` navigations |
| \`...-v1-data\` | stale-while-revalidate | \`/api/campus/.../{news,events,clubs,dining}\` |

Same-origin only — never intercepts DO Spaces uploads, MappedIn tiles, or fonts CDN. Push handlers (\`push\`, \`notificationclick\`) unchanged so the existing notification flow keeps working.

**Per-tenant manifest** — \`app/(public)/campus/[token]/manifest.webmanifest/route.ts\`. Each campus gets its own URL so the install card shows that campus's name + colour + logo, and \`scope\` pins the installed app to that tenant's subtree.

**Layout wiring** — \`generateMetadata\` injects the manifest + apple-web-app meta; \`generateViewport\` (Next 15 split it from metadata) injects \`theme_color\` so the mobile browser chrome picks up the rector's primary colour.

**\`ServiceWorkerRegistrar\`** — registers \`/sw.js\` on first paint in production. Skipped in dev so HMR isn't sniped.

**\`InstallPrompt\`** — floating card on \`beforeinstallprompt\`, brand-coloured, 14-day dismiss TTL, hides on \`appinstalled\`. Renders nothing on non-PWA browsers.

**\`/offline\`** — brand-neutral fallback (cached once at install, before the SW knows which tenant). Auto-reloads on \`online\`. \"Try again\" reloads the original URL.

**\`.gitignore\`** — exception added for \`apps/campus/public/sw.js\`. The blanket rule above it targets next-pwa output; ours is hand-rolled.

## Build verification

\`\`\`
├ ƒ /campus/[token]/manifest.webmanifest    220 B         102 kB
├ ○ /offline                                220 B         102 kB
\`\`\`

Routes resolve, full campus build is green.

## Why hand-rolled, not Serwist

The campus already had a hand-written \`sw.js\` for push delivery. Serwist would have meant a build-time precache pipeline, an \`app/sw.ts\` source, \`next.config.mjs\` wrapping, and rewriting the push handler in serwist conventions. A 110-line file with three explicit fetch handlers is easier to reason about and reverse than that, and the install prompt + manifest + offline page work the same either way.

## Test plan

- [ ] Visit a published campus on mobile Chrome → install card appears within a few seconds
- [ ] Install → home-screen icon uses the campus's logo, opens standalone
- [ ] DevTools → Application → Manifest shows per-tenant name + colour
- [ ] Toggle DevTools offline → reload → \`/offline\` shell appears, \"Try again\" reloads when network returns
- [ ] News / events / clubs / dining JSON endpoints visible in Cache Storage after one visit
- [ ] Push notification still delivers (regression check on the original SW responsibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)