### PR TITLE
feat(campus): a11y polish on the public surface

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
@@ -88,7 +88,7 @@ export default async function ClubDetailPage({
   );
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}
@@ -110,7 +110,7 @@ export default async function ClubDetailPage({
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={club.imageUrl}
-              alt=""
+              alt={name}
               className="h-16 w-16 rounded-2xl object-cover"
             />
           ) : (

--- a/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
@@ -72,7 +72,7 @@ export default async function ClubsPage({
   const clubs = await listTopClubsForProject(map.id, 50);
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/dining/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/dining/page.tsx
@@ -73,7 +73,7 @@ export default async function DiningPage({
   const locations = await listDiningForProject(map.id);
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
@@ -115,7 +115,7 @@ export default async function EventDetailPage({
   });
 
   return (
-    <main data-consumer lang={locale}>
+    <main id="main" data-consumer lang={locale}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/events/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/page.tsx
@@ -91,7 +91,7 @@ export default async function EventsPage({
   ]);
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/klio/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/klio/page.tsx
@@ -69,7 +69,7 @@ export default async function KlioPage({
   const lang = `?lang=${locale}`;
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/layout.tsx
+++ b/apps/campus/app/(public)/campus/[token]/layout.tsx
@@ -42,6 +42,16 @@ export default async function CampusPublicLayout({
   return (
     <SWRProvider>
       <div style={themeStyle}>
+        {/* Skip link — first focusable element so a Tab from the URL
+            bar jumps straight to the page content, past the nav. Each
+            page renders `<main id="main">` so the target always
+            exists. Hidden visually until focused. */}
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-50 focus:rounded-md focus:bg-[var(--brand-primary,#534ab7)] focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
+        >
+          Skip to content
+        </a>
         {children}
         <CampusBottomNav token={token} />
       </div>

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -56,6 +56,7 @@ export default async function CampusMapPage({
     const lang = `?lang=${locale}`;
     return (
       <main
+        id="main"
         data-mappedin
         lang={locale}
         className="flex h-[100dvh] w-full flex-col"

--- a/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
@@ -92,7 +92,7 @@ export default async function NewsDetailPage({
   const shareUrl = `/campus/${token}/news/${id}${lang}`;
 
   return (
-    <main data-consumer lang={locale}>
+    <main id="main" data-consumer lang={locale}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/news/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/page.tsx
@@ -102,7 +102,7 @@ export default async function NewsPage({
   }));
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={branding.logo}

--- a/apps/campus/app/(public)/campus/[token]/not-found.tsx
+++ b/apps/campus/app/(public)/campus/[token]/not-found.tsx
@@ -8,7 +8,7 @@ import { KloradMark } from "@klorad/design-system";
  */
 export default function CampusNotFound() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center">
+    <main id="main" className="flex min-h-screen flex-col items-center justify-center bg-bg px-6 py-16 text-center">
       <KloradMark className="h-10 w-10" />
       <h1 className="mt-6 text-2xl font-semibold tracking-tight text-text-primary">
         Campus not found

--- a/apps/campus/lib/consumer/ClubsListClient.tsx
+++ b/apps/campus/lib/consumer/ClubsListClient.tsx
@@ -68,7 +68,7 @@ export function ClubsListClient({
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={c.imageUrl}
-                  alt=""
+                  alt={name}
                   className="h-12 w-12 rounded-xl object-cover"
                 />
               ) : (

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -135,7 +135,7 @@ export function ConsumerHome({
     : undefined;
 
   return (
-    <main data-consumer lang={locale} style={themeStyle}>
+    <main id="main" data-consumer lang={locale} style={themeStyle}>
       <ConsumerNav
         campusName={campusName}
         logoUrl={logoUrl}

--- a/apps/campus/lib/consumer/DiningListClient.tsx
+++ b/apps/campus/lib/consumer/DiningListClient.tsx
@@ -59,7 +59,7 @@ export function DiningListClient({
               // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={l.imageUrl}
-                alt=""
+                alt={name}
                 className="block aspect-[16/9] w-full object-cover"
               />
             ) : (

--- a/apps/campus/lib/consumer/KlioPanel.tsx
+++ b/apps/campus/lib/consumer/KlioPanel.tsx
@@ -231,7 +231,7 @@ export function KlioPanel({ mapId, campusName, locale, mapHref }: KlioPanelProps
             onKeyDown={onKeyDown}
             placeholder={copy.placeholder}
             disabled={sending}
-            className="min-w-0 flex-1 bg-transparent text-sm text-[var(--brand-text)] outline-none placeholder:text-[var(--brand-text-muted)] disabled:opacity-60"
+            className="min-w-0 flex-1 bg-transparent text-sm text-[var(--brand-text)] outline-none placeholder:text-[var(--brand-text-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-primary)] disabled:opacity-60"
           />
           <button
             type="button"

--- a/apps/campus/lib/consumer/RouteEndpointPicker.tsx
+++ b/apps/campus/lib/consumer/RouteEndpointPicker.tsx
@@ -158,7 +158,7 @@ export function RouteEndpointPicker({
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder={copy.search}
-                  className="min-w-0 flex-1 bg-transparent text-sm text-[var(--brand-text)] outline-none placeholder:text-[var(--brand-text-muted)]"
+                  className="min-w-0 flex-1 bg-transparent text-sm text-[var(--brand-text)] outline-none placeholder:text-[var(--brand-text-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-primary)]"
                 />
                 {query ? (
                   <button


### PR DESCRIPTION
Audit pass on every \`/campus/[token]\` route. Five real findings, all fixed. No behavioural change — purely accessibility.

## What changed

**Skip-to-content link**
Added as the first focusable element of the shared public layout. Hidden visually until a Tab from the URL bar lands on it; then a brand-coloured pill appears top-left. Each \`<main>\` on the public surface (12 of them — home, map, explore subpages, detail pages, klio, 404, ConsumerHome) now carries \`id=\"main\"\` so the target always exists regardless of route.

**Image alts**
Three \`<img alt=\"\">\` on user-facing content images replaced with the entity name they depict:
- \`ClubsListClient\` — club avatar
- \`DiningListClient\` — dining location hero
- \`clubs/[id]\` detail — club avatar

These aren't decorative — a screen reader skipping them loses the only identifier the row has when the surrounding text is truncated.

**Focus rings on text inputs**
Two inputs (\`KlioPanel\` send box, \`RouteEndpointPicker\` search) used \`outline-none\` with no visible \`:focus-visible\` fallback. Added a 2px brand-coloured ring at offset 2 so keyboard users see where focus is.

## False positives I checked and skipped

The auditor flagged a few non-issues that I verified by hand and chose not to touch:

- \`<header>\` in \`ConsumerNav\` already implies banner role per HTML5; adding \`role=\"banner\"\` is redundant noise.
- \`KlioPanel\` send button already has \`aria-label=\"Send\"\`.
- \`BuildingsList\`'s outer \`<div>\` is a styled container with two real \`<button>\` children, not a click target.
- \`SegmentedTabs\` is already \`<nav aria-label=\"Explore\">\` with \`aria-current=\"page\"\` on the active tab.
- The \`h1=\"Explore\"\` pattern across news / events / clubs / dining is intentional — the \`SegmentedTabs\` below disambiguate the section, the bottom-nav tab matches, and changing the h1 per sub-page would break the visual mental model.

## Out of scope for this PR

- **Lighthouse audit on a published tenant** — would be valuable but needs a real campus URL to be meaningful; we can run it as part of the merge-time smoke check.
- **Contrast risks on \`--brand-text-muted\` with light brand primaries** — depends per tenant. Worth a follow-up that clamps muted text to a minimum contrast in the palette helper when the primary is bright.

## Test plan

- [ ] Tab from URL bar → \"Skip to content\" pill appears top-left, focuses ring visible, Enter jumps focus past the nav into \`<main>\`
- [ ] Keyboard-tab into the Klio composer and the route search — focus ring is visible
- [ ] Screen reader (VoiceOver) lands on Clubs / Dining cards → reads the entity name from the avatar/hero alt
- [ ] Build still green: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)