### PR TITLE
feat(campus): backoffice org tier — Phase 2 of redesign

### DIFF
--- a/apps/campus/app/(dashboard)/components/CampusCard.tsx
+++ b/apps/campus/app/(dashboard)/components/CampusCard.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import Link from "next/link";
+import { MapPin } from "lucide-react";
+import { bannerGradient, bannerOverlay } from "./campusBanner";
+
+interface Stat {
+  label: string;
+  value: string;
+}
+
+interface Props {
+  id: string;
+  name: string;
+  /** Optional location label rendered under the name ("Thessaloniki"). */
+  location?: string;
+  /** Optional kind label rendered as a pill inside the banner ("Headquarters" / "Campus"). */
+  kind?: string;
+  isPublished?: boolean;
+  /** Up to three small stat boxes shown in the card body. */
+  stats?: Stat[];
+  /** ISO/Date string — rendered as "Updated …" footer. Optional. */
+  updatedAt?: string | number | Date;
+  href: string;
+  /** Compact mode shrinks the banner height — used in dense grids. */
+  compact?: boolean;
+}
+
+/**
+ * The campus card shipped across the Org Overview's "Most active" rail
+ * and the Org Campuses grid. Gradient banner + name + optional pill +
+ * stats + updated stamp. Hue is derived from the campus id so it stays
+ * stable across screens — see `campusBanner.ts`.
+ */
+export function CampusCard({
+  id,
+  name,
+  location,
+  kind,
+  isPublished,
+  stats,
+  updatedAt,
+  href,
+  compact = false,
+}: Props) {
+  const updated = updatedAt
+    ? new Date(updatedAt).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : null;
+  const bannerHeight = compact ? "h-20" : "h-28";
+
+  return (
+    <Link
+      href={href}
+      className="group flex flex-col overflow-hidden rounded-2xl border border-line-soft bg-surface-1 transition-colors hover:border-line-strong"
+    >
+      <div
+        className={`${bannerHeight} relative flex items-end justify-between p-3`}
+        style={{
+          background: bannerGradient(id),
+          backgroundImage: `${bannerOverlay()}, ${bannerGradient(id)}`,
+          backgroundSize: "12px 12px, auto",
+        }}
+        aria-hidden
+      >
+        {kind ? (
+          <span className="inline-flex items-center rounded-md bg-black/30 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white">
+            {kind}
+          </span>
+        ) : (
+          <span />
+        )}
+        <MapPin
+          size={18}
+          strokeWidth={1.75}
+          className="text-white/90 drop-shadow-sm"
+        />
+      </div>
+      <div className="flex flex-1 flex-col gap-3 p-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-base font-semibold text-text-primary">
+              {name}
+            </div>
+            {location ? (
+              <div className="mt-0.5 flex items-center gap-1 text-xs text-text-tertiary">
+                <MapPin size={11} strokeWidth={1.75} aria-hidden />
+                {location}
+              </div>
+            ) : null}
+          </div>
+          {isPublished !== undefined ? (
+            <span
+              className={`shrink-0 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                isPublished
+                  ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                  : "bg-text-tertiary/10 text-text-tertiary"
+              }`}
+            >
+              <span
+                aria-hidden
+                className={`h-1.5 w-1.5 rounded-full ${
+                  isPublished ? "bg-emerald-500" : "bg-text-tertiary"
+                }`}
+              />
+              {isPublished ? "Published" : "Draft"}
+            </span>
+          ) : null}
+        </div>
+        {stats && stats.length > 0 ? (
+          <div className="grid grid-cols-3 gap-3 text-xs">
+            {stats.map((s) => (
+              <div key={s.label}>
+                <div className="text-base font-medium text-text-primary">
+                  {s.value}
+                </div>
+                <div className="text-[10px] uppercase tracking-wide text-text-tertiary">
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        <div className="mt-auto flex items-center justify-between border-t border-line-soft pt-3 text-xs">
+          <span className="text-text-tertiary">
+            {updated ? `Updated ${updated}` : ""}
+          </span>
+          <span className="font-medium text-accent group-hover:underline">
+            Open →
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/OrgWorldMap.tsx
+++ b/apps/campus/app/(dashboard)/components/OrgWorldMap.tsx
@@ -1,21 +1,39 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
 import mapboxgl, { type Map as MapboxMap, type Marker } from "mapbox-gl";
-import { Button } from "@klorad/design-system";
+import { Maximize2 } from "lucide-react";
 import type { CampusMap } from "@/app/hooks/useMaps";
 
 interface Props {
   maps: CampusMap[];
+  /** Tailwind height — overridable so the same component fits a hero
+   *  banner (taller) or a sidebar widget. */
+  className?: string;
 }
 
 const FALLBACK_CENTER: [number, number] = [23.7275, 37.9838]; // Athens
 const FALLBACK_ZOOM = 4;
-// Brand accent — constant across themes (mirrors --accent in tokens.css).
+// Brand accent — mirrors `--accent` in the tokens.css palette.
 const PIN_COLOR = "#158ca3";
 
-export default function LocationsHeader({ maps }: Props) {
+/**
+ * The Org Overview's world map — one pin per campus that has a stored
+ * `center` coordinate. The only surviving Mapbox surface in the
+ * product per [[campus-indoor-mappedin-decision]]; everything inside
+ * a single campus uses MappedIn.
+ *
+ * Lives in the dashboard chrome only — public surfaces never embed
+ * this. The map is non-interactive enough for an overview (cooperative
+ * gestures, no scroll-zoom hijack) and zooms to fit on prop change so
+ * adding a campus immediately reframes.
+ *
+ * Renders a "set NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN" hint instead of
+ * silently failing when the token isn't configured — the dashboard
+ * is rector-facing, so being explicit about the gap beats a blank
+ * box.
+ */
+export function OrgWorldMap({ maps, className = "h-[260px]" }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapboxMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
@@ -38,7 +56,11 @@ export default function LocationsHeader({ maps }: Props) {
     const map = mapRef.current;
     if (!map) return;
     if (pins.length === 0) {
-      map.flyTo({ center: FALLBACK_CENTER, zoom: FALLBACK_ZOOM, duration: 800 });
+      map.flyTo({
+        center: FALLBACK_CENTER,
+        zoom: FALLBACK_ZOOM,
+        duration: 800,
+      });
       return;
     }
     if (pins.length === 1) {
@@ -101,28 +123,31 @@ export default function LocationsHeader({ maps }: Props) {
   const hasToken = Boolean(process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN);
 
   return (
-    <div className="relative mb-6 h-[200px] w-full overflow-hidden rounded-2xl border border-line-soft bg-surface-1">
+    <div
+      className={`relative w-full overflow-hidden rounded-2xl border border-line-soft bg-surface-1 ${className}`}
+    >
       <div ref={containerRef} className="absolute inset-0" />
       {!hasToken && (
         <div className="absolute inset-0 flex items-center justify-center px-4 text-center text-sm text-text-secondary">
-          Set NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN to see campus locations on a map.
+          Set NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN to see campus locations.
         </div>
       )}
-      <div className="glass-panel absolute left-3 top-3 inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium text-text-primary">
+      <div className="absolute left-3 top-3 inline-flex items-center gap-2 rounded-full border border-line-soft bg-surface-1/90 px-3 py-1.5 text-xs font-medium text-text-primary shadow-sm backdrop-blur">
         <span>Campus locations</span>
-        <span className="inline-flex items-center rounded-full bg-accent-soft px-2 py-0.5 text-[0.7rem] font-semibold text-accent">
+        <span className="inline-flex items-center rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-semibold text-accent">
           {pins.length}
         </span>
       </div>
-      <Button
-        size="sm"
+      <button
+        type="button"
         onClick={fitToExtent}
         disabled={pins.length === 0}
-        className="absolute right-3 top-3"
+        aria-label="Fit to extent"
+        className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-line-soft bg-surface-1/90 px-3 py-1.5 text-xs font-medium text-text-primary shadow-sm backdrop-blur transition-opacity hover:opacity-90 disabled:opacity-40"
       >
-        <CenterFocusStrongIcon sx={{ fontSize: 16 }} />
-        Fit to extent
-      </Button>
+        <Maximize2 size={12} strokeWidth={1.75} aria-hidden />
+        Fit
+      </button>
     </div>
   );
 }

--- a/apps/campus/app/(dashboard)/components/PageHeader.tsx
+++ b/apps/campus/app/(dashboard)/components/PageHeader.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  /** Small caps eyebrow above the title — e.g. "Organisation". */
+  eyebrow?: string;
+  /** The big title. */
+  title: string;
+  /** Optional one-line description below the title. */
+  subtitle?: string;
+  /** Right-side actions slot (typically buttons). */
+  actions?: ReactNode;
+}
+
+/**
+ * Shared header used at the top of every backoffice screen. Sits flush
+ * against the AppShell content area's top edge and gives every screen
+ * the same vertical rhythm + the same place for primary actions.
+ *
+ * Designed to be replaceable by per-screen variants when a screen
+ * needs richer chrome (e.g. status pills, breadcrumbs) — this is the
+ * default for the common case.
+ */
+export function PageHeader({ eyebrow, title, subtitle, actions }: Props) {
+  return (
+    <header className="mb-8 flex items-start justify-between gap-4">
+      <div className="min-w-0">
+        {eyebrow ? (
+          <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className="mt-1 truncate text-2xl font-semibold text-text-primary">
+          {title}
+        </h1>
+        {subtitle ? (
+          <p className="mt-1 text-sm text-text-secondary">{subtitle}</p>
+        ) : null}
+      </div>
+      {actions ? (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      ) : null}
+    </header>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/StatCard.tsx
+++ b/apps/campus/app/(dashboard)/components/StatCard.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  icon: ReactNode;
+  /** Big number — pass `"—"` for stats that don't have a backend yet. */
+  value: string;
+  /** Short label under the number. */
+  label: string;
+  /** Optional secondary line — e.g. "↑ 12% vs last month". */
+  trend?: ReactNode;
+}
+
+/**
+ * The headline KPI card used across every backoffice overview screen.
+ * Icon in a soft accent tile, big light value, label below, optional
+ * trend chip in muted text.
+ */
+export function StatCard({ icon, value, label, trend }: Props) {
+  return (
+    <div className="rounded-2xl border border-line-soft bg-surface-1 p-5">
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
+        {icon}
+      </div>
+      <div className="mt-4 text-2xl font-light text-text-primary">{value}</div>
+      <div className="mt-0.5 text-sm text-text-secondary">{label}</div>
+      {trend ? (
+        <div className="mt-2 text-xs text-text-tertiary">{trend}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/campusBanner.ts
+++ b/apps/campus/app/(dashboard)/components/campusBanner.ts
@@ -1,0 +1,44 @@
+/**
+ * Deterministic gradient + label colour for a campus card banner.
+ *
+ * The IHU mocks show every campus card topped with a coloured gradient
+ * banner — teal / green / purple / orange / pink / etc. — used as a
+ * visual handle so rectors can tell campuses apart at a glance.
+ * Picking the hue from a hash of the campus id means the same campus
+ * always gets the same colour across the dashboard (Org Overview's
+ * "Most active" cards, the Campuses grid, the campus picker) without
+ * us having to store one in the schema.
+ */
+
+const HUES = [200, 160, 270, 25, 320, 100, 50, 240];
+
+/** Hash a string to a stable non-negative integer. djb2 — fast enough. */
+function hashString(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+/**
+ * Two-stop diagonal gradient suitable for a CSS `background` value.
+ * Picks one of `HUES` based on the campus id, then renders a darker
+ * lower-right and lighter upper-left to give the banner the same
+ * depth as the design mocks.
+ */
+export function bannerGradient(campusId: string): string {
+  const hue = HUES[hashString(campusId) % HUES.length];
+  const start = `hsl(${hue}, 55%, 45%)`;
+  const end = `hsl(${hue}, 60%, 30%)`;
+  return `linear-gradient(135deg, ${start} 0%, ${end} 100%)`;
+}
+
+/**
+ * A dot-grid pattern overlay drawn on top of the gradient — matches
+ * the texture in the mocks. Returns a CSS `background-image` value
+ * stacked over the gradient; the caller composes them.
+ */
+export function bannerOverlay(): string {
+  return "radial-gradient(rgba(255,255,255,0.12) 1px, transparent 1px)";
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/dashboard/DashboardClient.tsx
@@ -1,77 +1,155 @@
 "use client";
 
 import { useMemo } from "react";
-import type { ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import MapIcon from "@mui/icons-material/Map";
-import PlaceIcon from "@mui/icons-material/Place";
-import VisibilityIcon from "@mui/icons-material/Visibility";
-import AccessibleIcon from "@mui/icons-material/Accessible";
-import { Panel, Button } from "@klorad/design-system";
+import {
+  Accessibility,
+  Building2,
+  Eye,
+  MapPin,
+  Plus,
+  UserPlus,
+} from "lucide-react";
+import { Button } from "@klorad/design-system";
 import { useMaps } from "@/app/hooks/useMaps";
-import LocationsHeader from "../maps/LocationsHeader";
+import { useOrganization } from "@/app/hooks/useOrganizations";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { StatCard } from "@/app/(dashboard)/components/StatCard";
+import { CampusCard } from "@/app/(dashboard)/components/CampusCard";
+import { OrgWorldMap } from "@/app/(dashboard)/components/OrgWorldMap";
 
 interface Props {
   orgId: string;
 }
 
+/**
+ * Org Overview — the rector's first-screen-of-the-morning.
+ *
+ * Structure matches the IHU mocks:
+ *   header (org name + invite/new campus actions)
+ *   Mapbox world map with one pin per campus
+ *   4 stat cards (Campuses · POIs · Public views · Avg accessibility)
+ *   "Most active campuses" — 3 gradient cards sorted by recent edits
+ *
+ * Stats with a real backend show the real number; everything else
+ * is rendered as "—" rather than fake data, so the rector trusts
+ * what's displayed.
+ */
 export default function DashboardClient({ orgId }: Props) {
   const router = useRouter();
   const { maps, isLoading } = useMaps(orgId);
+  const { organization } = useOrganization(orgId);
 
-  const recentMaps = useMemo(() => maps.slice(0, 3), [maps]);
+  const sortedByActivity = useMemo(
+    () =>
+      [...maps].sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      ),
+    [maps],
+  );
+  const mostActive = sortedByActivity.slice(0, 3);
+  const publishedCount = maps.filter((m) => m.isPublished).length;
+  const draftCount = maps.length - publishedCount;
   const showSkeleton = isLoading && maps.length === 0;
 
   return (
-    <div className="w-full space-y-10 px-6 py-8 md:px-10">
-      <LocationsHeader maps={maps} />
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Organisation"
+        title={organization?.name ?? "Organisation"}
+        subtitle="Every campus this organisation runs, across all locations."
+        actions={
+          <>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() =>
+                router.push(`/org/${orgId}/settings/members`)
+              }
+            >
+              <UserPlus size={14} strokeWidth={1.75} aria-hidden />
+              Invite team
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => router.push(`/org/${orgId}/maps`)}
+            >
+              <Plus size={14} strokeWidth={1.75} aria-hidden />
+              New campus
+            </Button>
+          </>
+        }
+      />
 
-      {/* KPI row */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <OrgWorldMap maps={maps} />
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
-          icon={<MapIcon fontSize="small" />}
+          icon={<Building2 size={18} strokeWidth={1.75} aria-hidden />}
           value={String(maps.length)}
-          label="Campus maps"
+          label="Campuses"
+          trend={
+            maps.length > 0
+              ? `${publishedCount} published · ${draftCount} draft`
+              : null
+          }
         />
         <StatCard
-          icon={<PlaceIcon fontSize="small" />}
+          icon={<MapPin size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
           label="POIs across maps"
         />
         <StatCard
-          icon={<VisibilityIcon fontSize="small" />}
+          icon={<Eye size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
           label="Public views (30d)"
         />
         <StatCard
-          icon={<AccessibleIcon fontSize="small" />}
+          icon={<Accessibility size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
-          label="Accessibility coverage"
+          label="Avg accessibility"
         />
       </div>
 
-      {/* Recent campuses */}
-      <section className="space-y-4">
-        <SectionTitle>Recent campuses</SectionTitle>
+      <section className="mt-10">
+        <div className="mb-4 flex items-end justify-between">
+          <h2 className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+            Most active campuses
+          </h2>
+          {maps.length > 3 ? (
+            <Link
+              href={`/org/${orgId}/maps`}
+              className="text-sm font-medium text-accent hover:underline"
+            >
+              View all campuses →
+            </Link>
+          ) : null}
+        </div>
         {showSkeleton ? (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {[0, 1, 2].map((i) => (
               <div
                 key={i}
-                className="h-[208px] animate-pulse rounded-xl bg-surface-2"
+                className="h-[208px] animate-pulse rounded-2xl bg-surface-2"
               />
             ))}
           </div>
-        ) : recentMaps.length === 0 ? (
-          <Panel className="flex flex-col items-center gap-3 px-6 py-12 text-center">
-            <MapIcon className="text-accent opacity-60" fontSize="large" />
+        ) : mostActive.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-line-soft bg-surface-1 px-6 py-12 text-center">
+            <Building2
+              size={28}
+              strokeWidth={1.5}
+              className="text-accent opacity-60"
+              aria-hidden
+            />
             <p className="text-base font-medium text-text-primary">
               No campuses yet
             </p>
             <p className="max-w-sm text-sm text-text-secondary">
-              Create your first campus map. Drop some POIs, share the URL —
-              it&apos;s a five-minute setup.
+              Create your first campus. Five-minute setup — pick a location,
+              annotate, share.
             </p>
             <Button
               className="mt-1"
@@ -79,142 +157,22 @@ export default function DashboardClient({ orgId }: Props) {
             >
               Create a campus
             </Button>
-          </Panel>
+          </div>
         ) : (
-          <div className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {recentMaps.map((m) => (
-                <CampusCard
-                  key={m.id}
-                  name={m.name}
-                  updatedAt={m.updatedAt}
-                  thumbnail={m.thumbnail ?? undefined}
-                  href={`/org/${orgId}/maps/${m.id}`}
-                />
-              ))}
-            </div>
-            <div className="flex justify-end">
-              <Link
-                href={`/org/${orgId}/maps`}
-                className="text-sm font-medium text-accent transition-colors hover:text-accent-hover"
-              >
-                View all campuses →
-              </Link>
-            </div>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {mostActive.map((m) => (
+              <CampusCard
+                key={m.id}
+                id={m.id}
+                name={m.name}
+                isPublished={m.isPublished}
+                updatedAt={m.updatedAt}
+                href={`/org/${orgId}/maps/${m.id}`}
+              />
+            ))}
           </div>
         )}
       </section>
-
-      {/* Quick actions */}
-      <section className="space-y-4">
-        <SectionTitle>Quick actions</SectionTitle>
-        <div className="grid gap-4 md:grid-cols-3">
-          <QuickAction
-            title="Create a new campus"
-            description="Start with a blank 3D map. Drop POIs in seconds."
-            href={`/org/${orgId}/maps`}
-          />
-          <QuickAction
-            title="Invite a teammate"
-            description="Bring marketing or facilities staff into the org."
-            href={`/org/${orgId}/settings/members`}
-          />
-          <QuickAction
-            title="Review usage"
-            description="See plan limits, POI counts, and view analytics."
-            href={`/org/${orgId}/settings/usage`}
-          />
-        </div>
-      </section>
     </div>
-  );
-}
-
-function SectionTitle({ children }: { children: ReactNode }) {
-  return (
-    <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
-      {children}
-    </h2>
-  );
-}
-
-function StatCard({
-  icon,
-  value,
-  label,
-}: {
-  icon: ReactNode;
-  value: string;
-  label: string;
-}) {
-  return (
-    <Panel className="rounded-2xl p-5">
-      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
-        {icon}
-      </div>
-      <div className="mt-4 text-2xl font-light text-text-primary">{value}</div>
-      <div className="mt-0.5 text-sm text-text-secondary">{label}</div>
-    </Panel>
-  );
-}
-
-function CampusCard({
-  name,
-  updatedAt,
-  thumbnail,
-  href,
-}: {
-  name: string;
-  updatedAt: string | number | Date;
-  thumbnail?: string;
-  href: string;
-}) {
-  const updated = new Date(updatedAt).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-  return (
-    <Link href={href} className="group block">
-      <Panel className="overflow-hidden rounded-2xl transition-colors duration-200 group-hover:border-line-strong">
-        <div className="aspect-video bg-surface-2">
-          {thumbnail ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={thumbnail}
-              alt=""
-              className="h-full w-full object-cover"
-            />
-          ) : null}
-        </div>
-        <div className="p-4">
-          <div className="font-medium text-text-primary">{name}</div>
-          <div className="mt-1 text-xs text-text-tertiary">
-            Updated {updated}
-          </div>
-        </div>
-      </Panel>
-    </Link>
-  );
-}
-
-function QuickAction({
-  title,
-  description,
-  href,
-}: {
-  title: string;
-  description: string;
-  href: string;
-}) {
-  return (
-    <Link href={href} className="group block">
-      <Panel className="h-full rounded-2xl p-5 transition-colors duration-200 group-hover:border-line-strong">
-        <div className="text-sm font-semibold text-text-primary">{title}</div>
-        <div className="mt-1 text-xs leading-relaxed text-text-secondary">
-          {description}
-        </div>
-      </Panel>
-    </Link>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/MapsPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/MapsPageClient.tsx
@@ -1,41 +1,43 @@
 "use client";
 
-import { useState } from "react";
-import Link from "next/link";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import AddIcon from "@mui/icons-material/Add";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import {
-  Badge,
-  Button,
-  EmptyState,
-  Field,
-  IconButton,
-  Input,
-  Menu,
-  MenuItem,
-  Modal,
-  Panel,
-} from "@klorad/design-system";
+import { Plus, Search } from "lucide-react";
+import { Button, Field, Input, Modal } from "@klorad/design-system";
 import { useMaps } from "@/app/hooks/useMaps";
-import LocationsHeader from "./LocationsHeader";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { CampusCard } from "@/app/(dashboard)/components/CampusCard";
 
 interface Props {
   orgId: string;
   userId: string;
 }
 
+type Filter = "all" | "published" | "drafts";
+
+/**
+ * Org Campuses — the searchable / filterable grid of every campus this
+ * organisation runs. The Org Overview's "Most active" rail is a
+ * curated three; this is the place to find any campus by name or
+ * publication state.
+ *
+ * Mirrors the IHU mock: header (title + "New campus"), search +
+ * three pills (All / Published / Drafts), the grid, and an "Add a
+ * campus" dashed tile at the end so creating one feels native to the
+ * grid instead of hiding behind a header CTA only.
+ *
+ * Per [[campus-backoffice-redesign]], the world map that used to live
+ * here was promoted to the Org Overview — this screen is now purely
+ * about *which* campuses exist, not *where* they are.
+ */
 export default function MapsPageClient({ orgId }: Props) {
   const router = useRouter();
-  const { maps, isLoading, createMap, deleteMap } = useMaps(orgId);
+  const { maps, isLoading, createMap } = useMaps(orgId);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [query, setQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
-  const [deleting, setDeleting] = useState(false);
 
   const closeCreate = () => {
     if (creating) return;
@@ -53,77 +55,139 @@ export default function MapsPageClient({ orgId }: Props) {
     if (map) router.push(`/org/${orgId}/maps/${map.id}`);
   };
 
-  const handleConfirmDelete = async () => {
-    if (!confirmDelete) return;
-    setDeleting(true);
-    await deleteMap(confirmDelete.id);
-    setDeleting(false);
-    setConfirmDelete(null);
-  };
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return maps.filter((m) => {
+      if (filter === "published" && !m.isPublished) return false;
+      if (filter === "drafts" && m.isPublished) return false;
+      if (q && !m.name.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [maps, filter, query]);
+
+  const counts = useMemo(
+    () => ({
+      all: maps.length,
+      published: maps.filter((m) => m.isPublished).length,
+      drafts: maps.filter((m) => !m.isPublished).length,
+    }),
+    [maps],
+  );
 
   const showSkeleton = isLoading && maps.length === 0;
-  const showEmpty = !isLoading && maps.length === 0;
 
   return (
-    <div className="w-full space-y-8 px-6 py-8 md:px-10">
-      <LocationsHeader maps={maps} />
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Organisation"
+        title="Campuses"
+        subtitle="Pick a campus to manage its public app — or spin up a new one."
+        actions={
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus size={14} strokeWidth={1.75} aria-hidden />
+            New campus
+          </Button>
+        }
+      />
 
-      {showEmpty ? (
-        <EmptyState
-          icon={CampusGlyph}
-          title="No campuses yet"
-          body="Start with a blank campus, then pick a location on the map and draw the first building."
-          action={
-            <Button onClick={() => setCreateOpen(true)}>
-              <AddIcon fontSize="small" />
-              Create your first campus
-            </Button>
-          }
-        />
-      ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[240px]">
+          <Search
+            size={14}
+            strokeWidth={1.75}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary"
+            aria-hidden
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search campuses…"
+            className="h-9 w-full rounded-full border border-line-soft bg-surface-1 pl-9 pr-3 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus-visible:border-accent"
+          />
+        </div>
+        <div
+          role="tablist"
+          aria-label="Filter campuses"
+          className="inline-flex items-center gap-1 rounded-full border border-line-soft bg-surface-1 p-1"
+        >
+          {(["all", "published", "drafts"] as Filter[]).map((f) => {
+            const isActive = filter === f;
+            return (
+              <button
+                key={f}
+                role="tab"
+                type="button"
+                aria-selected={isActive}
+                onClick={() => setFilter(f)}
+                className={
+                  isActive
+                    ? "rounded-full bg-accent px-3 py-1 text-xs font-medium text-white"
+                    : "rounded-full px-3 py-1 text-xs font-medium text-text-secondary hover:text-text-primary"
+                }
+              >
+                <span className="capitalize">{f}</span>
+                <span className="ml-1 text-text-tertiary">
+                  {counts[f]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {showSkeleton
+          ? [0, 1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="h-[208px] animate-pulse rounded-2xl bg-surface-2"
+              />
+            ))
+          : filtered.map((m) => (
+              <CampusCard
+                key={m.id}
+                id={m.id}
+                name={m.name}
+                isPublished={m.isPublished}
+                updatedAt={m.updatedAt}
+                href={`/org/${orgId}/maps/${m.id}`}
+              />
+            ))}
+
+        {!showSkeleton && filtered.length === 0 ? (
+          <div className="col-span-full rounded-2xl border border-dashed border-line-soft bg-surface-1 px-6 py-10 text-center text-sm text-text-secondary">
+            {query
+              ? "No campuses match that search."
+              : filter === "published"
+                ? "No published campuses yet."
+                : filter === "drafts"
+                  ? "No drafts."
+                  : "No campuses yet."}
+          </div>
+        ) : null}
+
+        {!showSkeleton ? (
           <button
             type="button"
             onClick={() => setCreateOpen(true)}
             className="group flex min-h-[208px] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-line-strong bg-surface-1 text-text-secondary transition-colors hover:border-accent hover:text-accent"
           >
             <span className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent">
-              <AddIcon fontSize="small" />
+              <Plus size={18} strokeWidth={1.75} aria-hidden />
             </span>
-            <span className="text-sm font-medium">New map</span>
+            <span className="text-sm font-medium">Add a campus</span>
             <span className="text-xs text-text-tertiary">
-              Create a new campus map
+              Link a MappedIn venue and brand it in minutes.
             </span>
           </button>
-
-          {showSkeleton
-            ? [0, 1, 2].map((i) => (
-                <div
-                  key={i}
-                  className="h-[208px] animate-pulse rounded-2xl bg-surface-2"
-                />
-              ))
-            : maps.map((map) => (
-                <CampusCard
-                  key={map.id}
-                  name={map.name}
-                  updatedAt={map.updatedAt}
-                  thumbnail={map.thumbnail ?? undefined}
-                  isPublished={map.isPublished ?? false}
-                  href={`/org/${orgId}/maps/${map.id}`}
-                  onEdit={() => router.push(`/org/${orgId}/maps/${map.id}`)}
-                  onDelete={() =>
-                    setConfirmDelete({ id: map.id, name: map.name })
-                  }
-                />
-              ))}
-        </div>
-      )}
+        ) : null}
+      </div>
 
       <Modal
         open={createOpen}
         onClose={closeCreate}
-        title="New campus map"
+        title="New campus"
         footer={
           <>
             <Button
@@ -137,12 +201,12 @@ export default function MapsPageClient({ orgId }: Props) {
               onClick={handleCreate}
               disabled={!newName.trim() || creating}
             >
-              {creating ? "Creating…" : "Create map"}
+              {creating ? "Creating…" : "Create campus"}
             </Button>
           </>
         }
       >
-        <Field label="Map name">
+        <Field label="Campus name">
           <Input
             autoFocus
             placeholder="e.g. Main Campus"
@@ -152,132 +216,6 @@ export default function MapsPageClient({ orgId }: Props) {
           />
         </Field>
       </Modal>
-
-      <Modal
-        open={confirmDelete !== null}
-        onClose={() => !deleting && setConfirmDelete(null)}
-        title="Delete map?"
-        description={`"${confirmDelete?.name ?? ""}" and all its POIs will be permanently removed. This cannot be undone.`}
-        footer={
-          <>
-            <Button
-              variant="secondary"
-              onClick={() => setConfirmDelete(null)}
-              disabled={deleting}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="danger"
-              onClick={handleConfirmDelete}
-              disabled={deleting}
-            >
-              {deleting ? "Deleting…" : "Delete map"}
-            </Button>
-          </>
-        }
-      />
     </div>
-  );
-}
-
-function CampusCard({
-  name,
-  updatedAt,
-  thumbnail,
-  isPublished,
-  href,
-  onEdit,
-  onDelete,
-}: {
-  name: string;
-  updatedAt: string | number | Date;
-  thumbnail?: string;
-  isPublished: boolean;
-  href: string;
-  onEdit: () => void;
-  onDelete: () => void;
-}) {
-  const updated = new Date(updatedAt).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-  return (
-    <div className="group relative">
-      <Link href={href} className="block">
-        <Panel className="overflow-hidden rounded-2xl transition-colors duration-200 group-hover:border-line-strong">
-          <div className="relative aspect-video bg-surface-2">
-            {thumbnail ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={thumbnail}
-                alt=""
-                className="h-full w-full object-cover"
-              />
-            ) : null}
-            <span className="absolute left-3 top-3">
-              <Badge tone={isPublished ? "success" : "neutral"}>
-                {isPublished ? "Published" : "Draft"}
-              </Badge>
-            </span>
-          </div>
-          <div className="p-4">
-            <div className="truncate font-medium text-text-primary">{name}</div>
-            <div className="mt-1 text-xs text-text-tertiary">
-              Updated {updated}
-            </div>
-          </div>
-        </Panel>
-      </Link>
-      <div className="absolute right-2 top-2">
-        <Menu
-          trigger={
-            <IconButton
-              variant="secondary"
-              size="sm"
-              aria-label="Map options"
-              className="bg-surface-1"
-            >
-              <MoreVertIcon fontSize="small" />
-            </IconButton>
-          }
-        >
-          <MenuItem onClick={onEdit}>Edit</MenuItem>
-          <MenuItem tone="danger" onClick={onDelete}>
-            Delete
-          </MenuItem>
-        </Menu>
-      </div>
-    </div>
-  );
-}
-
-/** Tiny campus glyph for the empty state — no need to pull a 24px MUI
- *  icon when an inline SVG matches the rest of our visual language. */
-function CampusGlyph({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <rect x="3" y="9" width="7" height="12" rx="1" />
-      <rect x="14" y="5" width="7" height="16" rx="1" />
-      <line x1="5.5" y1="13" x2="5.5" y2="13" />
-      <line x1="7.5" y1="13" x2="7.5" y2="13" />
-      <line x1="5.5" y1="16" x2="5.5" y2="16" />
-      <line x1="7.5" y1="16" x2="7.5" y2="16" />
-      <line x1="16" y1="9" x2="16" y2="9" />
-      <line x1="19" y1="9" x2="19" y2="9" />
-      <line x1="16" y1="13" x2="16" y2="13" />
-      <line x1="19" y1="13" x2="19" y2="13" />
-      <line x1="16" y1="17" x2="19" y2="17" />
-    </svg>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/general/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/general/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import { Button, Field, Input, Panel, Spinner, cn } from "@klorad/design-system";
 import { showToast } from "@klorad/ui";
 import { useOrganization } from "@/app/hooks/useOrganizations";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
 
 export default function SettingsGeneralPage() {
   const params = useParams<{ orgId: string }>();
@@ -82,32 +83,39 @@ export default function SettingsGeneralPage() {
   const scopeLabel = organization.isPersonal ? "Workspace" : "Organization";
 
   return (
-    <div className="w-full space-y-6 px-6 py-8 md:px-10">
-      <div className="flex items-center justify-end gap-2 border-b border-line-soft pb-5">
-        {hasChanges && (
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={saving}
-            onClick={() =>
-              setFormData({
-                name: organization.name,
-                slug: organization.slug ?? "",
-              })
-            }
-          >
-            Cancel
-          </Button>
-        )}
-        <Button
-          size="sm"
-          className="min-w-[96px]"
-          disabled={!canEdit || !hasChanges || saving}
-          onClick={handleSave}
-        >
-          {saving ? "Saving…" : "Save"}
-        </Button>
-      </div>
+    <div className="mx-auto w-full max-w-[1280px] space-y-6 px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Organisation"
+        title="Settings"
+        subtitle="Locale defaults, custom domain and billing."
+        actions={
+          <>
+            {hasChanges && (
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={saving}
+                onClick={() =>
+                  setFormData({
+                    name: organization.name,
+                    slug: organization.slug ?? "",
+                  })
+                }
+              >
+                Cancel
+              </Button>
+            )}
+            <Button
+              size="sm"
+              className="min-w-[96px]"
+              disabled={!canEdit || !hasChanges || saving}
+              onClick={handleSave}
+            >
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          </>
+        }
+      />
 
       <Panel className="rounded-2xl p-6">
         <h2 className="text-sm font-semibold text-text-primary">

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/members/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/members/page.tsx
@@ -17,11 +17,9 @@ import {
   Spinner,
 } from "@klorad/design-system";
 import { showToast } from "@klorad/ui";
-import DeleteIcon from "@mui/icons-material/Delete";
-import CancelIcon from "@mui/icons-material/Cancel";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import { Copy, Trash2, UserPlus, X } from "lucide-react";
 import { useOrganization } from "@/app/hooks/useOrganizations";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
 
 interface Member {
   id: string;
@@ -216,16 +214,20 @@ export default function SettingsMembersPage() {
 
   return (
     <>
-      <div className="w-full space-y-6 px-6 py-8 md:px-10">
-        {canInvite && (
-          <div className="flex justify-end">
-            <Button size="sm" onClick={() => setInviteOpen(true)}>
-              <PersonAddIcon fontSize="small" />
-              Invite member
-            </Button>
-          </div>
-        )}
-
+      <div className="mx-auto w-full max-w-[1280px] space-y-6 px-6 py-8 md:px-10">
+        <PageHeader
+          eyebrow="Organisation"
+          title="Team"
+          subtitle="Who can author this organisation's campuses, and a log of what changed."
+          actions={
+            canInvite ? (
+              <Button size="sm" onClick={() => setInviteOpen(true)}>
+                <UserPlus size={14} strokeWidth={1.75} aria-hidden />
+                Invite member
+              </Button>
+            ) : null
+          }
+        />
         <Panel className="rounded-2xl p-6">
           <h2 className="text-sm font-semibold text-text-primary">
             Organization members
@@ -323,7 +325,7 @@ export default function SettingsMembersPage() {
                                 }}
                                 className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-600"
                               >
-                                <DeleteIcon fontSize="small" />
+                                <Trash2 size={14} strokeWidth={1.75} aria-hidden />
                               </button>
                             )}
                           </td>
@@ -368,7 +370,7 @@ export default function SettingsMembersPage() {
                             }}
                             className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-600 disabled:opacity-50"
                           >
-                            <CancelIcon fontSize="small" />
+                            <X size={14} strokeWidth={1.75} aria-hidden />
                           </button>
                         </td>
                       )}
@@ -449,7 +451,7 @@ export default function SettingsMembersPage() {
               }
             }}
           >
-            <ContentCopyIcon fontSize="small" />
+            <Copy size={14} strokeWidth={1.75} aria-hidden />
           </IconButton>
         </div>
       </Modal>

--- a/apps/campus/app/(dashboard)/org/[orgId]/settings/usage/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/settings/usage/page.tsx
@@ -1,43 +1,53 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import type { ReactNode } from "react";
-import MapIcon from "@mui/icons-material/Map";
-import PlaceIcon from "@mui/icons-material/Place";
-import VisibilityIcon from "@mui/icons-material/Visibility";
-import ApartmentIcon from "@mui/icons-material/Apartment";
+import { Accessibility, Building2, Eye, MapPin } from "lucide-react";
 import { Panel } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { StatCard } from "@/app/(dashboard)/components/StatCard";
 
+/**
+ * Org Usage — quick plan + counters page. Lives at /settings/usage as
+ * a sibling of /settings/general because the broader IA rebuild keeps
+ * URL paths stable. Numbers are placeholders until the analytics
+ * arc lands; rendering "—" keeps trust intact.
+ */
 export default async function SettingsUsagePage() {
   const session = await auth();
   if (!session) redirect("/auth/signin");
 
   return (
-    <div className="w-full space-y-10 px-6 py-8 md:px-10">
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Organisation"
+        title="Usage"
+        subtitle="Plan, limits, counters across every campus."
+      />
+
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
-          icon={<MapIcon fontSize="small" />}
+          icon={<Building2 size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
-          label="Campus maps"
+          label="Campuses"
         />
         <StatCard
-          icon={<PlaceIcon fontSize="small" />}
+          icon={<MapPin size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
-          label="Total POIs"
+          label="POIs across maps"
         />
         <StatCard
-          icon={<ApartmentIcon fontSize="small" />}
+          icon={<Accessibility size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
-          label="Floor plans"
+          label="Accessible POIs"
         />
         <StatCard
-          icon={<VisibilityIcon fontSize="small" />}
+          icon={<Eye size={18} strokeWidth={1.75} aria-hidden />}
           value="—"
-          label="Views (30d)"
+          label="Public views (30d)"
         />
       </div>
 
-      <section className="space-y-4">
-        <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-text-tertiary">
+      <section className="mt-10 space-y-4">
+        <h2 className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
           Plan
         </h2>
         <Panel className="rounded-2xl p-5">
@@ -45,31 +55,11 @@ export default async function SettingsUsagePage() {
             Pro · €5k / yr
           </div>
           <p className="mt-1 max-w-prose text-sm text-text-secondary">
-            Detailed usage, plan limits, and invoicing land here once billing is
-            wired. Contact us to adjust your plan meanwhile.
+            Detailed usage, plan limits, and invoicing land here once billing
+            is wired. Contact us to adjust your plan in the meantime.
           </p>
         </Panel>
       </section>
     </div>
-  );
-}
-
-function StatCard({
-  icon,
-  value,
-  label,
-}: {
-  icon: ReactNode;
-  value: string;
-  label: string;
-}) {
-  return (
-    <Panel className="rounded-2xl p-5">
-      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-soft text-accent">
-        {icon}
-      </div>
-      <div className="mt-4 text-2xl font-light text-text-primary">{value}</div>
-      <div className="mt-0.5 text-sm text-text-secondary">{label}</div>
-    </Panel>
   );
 }


### PR DESCRIPTION
Phase 2 of the [backoffice redesign](https://github.com/prieston/klorad/blob/main). Picks up the shell shipped in #174 and lands the first set of real authoring chrome — the org-scope screens (Overview / Campuses / Team / Settings / Usage).

## Shared primitives — \`app/(dashboard)/components/\`

| Component | Role |
|---|---|
| \`PageHeader\` | Eyebrow + title + subtitle + actions slot. Top of every backoffice screen, same place for primary actions. |
| \`StatCard\` | Icon tile + big number + label + optional trend line. Single source for KPI cards. |
| \`CampusCard\` | Gradient banner + name + Published/Draft pill + optional stats + Open link. Reused on Overview's \"Most active\" + Campuses grid. |
| \`campusBanner.ts\` | djb2 hash → 8-hue palette so the same campus always lands on the same colour across screens, without storing one in the schema. |
| \`OrgWorldMap\` | Promoted from the old \`LocationsHeader\` to a first-class component. The only surviving Mapbox surface per [[campus-indoor-mappedin-decision]]. |

## Per-screen changes

**Org Overview** (\`/dashboard\`) — full rebuild. Org name + Invite team / New campus actions, Mapbox world map as a 260px hero, four stat cards (Campuses shows a real \"X published · Y draft\" trend; the rest stubbed \"—\" rather than fake numbers), \"Most active campuses\" rail sorted by \`updatedAt\`. Quick Actions section dropped — wasn't in the mocks. All MUI icons → lucide.

**Org Campuses** (\`/maps\`) — full rebuild. Search input + All / Published / Drafts pill tabs with live counts. Grid of \`CampusCard\`s. \"Add a campus\" dashed tile at the grid's end so creating one feels native. The world map removed from this screen (now lives at Overview only — single source of truth for the locations view). Create modal kept; the per-card delete affordance moves to each campus's Settings → Danger zone in a later phase.

**Org Team** (\`/settings/members\`) — \`PageHeader\` added, Invite-member action hoisted into it. Four MUI icons swapped to lucide (\`Trash2\`, \`X\`, \`Copy\`, \`UserPlus\`). The member-management UI inside stays as-is — full sweep is Phase 6.

**Org Settings** (\`/settings/general\`) — \`PageHeader\` added, Save / Cancel actions moved into it. Existing form intact.

**Org Usage** (\`/settings/usage\`) — small full rewrite. \`PageHeader\`, \`StatCard\` primitives, lucide icons. Numbers stay \"—\" until analytics lands.

## Trust honesty

Numbers we don't have a backend for render as \`\"—\"\` rather than fake placeholders. The rector sees what's real.

## Out of scope

- Audit log feed on Team — no \`AuditLog\` model exists yet; that section gets added when the model lands.
- Custom domain section on Settings — Phase 5 (or whenever the CNAME issuance flow ships).
- Plan & billing — Phase 5 / billing arc.
- Inner MUI usage in the member-management UI — Phase 6 sweep.

## Test plan

- [ ] Visit \`/org/[orgId]/dashboard\` — header + map + 4 stats + Most active campuses rail render; Mapbox map shows pins for campuses with \`center\` set
- [ ] Visit \`/org/[orgId]/maps\` — search filters by name; tabs filter by publication state; counts match
- [ ] \"Add a campus\" tile + \"New campus\" header button both open the create modal
- [ ] Open a campus card → drills into \`/maps/[mapId]\` (Phase 1 shell renders the campus rail)
- [ ] \`/org/[orgId]/settings/members\` shows the PageHeader + Invite action; member list still works
- [ ] \`/org/[orgId]/settings/general\` shows the PageHeader + Save action; form still works
- [ ] \`/org/[orgId]/settings/usage\` renders new StatCard layout
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)