### PR TITLE
feat(campus): backoffice shell — Phase 1 of redesign

### DIFF
--- a/apps/campus/app/(dashboard)/components/ComingSoonScreen.tsx
+++ b/apps/campus/app/(dashboard)/components/ComingSoonScreen.tsx
@@ -1,0 +1,41 @@
+import { Sparkles } from "lucide-react";
+
+interface Props {
+  /** Big title — matches the rail item that points here. */
+  title: string;
+  /** One-line description of what this surface will eventually own. */
+  hint: string;
+  /** Phase label so the visitor can place it on the roadmap ("Phase 4"). */
+  phase: string;
+}
+
+/**
+ * Stub renderer for the IA's new screens — Home / Map / Klio / Reach /
+ * Identity. The shell ships in Phase 1 of [[campus-backoffice-redesign]],
+ * but the real screens land in later phases. Showing an honest "this
+ * surface exists, it just isn't built yet" placeholder is better than
+ * dead links that confuse the rector and break trust in the nav.
+ */
+export function ComingSoonScreen({ title, hint, phase }: Props) {
+  return (
+    <div className="flex min-h-full items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md rounded-2xl border border-line-soft bg-surface-1 p-8 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-accent-soft">
+          <Sparkles
+            size={20}
+            strokeWidth={1.6}
+            className="text-accent"
+            aria-hidden
+          />
+        </div>
+        <h1 className="mt-4 text-xl font-semibold text-text-primary">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm text-text-secondary">{hint}</p>
+        <p className="mt-4 text-[11px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          {phase}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -4,24 +4,65 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
-import { AppShell, KloradMark, type NavItem } from "@klorad/design-system";
 import {
-  OrganizationSwitcher,
-  UserAccountMenu,
-  DashboardIcon,
-  MapIcon,
-  SettingsIcon,
-  useThemeMode,
-} from "@klorad/ui";
+  AppShell,
+  KloradMark,
+  type NavGroup,
+} from "@klorad/design-system";
+import { OrganizationSwitcher, UserAccountMenu } from "@klorad/ui";
+import {
+  Building2,
+  Calendar,
+  ChevronLeft,
+  Compass,
+  Globe2,
+  Home,
+  LayoutDashboard,
+  Megaphone,
+  Moon,
+  Newspaper,
+  Settings,
+  Sparkles,
+  Sun,
+  Users,
+  Utensils,
+} from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
 import { useOrganization, useOrganizations } from "@/app/hooks/useOrganizations";
+import { useMaps } from "@/app/hooks/useMaps";
 
-/** Light/dark toggle, driven by @klorad/ui's ThemeModeProvider. */
+/**
+ * Light/dark toggle, hand-rolled (no MUI). Reads/writes `klorad-theme` in
+ * localStorage, mirrors the class onto `<html>` so Tailwind's `dark:`
+ * variants flip together with the design-system tokens. Hydration
+ * guarded so the icon doesn't flash the wrong state.
+ */
 function ThemeToggleButton() {
-  const { mode, toggle } = useThemeMode();
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  const isDark = mode === "dark";
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    try {
+      const dark =
+        document.documentElement.classList.contains("dark") ||
+        localStorage.getItem("klorad-theme") === "dark";
+      setIsDark(dark);
+    } catch {
+      // Private mode / storage disabled — leave default.
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    try {
+      document.documentElement.classList.toggle("dark", next);
+      localStorage.setItem("klorad-theme", next ? "dark" : "light");
+    } catch {
+      // See above.
+    }
+  };
 
   return (
     <button
@@ -32,34 +73,9 @@ function ThemeToggleButton() {
     >
       {mounted ? (
         isDark ? (
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.7"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden
-          >
-            <circle cx="12" cy="12" r="4" />
-            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-          </svg>
+          <Sun size={16} strokeWidth={1.7} aria-hidden />
         ) : (
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.7"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden
-          >
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
-          </svg>
+          <Moon size={16} strokeWidth={1.7} aria-hidden />
         )
       ) : (
         <span className="block h-4 w-4" />
@@ -68,45 +84,208 @@ function ThemeToggleButton() {
   );
 }
 
+/**
+ * Sidebar block rendered only inside a campus scope (when the URL has a
+ * `mapId`). Shows an "All campuses" back link + a card with the current
+ * campus name + a status dot. Drives the "you are inside campus X"
+ * orientation that the org-level org switcher alone doesn't convey.
+ *
+ * The campus name comes from `useMaps(orgId)` — already cached SWR, so
+ * mounting this on every dashboard page doesn't add a round-trip.
+ */
+function CampusContextHeader({
+  orgId,
+  mapId,
+}: {
+  orgId: string;
+  mapId: string;
+}) {
+  const { maps } = useMaps(orgId);
+  const current = maps.find((m) => m.id === mapId);
+  const dotClass = current?.isPublished ? "bg-emerald-500" : "bg-text-tertiary";
+  return (
+    <div className="mt-3 space-y-2">
+      <Link
+        href={`/org/${orgId}/maps`}
+        className="inline-flex items-center gap-1 px-3 text-[11px] font-medium text-text-tertiary hover:text-text-secondary"
+      >
+        <ChevronLeft size={12} strokeWidth={1.8} aria-hidden />
+        All campuses
+      </Link>
+      <div className="rounded-lg px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className={`h-2 w-2 shrink-0 rounded-full ${dotClass}`}
+          />
+          <span className="truncate text-sm font-semibold text-text-primary">
+            {current?.name ?? "Campus"}
+          </span>
+        </div>
+        {current?.isPublished === false ? (
+          <span className="ml-4 text-[11px] text-text-tertiary">Draft</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** Compute the grouped nav for the org-scope rail. */
+function orgNavGroups(orgId: string, pathname: string): NavGroup[] {
+  const prefix = `/org/${orgId}`;
+  const is = (segment: string) =>
+    pathname === `${prefix}${segment}` || pathname.startsWith(`${prefix}${segment}/`);
+  return [
+    {
+      label: "Organisation",
+      items: [
+        {
+          label: "Overview",
+          href: `${prefix}/dashboard`,
+          icon: <LayoutDashboard size={16} strokeWidth={1.7} />,
+          active: is("/dashboard"),
+        },
+        {
+          label: "Campuses",
+          href: `${prefix}/maps`,
+          icon: <Building2 size={16} strokeWidth={1.7} />,
+          active: is("/maps") && !pathname.match(/\/maps\/[^/]+/),
+        },
+        {
+          label: "Team",
+          href: `${prefix}/settings/members`,
+          icon: <Users size={16} strokeWidth={1.7} />,
+          active: is("/settings/members"),
+        },
+        {
+          label: "Settings",
+          href: `${prefix}/settings/general`,
+          icon: <Settings size={16} strokeWidth={1.7} />,
+          active:
+            is("/settings/general") ||
+            is("/settings/usage"),
+        },
+      ],
+    },
+  ];
+}
+
+/** Compute the grouped nav for the campus-scope rail. */
+function campusNavGroups(
+  orgId: string,
+  mapId: string,
+  pathname: string,
+): NavGroup[] {
+  const prefix = `/org/${orgId}/maps/${mapId}`;
+  const is = (segment: string) =>
+    pathname === `${prefix}${segment}` || pathname.startsWith(`${prefix}${segment}/`);
+  return [
+    {
+      label: "Overview",
+      items: [
+        {
+          label: "Dashboard",
+          href: prefix,
+          icon: <LayoutDashboard size={16} strokeWidth={1.7} />,
+          // The campus root is the dashboard. Match exactly to avoid
+          // every campus-tier sub-route lighting this row.
+          active: pathname === prefix,
+        },
+      ],
+    },
+    {
+      label: "Public surfaces",
+      items: [
+        {
+          label: "Home",
+          href: `${prefix}/home`,
+          icon: <Home size={16} strokeWidth={1.7} />,
+          active: is("/home"),
+        },
+        {
+          label: "Map & Wayfinding",
+          href: `${prefix}/map`,
+          icon: <Compass size={16} strokeWidth={1.7} />,
+          active: is("/map"),
+        },
+        {
+          label: "News",
+          href: `${prefix}/news`,
+          icon: <Newspaper size={16} strokeWidth={1.7} />,
+          active: is("/news"),
+        },
+        {
+          label: "Events",
+          href: `${prefix}/events`,
+          icon: <Calendar size={16} strokeWidth={1.7} />,
+          active: is("/events"),
+        },
+        {
+          label: "Clubs",
+          href: `${prefix}/clubs`,
+          icon: <Users size={16} strokeWidth={1.7} />,
+          active: is("/clubs"),
+        },
+        {
+          label: "Dining",
+          href: `${prefix}/dining`,
+          icon: <Utensils size={16} strokeWidth={1.7} />,
+          active: is("/dining"),
+        },
+        {
+          label: "Klio",
+          href: `${prefix}/klio`,
+          icon: <Sparkles size={16} strokeWidth={1.7} />,
+          active: is("/klio"),
+        },
+      ],
+    },
+    {
+      label: "Manage",
+      items: [
+        {
+          label: "Reach",
+          href: `${prefix}/reach`,
+          icon: <Megaphone size={16} strokeWidth={1.7} />,
+          active: is("/reach"),
+        },
+        {
+          label: "Identity",
+          href: `${prefix}/identity`,
+          icon: <Globe2 size={16} strokeWidth={1.7} />,
+          active: is("/identity"),
+        },
+      ],
+    },
+  ];
+}
+
 export default function DashboardShell({ children }: { children: ReactNode }) {
   const { data: session } = useSession();
-  const params = useParams<{ orgId: string }>();
-  const pathname = usePathname();
+  const params = useParams<{ orgId: string; mapId?: string }>();
+  const pathname = usePathname() ?? "";
   const router = useRouter();
   const orgId = params?.orgId ?? "";
-  const pathPrefix = orgId ? `/org/${orgId}` : "";
+  const mapId = params?.mapId ?? "";
   const { organizations, loadingOrganizations } = useOrganizations();
   const { organization: currentOrganization, loadingOrganization } =
     useOrganization(orgId);
 
   // Builder + Workbench routes own the full viewport — no dashboard shell.
   const isFullScreen =
-    (pathname?.includes("/builder") ?? false) ||
-    (pathname?.includes("/workbench") ?? false);
+    pathname.includes("/builder") || pathname.includes("/workbench");
   if (isFullScreen) {
     return <main className="min-h-screen">{children}</main>;
   }
 
-  const nav: NavItem[] = [
-    {
-      label: "Dashboard",
-      href: `${pathPrefix}/dashboard`,
-      icon: <DashboardIcon fontSize="small" />,
-      active: pathname?.includes("/dashboard") ?? false,
-    },
-    {
-      label: "Campuses",
-      href: `${pathPrefix}/maps`,
-      icon: <MapIcon fontSize="small" />,
-      active: pathname?.includes("/maps") ?? false,
-    },
-    {
-      label: "Settings",
-      href: `${pathPrefix}/settings/general`,
-      icon: <SettingsIcon fontSize="small" />,
-      active: pathname?.includes("/settings") ?? false,
-    },
-  ];
+  // Two IAs share one shell: organisation tier when no campus is
+  // selected, campus tier the moment the URL carries a `mapId`. The
+  // sidebar header gains the "← All campuses" back link + a campus
+  // status card in the campus scope to anchor the visitor.
+  const inCampusScope = Boolean(mapId);
+  const navGroups = inCampusScope
+    ? campusNavGroups(orgId, mapId, pathname)
+    : orgNavGroups(orgId, pathname);
 
   return (
     <AppShell
@@ -129,16 +308,21 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
         </Link>
       }
       sidebarHeader={
-        <OrganizationSwitcher
-          organizations={organizations}
-          currentOrgId={orgId}
-          currentOrganization={currentOrganization}
-          loading={loadingOrganizations || loadingOrganization}
-          buildHref={(id) => `/org/${id}/dashboard`}
-          linkComponent={Link}
-        />
+        <div className="space-y-2">
+          <OrganizationSwitcher
+            organizations={organizations}
+            currentOrgId={orgId}
+            currentOrganization={currentOrganization}
+            loading={loadingOrganizations || loadingOrganization}
+            buildHref={(id) => `/org/${id}/dashboard`}
+            linkComponent={Link}
+          />
+          {inCampusScope ? (
+            <CampusContextHeader orgId={orgId} mapId={mapId} />
+          ) : null}
+        </div>
       }
-      nav={nav}
+      navGroups={navGroups}
       actions={<ThemeToggleButton />}
       sidebarFooter={
         <UserAccountMenu
@@ -150,7 +334,7 @@ export default function DashboardShell({ children }: { children: ReactNode }) {
             await signOut({ callbackUrl: "/auth/signin" });
             router.refresh();
           }}
-          profileActive={pathname?.includes("/profile") ?? false}
+          profileActive={pathname.includes("/profile")}
         />
       }
     >

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/page.tsx
@@ -1,0 +1,11 @@
+import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+
+export default function CampusHomePage() {
+  return (
+    <ComingSoonScreen
+      title="Home"
+      hint="Greeting copy, quick-action tiles, section toggles — composes the mobile home students see."
+      phase="Phase 4"
+    />
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/page.tsx
@@ -1,0 +1,11 @@
+import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+
+export default function CampusIdentityPage() {
+  return (
+    <ComingSoonScreen
+      title="Identity & branding"
+      hint="Campus name, display name, tagline and description in EL+EN. Logo, hero image, primary colour."
+      phase="Phase 5"
+    />
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/page.tsx
@@ -1,0 +1,11 @@
+import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+
+export default function CampusKlioPage() {
+  return (
+    <ComingSoonScreen
+      title="Klio"
+      hint="BYOK Anthropic key, tool toggles, persona sliders, suggestion chips for the empty state."
+      phase="Phase 4"
+    />
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/page.tsx
@@ -1,0 +1,11 @@
+import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+
+export default function CampusMapPage() {
+  return (
+    <ComingSoonScreen
+      title="Map & Wayfinding"
+      hint="Link the MappedIn venue, set the default floor, curate saved routes for QR sharing."
+      phase="Phase 4"
+    />
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/page.tsx
@@ -1,0 +1,11 @@
+import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+
+export default function CampusReachPage() {
+  return (
+    <ComingSoonScreen
+      title="Reach"
+      hint="Publish state, public URL + QR, push broadcast composer, subscriber count, broadcast history with CTR."
+      phase="Phase 5"
+    />
+  );
+}

--- a/packages/design-system/src/components/app-shell.tsx
+++ b/packages/design-system/src/components/app-shell.tsx
@@ -9,6 +9,14 @@ export type NavItem = {
   href: string;
   icon?: ReactNode;
   active?: boolean;
+  /** Optional small badge / count rendered at the right edge of the row. */
+  badge?: ReactNode;
+};
+
+export type NavGroup = {
+  /** Small-caps section header rendered above the items. Omit for an unlabeled group. */
+  label?: string;
+  items: NavItem[];
 };
 
 /** A link renderer — pass `next/link`'s `Link` so nav uses client routing. */
@@ -29,8 +37,17 @@ export type AppShellProps = {
   brand: ReactNode;
   /** Optional node between the brand and the nav — e.g. an org/workspace switcher. */
   sidebarHeader?: ReactNode;
-  /** Primary navigation. */
-  nav: NavItem[];
+  /**
+   * Primary navigation as a flat list. Pass either `nav` *or* `navGroups`;
+   * if both are provided, `navGroups` wins.
+   */
+  nav?: NavItem[];
+  /**
+   * Primary navigation as labelled groups — for IAs that need section
+   * headers (e.g. "PUBLIC SURFACES", "MANAGE"). When provided, replaces
+   * the flat `nav` rendering.
+   */
+  navGroups?: NavGroup[];
   /** Optional node pinned to the bottom of the sidebar (user menu, org switcher). */
   sidebarFooter?: ReactNode;
   /** Optional top-bar title or breadcrumb (left side). */
@@ -51,6 +68,7 @@ export function AppShell({
   brand,
   sidebarHeader,
   nav,
+  navGroups,
   sidebarFooter,
   title,
   actions,
@@ -59,6 +77,36 @@ export function AppShell({
 }: AppShellProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
+  // `navGroups` wins when both are passed — callers migrating from flat
+  // nav to grouped nav can do so without juggling both props.
+  const groups: NavGroup[] =
+    navGroups ?? (nav ? [{ items: nav }] : []);
+
+  const renderItem = (item: NavItem) => (
+    <Link
+      key={item.href}
+      href={item.href}
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+        item.active
+          ? "bg-accent-soft text-text-primary"
+          : "text-text-secondary hover:bg-accent-soft hover:text-text-primary",
+      )}
+    >
+      {item.icon ? (
+        <span className="flex h-5 w-5 items-center justify-center">
+          {item.icon}
+        </span>
+      ) : null}
+      <span className="flex-1 truncate">{item.label}</span>
+      {item.badge !== undefined && item.badge !== null ? (
+        <span className="shrink-0 text-[11px] font-medium text-text-tertiary">
+          {item.badge}
+        </span>
+      ) : null}
+    </Link>
+  );
+
   const sidebar = (
     <div className="flex h-full flex-col">
       <div className="flex h-16 shrink-0 items-center px-5">{brand}</div>
@@ -66,27 +114,21 @@ export function AppShell({
         <div className="shrink-0 px-3 pb-2">{sidebarHeader}</div>
       ) : null}
       <nav
-        className="flex-1 space-y-1 overflow-y-auto px-3 py-2"
+        className="flex-1 overflow-y-auto px-3 py-2"
         onClick={() => setMobileOpen(false)}
       >
-        {nav.map((item) => (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
-              item.active
-                ? "bg-accent-soft text-text-primary"
-                : "text-text-secondary hover:bg-accent-soft hover:text-text-primary",
-            )}
+        {groups.map((group, idx) => (
+          <div
+            key={group.label ?? `group-${idx}`}
+            className={idx === 0 ? "space-y-1" : "mt-5 space-y-1"}
           >
-            {item.icon ? (
-              <span className="flex h-5 w-5 items-center justify-center">
-                {item.icon}
-              </span>
+            {group.label ? (
+              <div className="px-3 pb-1 text-[10px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+                {group.label}
+              </div>
             ) : null}
-            {item.label}
-          </Link>
+            {group.items.map(renderItem)}
+          </div>
         ))}
       </nav>
       {sidebarFooter ? (

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -66,6 +66,7 @@ export {
   AppShell,
   type AppShellProps,
   type NavItem,
+  type NavGroup,
 } from "./components/app-shell";
 export {
   MobileBottomNav,


### PR DESCRIPTION
Phase 1 of the [backoffice redesign](https://github.com/prieston/klorad/blob/main) rebuild. Load-bearing — every later phase plugs into this IA.

## What ships

### Design-system

\`AppShell\` gains \`navGroups: NavGroup[]\` for sidebars that need section labels (OVERVIEW / PUBLIC SURFACES / MANAGE). The existing \`nav: NavItem[]\` is preserved for callers with flat lists. \`NavItem\` also gains an optional \`badge\` so counts (e.g. \"4\" next to News) sit at the right edge of the row. Both additive, no breaking changes — every existing AppShell consumer keeps working.

### Campus \`DashboardShell\` — rebuilt around the new IA

- **Scope detection from the URL** — \`mapId\` present means campus tier, absent means org tier. One shell, two ways it renders.
- **Org rail** (4 rows): Overview / Campuses / Team / Settings. All labels point at the same routes they always did.
- **Campus rail** — three labelled groups:

  | Group | Items |
  |---|---|
  | Overview | Dashboard |
  | Public surfaces | Home, Map & Wayfinding, News, Events, Clubs, Dining, Klio |
  | Manage | Reach, Identity |

  Campus Members + Campus Settings are deferred to Phase 5 per the agreed plan — no placeholders yet.

- **\`CampusContextHeader\`** appears in the sidebar inside the campus scope — \"← All campuses\" back link + campus name + a status dot driven by \`isPublished\`. Reads from the already-cached \`useMaps(orgId)\` SWR call, so no extra round-trip per page.
- **Icons** swapped from \`@klorad/ui\` (which still re-exports \`@mui/icons-material\` under the hood) to direct \`lucide-react\`. Drops MUI from the shell's runtime entirely. Remaining MUI inside screen-internal components gets swept in Phase 6.
- **Theme toggle** hand-rolled against \`localStorage\` + \`<html class=\"dark\">\` to drop \`useThemeMode\` from \`@klorad/ui\` while respecting the same flag.

### Stub pages

Five new routes, each rendering a brand-neutral \`ComingSoonScreen\` so the new nav rows resolve to honest placeholders instead of 404s:

| Route | Phase |
|---|---|
| /org/[orgId]/maps/[mapId]/home | Phase 4 |
| /org/[orgId]/maps/[mapId]/map | Phase 4 |
| /org/[orgId]/maps/[mapId]/klio | Phase 4 |
| /org/[orgId]/maps/[mapId]/reach | Phase 5 |
| /org/[orgId]/maps/[mapId]/identity | Phase 5 |

Each registers at 824 B + 103 kB shared in the build.

## Route shape

URL paths stay \`/org/[orgId]/maps/[mapId]/...\` — UI labels say \"Campus\" everywhere. Per the agreed decision, the permanent \"URL says maps, UI says Campus\" cognitive drag was accepted in exchange for zero broken links and no redirect layer.

## What this doesn't touch

- Builder + workbench routes still own the full viewport (existing \`isFullScreen\` bypass kept).
- Existing News / Events / Clubs / Dining authoring screens keep working unchanged — their internal MUI usage stays until the corresponding Phase 4 rewrite.
- No screen-level redesign yet — that's Phases 2–5.

## Test plan

- [ ] Visit \`/org/[orgId]/dashboard\` → see the org rail (Overview / Campuses / Team / Settings) with Overview highlighted
- [ ] Visit \`/org/[orgId]/maps\` → Campuses row active
- [ ] Visit \`/org/[orgId]/maps/[mapId]\` → rail switches to grouped campus IA; \"← All campuses\" back link appears; campus name + status dot show in the sidebar header
- [ ] Navigate Home / Map / Klio / Reach / Identity → ComingSoonScreen placeholder renders with correct title + phase label
- [ ] Navigate to News / Events / Clubs / Dining → existing screens still render unchanged
- [ ] Workbench route → full-viewport bypass still works
- [ ] Theme toggle → flips html.dark + persists across reload
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)