### PR TITLE
feat(campus): backoffice 4a — Home, Map & Wayfinding, Klio

### DIFF
--- a/apps/campus/app/(dashboard)/components/IndoorMapIdCard.tsx
+++ b/apps/campus/app/(dashboard)/components/IndoorMapIdCard.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR, { mutate as mutateGlobal } from "swr";
+import { toast } from "react-toastify";
+import { ExternalLink, Link2, Link2Off } from "lucide-react";
+import { Button, Field, Input, Panel } from "@klorad/design-system";
+
+interface Props {
+  mapId: string;
+}
+
+interface ServerMap {
+  sceneData?: { indoorMapId?: string } & Record<string, unknown>;
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => r.json() as Promise<ServerMap>);
+
+/**
+ * "MappedIn venue" config card on the Map & Wayfinding screen.
+ *
+ * Owns one knob — the campus's `indoorMapId`. Stored in
+ * `sceneData.indoorMapId` (same place the rest of the campus's map
+ * config lives); the public viewer reads it to spin up MappedIn.
+ *
+ * Mirrors the IHU mock — pill that shows Connected / Disconnected
+ * based on whether an id is set + linked to the saved value, an
+ * input row for editing, Save button. Status is computed from the
+ * *saved* id, not the draft, so the pill doesn't lie while you
+ * type.
+ */
+export function IndoorMapIdCard({ mapId }: Props) {
+  const { data: serverMap } = useSWR<ServerMap>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
+  const savedId = serverMap?.sceneData?.indoorMapId ?? "";
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Seed the input from the server exactly once — re-running this
+  // on every SWR revalidate (e.g. window-focus) would clobber an
+  // in-progress edit.
+  useEffect(() => {
+    if (hydrated || !serverMap) return;
+    setDraft(savedId);
+    setHydrated(true);
+  }, [hydrated, serverMap, savedId]);
+
+  const dirty = hydrated && draft.trim() !== savedId.trim();
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const nextSceneData = {
+        ...(serverMap?.sceneData ?? {}),
+        indoorMapId: draft.trim() || undefined,
+      };
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneData: nextSceneData }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      await mutateGlobal(`/api/maps/${mapId}`);
+      toast.success(draft.trim() ? "Venue linked" : "Venue disconnected");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isConnected = savedId.trim().length > 0;
+
+  return (
+    <Panel className="rounded-2xl p-6">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-text-primary">
+            MappedIn venue
+          </h2>
+          <p className="mt-0.5 text-xs text-text-tertiary">
+            Indoor 3D map, search &amp; wayfinding.
+          </p>
+        </div>
+        <span
+          className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${
+            isConnected
+              ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+              : "bg-text-tertiary/10 text-text-tertiary"
+          }`}
+        >
+          {isConnected ? (
+            <Link2 size={12} strokeWidth={1.75} aria-hidden />
+          ) : (
+            <Link2Off size={12} strokeWidth={1.75} aria-hidden />
+          )}
+          {isConnected ? "Connected" : "Not connected"}
+        </span>
+      </div>
+      <Field label="Indoor map ID">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="682c13a27f034f8800b56f6ab"
+          spellCheck={false}
+        />
+      </Field>
+      <p className="mt-2 text-xs text-text-tertiary">
+        Paste the MappedIn venue ID to enable the indoor viewer.
+      </p>
+      <div className="mt-4 flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+        {isConnected ? (
+          <a
+            href={`/campus/${mapId}/map`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs font-medium text-accent hover:underline"
+          >
+            <ExternalLink size={12} strokeWidth={1.75} aria-hidden />
+            Open public map
+          </a>
+        ) : null}
+      </div>
+    </Panel>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/CampusHomePageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/CampusHomePageClient.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ExternalLink, LayoutGrid } from "lucide-react";
+import { Button, Panel } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import HomePagePanel from "@/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+/**
+ * Home — composes the mobile home students see. Phase 4a hosts the
+ * existing bilingual hero / tagline / section-toggle editor under
+ * the new shell. Drag-to-reorder quick tiles is a follow-up — needs
+ * a `sceneData.homeTiles` schema and a reorder primitive.
+ */
+export default function CampusHomePageClient({
+  orgId: _orgId,
+  mapId,
+}: Props) {
+  return (
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="Home"
+        subtitle="Greeting, hero image and which home sections appear. EL + EN."
+        actions={
+          <a
+            href={`/campus/${mapId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button size="sm" variant="secondary">
+              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
+              Open public
+            </Button>
+          </a>
+        }
+      />
+
+      <div className="space-y-6">
+        <HomePagePanel mapId={mapId} />
+
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              <LayoutGrid size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Quick-action tiles
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                The four tiles under the greeting — Find a room, Get
+                directions, Today&rsquo;s events, Ask Klio. Reorder + pick
+                from a library.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+            Drag-to-reorder tile editor lands next.
+          </div>
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/page.tsx
@@ -1,11 +1,14 @@
-import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusHomePageClient from "./CampusHomePageClient";
 
-export default function CampusHomePage() {
-  return (
-    <ComingSoonScreen
-      title="Home"
-      hint="Greeting copy, quick-action tiles, section toggles — composes the mobile home students see."
-      phase="Phase 4"
-    />
-  );
+export default async function CampusHomePage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
+  return <CampusHomePageClient orgId={orgId} mapId={mapId} />;
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/CampusKlioPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/CampusKlioPageClient.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { ExternalLink, MessageSquare, Sliders, Wrench } from "lucide-react";
+import { Button, Panel } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { AiKeyPanel } from "@/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/AiKeyPanel";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+/**
+ * Klio — the AI campus assistant settings screen. Phase 4a ships the
+ * BYOK Anthropic key card (real, wired to `/ai-settings`) plus
+ * placeholder cards for the three knobs that need a backend before
+ * they can land: tools the assistant can call, persona sliders,
+ * suggestion chips. Those move to "Coming next" so the rail row
+ * resolves to something honest instead of dead UI.
+ */
+export default function CampusKlioPageClient({
+  orgId: _orgId,
+  mapId,
+}: Props) {
+  return (
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="Klio"
+        subtitle="The AI campus assistant, powered by Claude. BYOK Anthropic key, choose its tools and seed the prompts students see first."
+        actions={
+          <a
+            href={`/campus/${mapId}/klio`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button size="sm" variant="secondary">
+              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
+              Open public
+            </Button>
+          </a>
+        }
+      />
+
+      <div className="space-y-6">
+        <AiKeyPanel mapId={mapId} />
+
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              <Wrench size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Tools Klio can call
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Search news, lookup buildings, give directions, fetch events,
+                list clubs — toggle each on or off.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+            All tools on by default. Per-tool toggles land next.
+          </div>
+        </Panel>
+
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              <Sliders size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Persona &amp; tone
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Formal ↔ casual, English-first ↔ Greek-first, disclosure copy.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+            Sliders + tone copy land alongside the tool toggles.
+          </div>
+        </Panel>
+
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              <MessageSquare size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Suggestion chips
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                EL + EN prompts students see in the empty Klio state.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+            Editable chip list lands next.
+          </div>
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/page.tsx
@@ -1,11 +1,14 @@
-import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusKlioPageClient from "./CampusKlioPageClient";
 
-export default function CampusKlioPage() {
-  return (
-    <ComingSoonScreen
-      title="Klio"
-      hint="BYOK Anthropic key, tool toggles, persona sliders, suggestion chips for the empty state."
-      phase="Phase 4"
-    />
-  );
+export default async function CampusKlioPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
+  return <CampusKlioPageClient orgId={orgId} mapId={mapId} />;
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/CampusMapPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/CampusMapPageClient.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Compass, ExternalLink, Route } from "lucide-react";
+import { Button, Panel } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { IndoorMapIdCard } from "@/app/(dashboard)/components/IndoorMapIdCard";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+/**
+ * Map & Wayfinding — thin authoring surface per
+ * [[campus-indoor-mappedin-decision]]. Klorad doesn't own buildings,
+ * POIs or rooms — MappedIn does. So this screen is about linking the
+ * venue and curating shareable routes; the rest is authored in
+ * MappedIn's hosted tools.
+ *
+ * Phase 4a ships the venue link + Saved Routes empty state. The
+ * Saved Routes editor + default-floor selector land in a follow-up
+ * once the data model + MappedIn space picker primitive are in
+ * place.
+ */
+export default function CampusMapPageClient({ orgId: _orgId, mapId }: Props) {
+  return (
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="Map & Wayfinding"
+        subtitle="Link the MappedIn venue and curate the routes worth sharing."
+        actions={
+          <a
+            href={`/campus/${mapId}/map`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button size="sm" variant="secondary">
+              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
+              Open public
+            </Button>
+          </a>
+        }
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <IndoorMapIdCard mapId={mapId} />
+
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">
+                Default floor
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Which floor the public viewer opens on.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-line-soft bg-surface-2/40 py-8 text-center">
+            <Compass
+              size={20}
+              strokeWidth={1.6}
+              className="text-text-tertiary"
+              aria-hidden
+            />
+            <p className="text-xs text-text-tertiary">
+              Floor selector lands once a venue is linked.
+            </p>
+          </div>
+        </Panel>
+      </div>
+
+      <section className="mt-6">
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">
+                Saved routes
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Pre-computed From → To routes that students can share via QR
+                or deep link.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent">
+              <Route size={18} strokeWidth={1.6} aria-hidden />
+            </div>
+            <p className="text-sm font-medium text-text-primary">
+              No saved routes yet
+            </p>
+            <p className="max-w-sm text-xs text-text-tertiary">
+              Curate a route — Library → Main Cafeteria, say — and we&rsquo;ll
+              generate a QR code students can scan from a printed sign.
+            </p>
+            <span className="mt-2 text-[10px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+              Coming next
+            </span>
+          </div>
+        </Panel>
+      </section>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/page.tsx
@@ -1,11 +1,14 @@
-import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusMapPageClient from "./CampusMapPageClient";
 
-export default function CampusMapPage() {
-  return (
-    <ComingSoonScreen
-      title="Map & Wayfinding"
-      hint="Link the MappedIn venue, set the default floor, curate saved routes for QR sharing."
-      phase="Phase 4"
-    />
-  );
+export default async function CampusMapPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
+  return <CampusMapPageClient orgId={orgId} mapId={mapId} />;
 }


### PR DESCRIPTION
Phase 4a of the [backoffice redesign](https://github.com/prieston/klorad/blob/main). Replaces the \`ComingSoonScreen\` stubs at \`/home\`, \`/map\`, and \`/klio\` with real authoring shells that reuse existing panel logic under the new IA.

Lean by design: the heavy bespoke pieces (drag-to-reorder tiles, tool toggles, persona sliders, saved-routes editor, MappedIn space picker) are flagged as \"Coming next\" cards on the same screen so the shape is in place when they land.

## New primitive

**\`IndoorMapIdCard\`** — MappedIn venue config card. Owns \`sceneData.indoorMapId\`. Hydrates once from the server (SWR window-focus revalidates can't clobber in-progress edits), shows a Connected / Not connected pill driven by the *saved* id (not the draft, so the pill doesn't lie while you type), and exposes an Open public map link when an id is set.

## Per-screen

### Map & Wayfinding (\`/maps/[mapId]/map\`)
PageHeader + Open public action. Two-column body:
- \`IndoorMapIdCard\` — real
- Default floor — placeholder card (needs the venue-aware floor list before it can ship for real)

Full-width \"Saved routes\" card with an empty state that makes the Library → Cafeteria QR story tangible without pretending the editor exists.

### Klio (\`/maps/[mapId]/klio\`)
PageHeader + Open public action. Sections, in order:
- **\`AiKeyPanel\`** — real, reused as-is. BYOK Anthropic key with mask + Save + Test wired to \`/ai-settings\`
- Tools Klio can call — placeholder
- Persona & tone — placeholder
- Suggestion chips — placeholder

Each placeholder names exactly what's coming so the rail row feels intentional, not abandoned.

### Home (\`/maps/[mapId]/home\`)
PageHeader + Open public action. Wraps the existing \`HomePagePanel\` (real — bilingual greeting + tagline + hero image upload + section toggles, all persisted to \`sceneData.homePage\`) + a Quick-action tiles placeholder for the drag-to-reorder editor that lands next.

## What's not in this PR

- **Live phone preview iframe** — deferred to Phase 4b where the pattern pays off most (rolling across News / Events / Clubs / Dining at once).
- **Saved Routes editor** — needs MappedIn space picker primitive first.
- **Klio tool toggles / persona / chips** — placeholders only until each has a backing schema.
- **Quick-action tiles drag editor** — placeholder; needs \`sceneData.homeTiles\` schema + reorder primitive.

## Test plan

- [ ] \`/org/[orgId]/maps/[mapId]/map\` — IndoorMapIdCard saves an id; pill flips to Connected; Open public map link appears
- [ ] \`/org/[orgId]/maps/[mapId]/klio\` — AiKeyPanel still saves + tests against \`/ai-settings\`; three placeholder cards render
- [ ] \`/org/[orgId]/maps/[mapId]/home\` — HomePagePanel still loads, saves bilingual fields, uploads a hero
- [ ] Open public links open the right public route in a new tab
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)