### PR TITLE
feat(campus): backoffice campus dashboard — Phase 3 of redesign

### DIFF
--- a/apps/campus/app/(dashboard)/components/CampusHealthCard.tsx
+++ b/apps/campus/app/(dashboard)/components/CampusHealthCard.tsx
@@ -1,0 +1,89 @@
+import { Check } from "lucide-react";
+import type { CampusHealth } from "@/lib/campus-health";
+
+interface Props {
+  health: CampusHealth | null;
+  isLoading?: boolean;
+}
+
+/**
+ * The 2-column checklist on the Campus Dashboard. Each row is one of
+ * the 8 readiness checks from `readCampusHealth`. Top progress bar
+ * makes the X/Y read at a glance — "5/8 done" beats "5 done".
+ *
+ * Renders a skeleton on cold load so the layout doesn't pop.
+ */
+export function CampusHealthCard({ health, isLoading }: Props) {
+  if (isLoading && !health) {
+    return (
+      <section className="rounded-2xl border border-line-soft bg-surface-1 p-6">
+        <div className="mb-4 h-4 w-32 animate-pulse rounded bg-surface-2" />
+        <div className="mb-6 h-1.5 w-full animate-pulse rounded-full bg-surface-2" />
+        <div className="grid gap-3 sm:grid-cols-2">
+          {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-xl bg-surface-2"
+            />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!health) return null;
+
+  const pct = Math.round((health.passed / health.total) * 100);
+
+  return (
+    <section className="rounded-2xl border border-line-soft bg-surface-1 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Campus health
+        </h2>
+        <span className="text-xs font-medium text-text-tertiary">
+          {health.passed} / {health.total}
+        </span>
+      </div>
+      <div
+        className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-surface-2"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className="h-full rounded-full bg-emerald-500 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {health.checks.map((c) => (
+          <li
+            key={c.key}
+            className="flex items-start gap-3 rounded-xl border border-line-soft bg-surface-2/40 p-3"
+          >
+            <span
+              aria-hidden
+              className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
+                c.done
+                  ? "bg-emerald-500 text-white"
+                  : "border border-line-strong text-text-tertiary"
+              }`}
+            >
+              {c.done ? <Check size={12} strokeWidth={3} /> : null}
+            </span>
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-text-primary">
+                {c.title}
+              </div>
+              <div className="mt-0.5 truncate text-xs text-text-tertiary">
+                {c.hint}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/JumpBackInTiles.tsx
+++ b/apps/campus/app/(dashboard)/components/JumpBackInTiles.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  Compass,
+  Home,
+  Megaphone,
+  Newspaper,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface Tile {
+  label: string;
+  href: string;
+  Icon: LucideIcon;
+}
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+/**
+ * The four shortcuts at the bottom of the campus dashboard — the
+ * surfaces rectors open most often. Routes are stable across the
+ * redesign per the agreed plan; only the labels track the new IA.
+ */
+export function JumpBackInTiles({ orgId, mapId }: Props) {
+  const prefix = `/org/${orgId}/maps/${mapId}`;
+  const tiles: Tile[] = [
+    { label: "Home", href: `${prefix}/home`, Icon: Home },
+    {
+      label: "Map & Wayfinding",
+      href: `${prefix}/map`,
+      Icon: Compass,
+    },
+    { label: "Post news", href: `${prefix}/news`, Icon: Newspaper },
+    {
+      label: "Send a broadcast",
+      href: `${prefix}/reach`,
+      Icon: Megaphone,
+    },
+  ];
+
+  return (
+    <section className="rounded-2xl border border-line-soft bg-surface-1 p-6">
+      <div className="mb-4">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Jump back in
+        </h2>
+        <p className="mt-0.5 text-xs text-text-tertiary">
+          The surfaces students open most.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {tiles.map((t) => (
+          <Link
+            key={t.href}
+            href={t.href}
+            className="group flex items-center justify-between gap-3 rounded-xl border border-line-soft bg-surface-2/40 px-4 py-3 transition-colors hover:border-line-strong hover:bg-surface-2"
+          >
+            <span className="flex items-center gap-3">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <t.Icon size={16} strokeWidth={1.75} aria-hidden />
+              </span>
+              <span className="text-sm font-medium text-text-primary">
+                {t.label}
+              </span>
+            </span>
+            <ArrowRight
+              size={14}
+              strokeWidth={1.75}
+              className="text-text-tertiary transition-colors group-hover:text-text-primary"
+              aria-hidden
+            />
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/WhatChangedCard.tsx
+++ b/apps/campus/app/(dashboard)/components/WhatChangedCard.tsx
@@ -1,0 +1,39 @@
+import { History } from "lucide-react";
+
+/**
+ * Stub of the What Changed activity feed for the campus dashboard.
+ *
+ * The IHU mocks show a list of recent attributed actions ("Maria
+ * Georgiou published news …" / "You changed primary colour to …"),
+ * but no AuditLog model exists in the schema yet. Rather than
+ * sprinkling fake entries that misrepresent the product, this card
+ * ships as an empty state until the audit-log arc lands.
+ *
+ * When that arc happens, this becomes a thin renderer over a real
+ * list — props change, layout stays.
+ */
+export function WhatChangedCard() {
+  return (
+    <section className="rounded-2xl border border-line-soft bg-surface-1 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-text-primary">
+          What changed
+        </h2>
+        <span className="text-xs text-text-tertiary">last 7 days</span>
+      </div>
+      <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+        <div
+          aria-hidden
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent"
+        >
+          <History size={18} strokeWidth={1.6} />
+        </div>
+        <p className="text-sm font-medium text-text-primary">No activity yet</p>
+        <p className="max-w-xs text-xs text-text-tertiary">
+          Edits to this campus appear here so the team can see what changed
+          and by whom.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
@@ -1,24 +1,23 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 import { toast as toastify } from "react-toastify";
 import useSWR from "swr";
-import EditIcon from "@mui/icons-material/Edit";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import ShareIcon from "@mui/icons-material/Share";
-import PublishIcon from "@mui/icons-material/Publish";
 import {
-  Badge,
-  Button,
-  WorkbenchStatTile,
-  cn,
-} from "@klorad/design-system";
-import OverviewTab from "./tabs/OverviewTab";
-import NewsTab from "./tabs/NewsTab";
-import IndoorTab from "./tabs/IndoorTab";
-import SettingsTab from "./tabs/SettingsTab";
-import IntegrationsTab from "./tabs/IntegrationsTab";
+  Accessibility,
+  Eye,
+  ExternalLink,
+  MapPin,
+  Share2,
+} from "lucide-react";
+import { Button } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { StatCard } from "@/app/(dashboard)/components/StatCard";
+import { CampusHealthCard } from "@/app/(dashboard)/components/CampusHealthCard";
+import { WhatChangedCard } from "@/app/(dashboard)/components/WhatChangedCard";
+import { JumpBackInTiles } from "@/app/(dashboard)/components/JumpBackInTiles";
+import { useCampusHealth } from "@/app/hooks/useCampusHealth";
+import { useOrganization } from "@/app/hooks/useOrganizations";
 
 interface Props {
   orgId: string;
@@ -30,202 +29,41 @@ interface CampusMap {
   name: string;
   updatedAt: string;
   createdAt: string;
-  sceneData?: unknown;
   thumbnail?: string | null;
   isPublished?: boolean;
 }
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-type TabKey = "overview" | "news" | "indoor" | "settings" | "integrations";
-const TABS: { key: TabKey; label: string }[] = [
-  { key: "overview", label: "Overview" },
-  { key: "news", label: "News" },
-  { key: "indoor", label: "Indoor" },
-  { key: "settings", label: "Settings" },
-  { key: "integrations", label: "Integrations" },
-];
-
 /**
- * Phase 0 of the production-polish arc — the campus profile hub.
+ * Campus Dashboard — Phase 3 of [[campus-backoffice-redesign]].
  *
- * What changed:
- *   - Hero now leads with a real status badge derived from the
- *     scene (Draft vs Published — persisted publish state ships
- *     in a follow-up commit).
- *   - Stats row gives a one-glance read of the campus's size +
- *     accessibility coverage.
- *   - Three primary CTAs (Edit / Open public viewer / Share) sit
- *     in the hero where buyers expect them. Share copies the
- *     public-viewer link — same flow the workbench top bar uses.
+ * Single-screen overview replacing the prior tab-based hub. The tabs
+ * (Overview / News / Indoor / Settings / Integrations) became
+ * first-class left-rail destinations in Phase 1, so this surface is
+ * now purely a glance-of-the-morning:
  *
- * The hero structure is intentionally generic so it lifts cleanly
- * into a `WorldProfileHero` DS primitive when the second vertical
- * (mobility / heritage / …) ships. For now it lives here.
+ *   header  → name + org context + Share + Open public viewer
+ *   stats   → 4 KPI cards (Public views, Push subscribers, POIs,
+ *             Accessibility); unbacked stats render "—" not fake data
+ *   left    → Campus Health checklist (server-side checks)
+ *   right   → What Changed feed (empty state until the audit log
+ *             arc lands)
+ *   bottom  → Jump back in shortcuts
  */
 export default function CampusProfileClient({ orgId, mapId }: Props) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const tabParam = searchParams.get("tab") as TabKey | null;
-  const activeTab: TabKey = TABS.some((t) => t.key === tabParam)
-    ? (tabParam as TabKey)
-    : "overview";
-
-  const { data: map, isLoading, mutate } = useSWR<CampusMap>(
+  const { data: map, isLoading } = useSWR<CampusMap>(
     `/api/maps/${mapId}`,
     fetcher,
   );
-
-  const setTab = (key: TabKey) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (key === "overview") params.delete("tab");
-    else params.set("tab", key);
-    const qs = params.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  };
-
-  if (!map && isLoading) {
-    return (
-      <div className="w-full space-y-3 px-6 py-8 md:px-10">
-        <div className="h-32 animate-pulse rounded-2xl bg-surface-2" />
-        <div className="h-12 animate-pulse rounded-xl bg-surface-2" />
-        <div className="h-80 animate-pulse rounded-2xl bg-surface-2" />
-      </div>
-    );
-  }
-
-  if (!map) {
-    return (
-      <div className="w-full px-6 py-8 md:px-10">
-        <p className="text-sm text-red-600">Map not found.</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="w-full px-6 py-8 md:px-10">
-      <CampusProfileHero
-        orgId={orgId}
-        mapId={mapId}
-        map={map}
-        onMutate={mutate}
-      />
-
-      <div className="mt-8 flex gap-1 border-b border-line-soft">
-        {TABS.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            onClick={() => setTab(t.key)}
-            className={cn(
-              "relative px-3 py-2.5 text-sm font-medium transition-colors",
-              activeTab === t.key
-                ? "text-text-primary"
-                : "text-text-secondary hover:text-text-primary",
-            )}
-          >
-            {t.label}
-            {activeTab === t.key && (
-              <span className="absolute inset-x-0 -bottom-px h-0.5 rounded-full bg-accent" />
-            )}
-          </button>
-        ))}
-      </div>
-
-      <div className="pt-2">
-        {activeTab === "overview" && (
-          <OverviewTab orgId={orgId} mapId={mapId} map={map} />
-        )}
-        {activeTab === "news" && <NewsTab mapId={mapId} />}
-        {activeTab === "indoor" && (
-          <IndoorTab map={map} onConfigure={() => setTab("settings")} />
-        )}
-        {activeTab === "settings" && (
-          <SettingsTab orgId={orgId} mapId={mapId} map={map} />
-        )}
-        {activeTab === "integrations" && <IntegrationsTab mapId={mapId} />}
-      </div>
-    </div>
-  );
-}
-
-/* ─── Hero ────────────────────────────────────────────────────────── */
-
-interface CampusHeroPoi {
-  id: string;
-  meta?: {
-    poi?: {
-      accessibility?: { wheelchairAccessible?: boolean };
-      linkedBuilding?: unknown;
-    };
-  };
-}
-
-/**
- * Top-of-page hero: status, name, last-updated, four stat tiles, and
- * a context-aware action group.
- *
- * The CTAs reshape based on `isPublished`:
- *   - Draft (with ≥1 POI)  → [Publish] (primary), [Edit campus]
- *   - Draft (empty)        → [Edit campus] only (Publish disabled
- *                              with a tooltip)
- *   - Published            → [Share], [Open public viewer], [Edit campus]
- *
- * `onMutate` is the SWR revalidator from the parent — called after
- * a publish / unpublish so the badge and CTA shape update without
- * a page reload.
- *
- * Stays inline in `CampusProfileClient` for now. Lifts to a shared
- * `WorldProfileHero` DS primitive when the second vertical needs
- * it (`memory/reusable-feature-primitives.md`).
- */
-function CampusProfileHero({
-  orgId,
-  mapId,
-  map,
-  onMutate,
-}: {
-  orgId: string;
-  mapId: string;
-  map: CampusMap;
-  onMutate: () => Promise<unknown>;
-}) {
-  const router = useRouter();
-
-  const stats = useMemo(() => {
-    const scene = map.sceneData as
-      | { objects?: CampusHeroPoi[] }
-      | undefined;
-    const objects = scene?.objects ?? [];
-    const pois = objects.filter((o) => o?.meta?.poi);
-    const buildings = pois.filter((p) => p?.meta?.poi?.linkedBuilding);
-    const accessible = pois.filter(
-      (p) => p?.meta?.poi?.accessibility?.wheelchairAccessible,
-    );
-    return {
-      poiCount: pois.length,
-      buildingCount: buildings.length,
-      accessibleCount: accessible.length,
-      accessibilityPct:
-        pois.length > 0
-          ? Math.round((accessible.length / pois.length) * 100)
-          : 0,
-    };
-  }, [map.sceneData]);
-
-  const isPublished = Boolean(map.isPublished);
-  const status: { label: string; tone: "neutral" | "success" } = isPublished
-    ? { label: "Published", tone: "success" }
-    : { label: "Draft", tone: "neutral" };
+  const { health, isLoading: healthLoading } = useCampusHealth(mapId);
+  const { organization } = useOrganization(orgId);
+  const [shareBusy, setShareBusy] = useState(false);
 
   const publicUrl =
     typeof window !== "undefined"
       ? `${window.location.origin}/campus/${mapId}`
       : `/campus/${mapId}`;
-
-  const [shareBusy, setShareBusy] = useState(false);
-  const [publishBusy, setPublishBusy] = useState(false);
 
   const handleShare = async () => {
     if (typeof window === "undefined") return;
@@ -240,116 +78,122 @@ function CampusProfileHero({
     }
   };
 
-  const setPublished = async (next: boolean) => {
-    setPublishBusy(true);
-    try {
-      const res = await fetch(`/api/maps/${mapId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ isPublished: next }),
-      });
-      if (!res.ok) throw new Error("Patch failed");
-      await onMutate();
-      toastify.success(next ? "Campus published" : "Campus unpublished");
-    } catch {
-      toastify.error(
-        next ? "Couldn't publish the campus" : "Couldn't unpublish",
-      );
-    } finally {
-      setPublishBusy(false);
-    }
-  };
-
-  const canPublish = stats.poiCount > 0;
-
-  return (
-    <section className="space-y-5">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0 space-y-1.5">
-          <div className="flex items-center gap-2">
-            <Badge tone={status.tone}>{status.label}</Badge>
-            <span className="text-[0.7rem] text-text-tertiary">
-              Updated {new Date(map.updatedAt).toLocaleDateString()}
-            </span>
-          </div>
-          <h1 className="truncate text-2xl font-semibold tracking-tight text-text-primary">
-            {map.name}
-          </h1>
-        </div>
-
-        <div className="flex shrink-0 flex-wrap items-center gap-2">
-          {isPublished ? (
-            <>
-              <Button
-                variant="secondary"
-                onClick={handleShare}
-                disabled={shareBusy}
-              >
-                <ShareIcon fontSize="small" />
-                {shareBusy ? "Copying…" : "Share"}
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() =>
-                  window.open(publicUrl, "_blank", "noopener,noreferrer")
-                }
-              >
-                <OpenInNewIcon fontSize="small" />
-                Open public viewer
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => setPublished(false)}
-                disabled={publishBusy}
-              >
-                {publishBusy ? "Working…" : "Unpublish"}
-              </Button>
-            </>
-          ) : (
-            <Button
-              onClick={() => setPublished(true)}
-              disabled={publishBusy || !canPublish}
-              title={
-                !canPublish
-                  ? "Add at least one POI before publishing"
-                  : undefined
-              }
-            >
-              <PublishIcon fontSize="small" />
-              {publishBusy ? "Publishing…" : "Publish"}
-            </Button>
-          )}
-          <Button
-            onClick={() =>
-              router.push(`/org/${orgId}/maps/${mapId}/workbench`)
-            }
-          >
-            <EditIcon fontSize="small" />
-            Edit campus
-          </Button>
+  if (!map && isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-[1280px] space-y-4 px-6 py-8 md:px-10">
+        <div className="h-16 animate-pulse rounded-2xl bg-surface-2" />
+        <div className="h-32 animate-pulse rounded-2xl bg-surface-2" />
+        <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+          <div className="h-96 animate-pulse rounded-2xl bg-surface-2" />
+          <div className="h-96 animate-pulse rounded-2xl bg-surface-2" />
         </div>
       </div>
+    );
+  }
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <WorkbenchStatTile label="POIs" value={stats.poiCount} />
-        <WorkbenchStatTile label="Buildings" value={stats.buildingCount} />
-        <WorkbenchStatTile
-          label="Accessible"
-          value={stats.accessibleCount}
-          hint={`${stats.accessibilityPct}% of POIs`}
+  if (!map) {
+    return (
+      <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+        <p className="text-sm text-red-600">Campus not found.</p>
+      </div>
+    );
+  }
+
+  const isPublished = Boolean(map.isPublished);
+
+  return (
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Overview"
+        title={map.name}
+        subtitle={organization?.name ?? undefined}
+        actions={
+          <>
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${
+                isPublished
+                  ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                  : "bg-text-tertiary/10 text-text-tertiary"
+              }`}
+            >
+              <span
+                aria-hidden
+                className={`h-1.5 w-1.5 rounded-full ${
+                  isPublished ? "bg-emerald-500" : "bg-text-tertiary"
+                }`}
+              />
+              {isPublished ? "Published" : "Draft"}
+            </span>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleShare}
+              disabled={shareBusy || !isPublished}
+              title={
+                !isPublished ? "Publish the campus to share it" : undefined
+              }
+            >
+              <Share2 size={14} strokeWidth={1.75} aria-hidden />
+              {shareBusy ? "Copying…" : "Share"}
+            </Button>
+            <Button
+              size="sm"
+              onClick={() =>
+                window.open(publicUrl, "_blank", "noopener,noreferrer")
+              }
+            >
+              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
+              Open public viewer
+            </Button>
+          </>
+        }
+      />
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={<Eye size={18} strokeWidth={1.75} aria-hidden />}
+          value="—"
+          label="Public views (30d)"
         />
-        <WorkbenchStatTile
-          label="Status"
-          value={status.label}
-          hint={
-            !canPublish
-              ? "Add your first POI to publish"
-              : isPublished
-                ? "Reachable via the public link"
-                : "Not yet published"
+        <StatCard
+          icon={<MapPin size={18} strokeWidth={1.75} aria-hidden />}
+          value="—"
+          label="Push subscribers"
+        />
+        <StatCard
+          icon={<MapPin size={18} strokeWidth={1.75} aria-hidden />}
+          value={health ? String(health.counts.pois) : "—"}
+          label="Points of interest"
+          trend={
+            health && health.counts.buildings > 0
+              ? `across ${health.counts.buildings} buildings`
+              : undefined
+          }
+        />
+        <StatCard
+          icon={<Accessibility size={18} strokeWidth={1.75} aria-hidden />}
+          value={
+            health && health.counts.pois > 0
+              ? `${health.counts.accessibilityPct}%`
+              : "—"
+          }
+          label="Accessibility"
+          trend={
+            health && health.counts.accessibleSpaces > 0
+              ? `${health.counts.accessibleSpaces} step-free tagged`
+              : undefined
           }
         />
       </div>
-    </section>
+
+      <div className="mt-8 grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <CampusHealthCard health={health} isLoading={healthLoading} />
+        <WhatChangedCard />
+      </div>
+
+      <div className="mt-4">
+        <JumpBackInTiles orgId={orgId} mapId={mapId} />
+      </div>
+    </div>
   );
 }

--- a/apps/campus/app/api/maps/[mapId]/health/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/health/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { requireCampusAccess } from "@/lib/authz";
+import { readCampusHealth } from "@/lib/campus-health";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * `GET /api/maps/[mapId]/health` — returns the Campus Health snapshot
+ * feeding the campus dashboard's checklist + KPI cards.
+ *
+ * One server hop replaces the 4 separate count queries the client
+ * would otherwise make (news / events / clubs / dining), and keeps
+ * raw row data on the server side — the dashboard only needs totals
+ * and booleans.
+ *
+ * Gated behind `requireCampusAccess` since the snapshot reveals
+ * unpublished state.
+ */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  const health = await readCampusHealth(mapId);
+  if (!health) return new NextResponse(null, { status: 404 });
+  return NextResponse.json(health);
+}

--- a/apps/campus/app/hooks/useCampusHealth.ts
+++ b/apps/campus/app/hooks/useCampusHealth.ts
@@ -1,0 +1,28 @@
+import useSWR from "swr";
+import type { CampusHealth } from "@/lib/campus-health";
+
+const fetcher = (url: string) =>
+  fetch(url, { credentials: "include" }).then((r) => {
+    if (!r.ok) throw new Error(String(r.status));
+    return r.json() as Promise<CampusHealth>;
+  });
+
+/**
+ * SWR-backed read of the campus health snapshot — drives the
+ * Campus Dashboard's checklist + the KPI cards. Reuses SWR's dedupe
+ * so two screens mounting this hook in the same tab share one
+ * round-trip.
+ */
+export function useCampusHealth(mapId: string | null | undefined) {
+  const { data, error, isLoading, mutate } = useSWR<CampusHealth>(
+    mapId ? `/api/maps/${mapId}/health` : null,
+    fetcher,
+    { revalidateOnFocus: true, dedupingInterval: 5000 },
+  );
+  return {
+    health: data ?? null,
+    error,
+    isLoading,
+    mutate,
+  };
+}

--- a/apps/campus/lib/campus-health.ts
+++ b/apps/campus/lib/campus-health.ts
@@ -1,0 +1,189 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+
+export interface HealthCheck {
+  /** Stable id used by the client to render an icon and order. */
+  key:
+    | "branding"
+    | "mappedin"
+    | "published"
+    | "news"
+    | "events"
+    | "clubs"
+    | "dining"
+    | "klio";
+  /** Title shown next to the green/empty dot. */
+  title: string;
+  /** One-line hint shown under the title. */
+  hint: string;
+  done: boolean;
+}
+
+export interface CampusHealth {
+  /** How many checks pass — drives the X/Y progress label. */
+  passed: number;
+  /** Total number of checks. */
+  total: number;
+  checks: HealthCheck[];
+  /** Counts surfaced separately so the dashboard can show them
+   *  in stat cards / hints without re-running the check arithmetic. */
+  counts: {
+    pois: number;
+    accessibleSpaces: number;
+    news: number;
+    events: number;
+    clubs: number;
+    dining: number;
+    /** % of POIs flagged wheelchair-accessible, 0–100. */
+    accessibilityPct: number;
+    /** Buildings linked by POIs. */
+    buildings: number;
+  };
+}
+
+interface ScenePoiObject {
+  meta?: {
+    poi?: {
+      accessibility?: { wheelchairAccessible?: boolean };
+      linkedBuilding?: unknown;
+    };
+  };
+}
+
+interface SceneShape {
+  objects?: ScenePoiObject[];
+  branding?: {
+    name?: string;
+    logo?: string;
+    primaryColor?: string;
+    indoorMapId?: string;
+  };
+}
+
+/**
+ * One-shot snapshot of a campus's readiness — drives the Campus
+ * Dashboard's Campus Health checklist + stat cards.
+ *
+ * Lives server-side so a single call counts News / Events / Clubs /
+ * Dining rows in parallel instead of the dashboard firing 4 separate
+ * fetches. Also avoids exposing per-row data the dashboard never
+ * needs — just totals and booleans.
+ *
+ * Each `done` check is a green dot on the dashboard; the count of
+ * passes is the progress bar's numerator.
+ */
+export async function readCampusHealth(mapId: string): Promise<CampusHealth | null> {
+  const [project, newsCount, eventsCount, clubsCount, diningCount] =
+    await Promise.all([
+      prisma.project.findUnique({
+        where: { id: mapId },
+        select: {
+          id: true,
+          title: true,
+          isPublished: true,
+          sceneData: true,
+          anthropicApiKeyEncrypted: true,
+        },
+      }),
+      prisma.newsPost.count({ where: { projectId: mapId } }).catch(() => 0),
+      prisma.eventPost.count({ where: { projectId: mapId } }).catch(() => 0),
+      prisma.club.count({ where: { projectId: mapId } }).catch(() => 0),
+      prisma.diningLocation
+        .count({ where: { projectId: mapId } })
+        .catch(() => 0),
+    ]);
+
+  if (!project) return null;
+
+  const scene = (project.sceneData ?? {}) as SceneShape;
+  const objects = scene.objects ?? [];
+  const pois = objects.filter((o) => o?.meta?.poi);
+  const accessibleSpaces = pois.filter(
+    (p) => p?.meta?.poi?.accessibility?.wheelchairAccessible,
+  ).length;
+  const buildings = pois.filter((p) => p?.meta?.poi?.linkedBuilding).length;
+  const accessibilityPct =
+    pois.length > 0 ? Math.round((accessibleSpaces / pois.length) * 100) : 0;
+
+  const branding = scene.branding ?? {};
+  const brandingDone = Boolean(
+    project.title && branding.logo && branding.primaryColor,
+  );
+  const mappedinDone = Boolean(branding.indoorMapId);
+  const klioDone = Boolean(project.anthropicApiKeyEncrypted);
+
+  const checks: HealthCheck[] = [
+    {
+      key: "branding",
+      title: "Branding is complete",
+      hint: "Name, logo and primary colour all set.",
+      done: brandingDone,
+    },
+    {
+      key: "mappedin",
+      title: "MappedIn venue connected",
+      hint: "Anchors can deep-link into the map.",
+      done: mappedinDone,
+    },
+    {
+      key: "published",
+      title: "Campus is published",
+      hint: "Drafts aren't visible to students.",
+      done: Boolean(project.isPublished),
+    },
+    {
+      key: "news",
+      title: "At least 1 news post",
+      hint:
+        newsCount > 0
+          ? `${newsCount} published`
+          : "Drives the home news rail.",
+      done: newsCount >= 1,
+    },
+    {
+      key: "events",
+      title: "3+ events scheduled",
+      hint: eventsCount > 0 ? `Currently ${eventsCount}` : "Powers Today.",
+      done: eventsCount >= 3,
+    },
+    {
+      key: "clubs",
+      title: "1+ club published",
+      hint: clubsCount > 0 ? `${clubsCount} clubs` : "Anchor of campus life.",
+      done: clubsCount >= 1,
+    },
+    {
+      key: "dining",
+      title: "1+ dining location",
+      hint:
+        diningCount > 0
+          ? `${diningCount} venues`
+          : "Drives Dining now on home.",
+      done: diningCount >= 1,
+    },
+    {
+      key: "klio",
+      title: "Klio enabled",
+      hint: klioDone
+        ? "Anthropic key set — Claude is live."
+        : "Add an API key to unlock the assistant.",
+      done: klioDone,
+    },
+  ];
+
+  return {
+    passed: checks.filter((c) => c.done).length,
+    total: checks.length,
+    checks,
+    counts: {
+      pois: pois.length,
+      accessibleSpaces,
+      news: newsCount,
+      events: eventsCount,
+      clubs: clubsCount,
+      dining: diningCount,
+      accessibilityPct,
+      buildings,
+    },
+  };
+}


### PR DESCRIPTION
Phase 3 of the [backoffice redesign](https://github.com/prieston/klorad/blob/main). Replaces the tab-based campus profile hub with the single-screen dashboard from the mocks. The tabs (Overview / News / Indoor / Settings / Integrations) became first-class left-rail destinations in Phase 1, so this surface no longer needs them — it's purely a glance-of-the-morning.

## Server side

**\`lib/campus-health.ts\`** — one-shot snapshot of a campus's readiness. Parallel Prisma queries for project + news / events / clubs / dining counts + POI / accessibility metrics from \`sceneData\`. Returns 8 readiness checks plus a \`counts\` block the dashboard's KPI cards consume.

| Check | Source |
|---|---|
| \`branding\` | logo + primary colour + title all set |
| \`mappedin\` | \`sceneData.branding.indoorMapId\` present |
| \`published\` | \`Project.isPublished\` |
| \`news\` | \`NewsPost\` count ≥ 1 |
| \`events\` | \`EventPost\` count ≥ 3 (Today rail needs the cushion) |
| \`clubs\` | \`Club\` count ≥ 1 |
| \`dining\` | \`DiningLocation\` count ≥ 1 |
| \`klio\` | \`Project.anthropicApiKeyEncrypted\` set |

No schema migration — all derived from existing data.

**\`/api/maps/[mapId]/health\`** — thin GET wrapper. Gated by \`requireCampusAccess(mapId, \"read\")\` since the snapshot reveals unpublished state. One server hop replaces the 4 separate count queries the client would otherwise fire.

## Client

**\`useCampusHealth\`** — SWR over \`/health\` with revalidate-on-focus + 5s dedupe.

**New components** in \`app/(dashboard)/components/\`:

- **\`CampusHealthCard\`** — 8-row 2-column checklist with a top progress bar. Green check disc on done, outline disc on pending. Skeleton on cold load.
- **\`WhatChangedCard\`** — empty-state-only for now. No \`AuditLog\` model exists yet; rather than ship fake entries this card sits in the layout with a \"No activity yet\" copy until the audit-log arc lands. Component shape is ready to be fed a real list when the model arrives.
- **\`JumpBackInTiles\`** — four shortcut tiles (Home / Map & Wayfinding / Post news / Send a broadcast) pointing at the rail destinations rectors open most.

**Rebuilt \`CampusProfileClient\`** — single screen:

- **Header**: PageHeader with campus name + org name subtitle + Published/Draft chip + Share + Open public viewer. Share is disabled until published (with a tooltip) since the link goes nowhere otherwise.
- **Stats**: 4 cards — Public views (—), Push subscribers (—), POIs (real), Accessibility (real %). Unbacked numbers render \"—\" so the rector trusts what's displayed.
- **Body**: 2-column at lg+ — CampusHealthCard on the left (2fr), WhatChangedCard on the right (1fr).
- **Footer**: JumpBackInTiles.

## What's gone

The tab bar, \`OverviewTab\`, \`NewsTab\`, \`IndoorTab\`, \`SettingsTab\`, \`IntegrationsTab\`, and the \`CampusProfileHero\` helper are no longer imported. Files left in place to be reviewed for delete in Phase 6 — none of them are referenced anywhere else in the tree.

## Test plan

- [ ] Visit \`/org/[orgId]/maps/[mapId]\` — single-screen dashboard renders
- [ ] Header shows campus name + org name + correct Published/Draft chip
- [ ] Share button disabled on Draft, enabled + copies link on Published
- [ ] Open public viewer opens \`/campus/[mapId]\` in a new tab
- [ ] Stats: POI count + accessibility % reflect real \`sceneData\`; Public views / Push subscribers stay \"—\"
- [ ] Campus Health card shows 8 rows with the right boolean per check; progress bar matches \`X/8\`
- [ ] What Changed empty state copy reads
- [ ] Each Jump-back-in tile drills to the right route
- [ ] Skeleton renders on cold load before SWR settles
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)