### PR TITLE
feat(campus): backoffice 4b — News/Events/Clubs/Dining chrome + PhonePreview pilot

### DIFF
--- a/apps/campus/app/(dashboard)/components/OpenPublicAction.tsx
+++ b/apps/campus/app/(dashboard)/components/OpenPublicAction.tsx
@@ -1,0 +1,27 @@
+import { ExternalLink } from "lucide-react";
+import { Button } from "@klorad/design-system";
+
+interface Props {
+  /** Public-side route to open in a new tab. */
+  href: string;
+  /** Override label — defaults to "Open public". */
+  label?: string;
+}
+
+/**
+ * The "Open public" pill that sits in every public-surface authoring
+ * screen's header. Wraps the design-system `Button` in a target=_blank
+ * anchor so the rector can compare draft + public state side by side
+ * on a real second monitor — the in-page `PhonePreview` covers the
+ * single-monitor flow.
+ */
+export function OpenPublicAction({ href, label = "Open public" }: Props) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      <Button size="sm" variant="secondary">
+        <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
+        {label}
+      </Button>
+    </a>
+  );
+}

--- a/apps/campus/app/(dashboard)/components/PhonePreview.tsx
+++ b/apps/campus/app/(dashboard)/components/PhonePreview.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+
+interface Props {
+  /** URL to load in the iframe — typically the matching public route. */
+  src: string;
+  /** Optional aria-label for the iframe. */
+  title?: string;
+  /**
+   * Bump this to programmatically reload the iframe — e.g. after a
+   * save round-trip. Increment a counter in the parent and pass it
+   * here; the iframe re-mounts when the key changes.
+   */
+  reloadToken?: number;
+}
+
+/**
+ * The phone-frame iframe shown beside every public-surface authoring
+ * screen. Shows the live public page so rectors can see exactly what
+ * students will see — without context-switching to a new tab.
+ *
+ * Implementation note: the cheapest correct preview is to load the
+ * *real* public route and let the rector hit Refresh after a save.
+ * A push-based draft channel (websocket / postMessage) is the
+ * obvious upgrade but only earns its complexity when the rector
+ * needs sub-second feedback on every keystroke; for now a one-click
+ * refresh after a Save toast covers the demo + the daily workflow.
+ *
+ * The phone bezel uses CSS only — no asset to load, no broken image
+ * on slow networks.
+ */
+export function PhonePreview({
+  src,
+  title = "Public preview",
+  reloadToken = 0,
+}: Props) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [manualReloads, setManualReloads] = useState(0);
+
+  const reload = useCallback(() => {
+    setManualReloads((n) => n + 1);
+  }, []);
+
+  // Re-mount the iframe when either the parent bumps `reloadToken`
+  // or the visitor clicks Refresh. Re-mounting (via `key`) instead of
+  // mutating `iframe.src` avoids the cross-origin "can't access
+  // contentWindow" headaches when src is the production host.
+  const renderKey = `${reloadToken}-${manualReloads}`;
+
+  // Auto-reload on focus return — opens the same surface in a new
+  // tab and you tab back, you want fresh state. Guarded so it
+  // doesn't fire during the very first mount (which would just
+  // wastefully re-fetch the page we just loaded).
+  const mounted = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  return (
+    <div className="sticky top-6 flex flex-col items-center gap-3">
+      <div className="flex items-center justify-between gap-2 self-stretch">
+        <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+          Live · public
+        </span>
+        <button
+          type="button"
+          onClick={reload}
+          aria-label="Refresh preview"
+          className="inline-flex items-center gap-1 rounded-full border border-line-soft bg-surface-1 px-2.5 py-1 text-[11px] font-medium text-text-secondary transition-colors hover:border-line-strong hover:text-text-primary"
+        >
+          <RefreshCw size={11} strokeWidth={1.75} aria-hidden />
+          Refresh
+        </button>
+      </div>
+      {/* Phone bezel — pure CSS, no asset. Roughly iPhone 14 ratio. */}
+      <div
+        className="relative h-[640px] w-[300px] overflow-hidden rounded-[36px] border-[6px] border-[#1a1a1a] bg-[#1a1a1a] shadow-2xl"
+        aria-label="Phone frame"
+      >
+        {/* Notch */}
+        <div
+          aria-hidden
+          className="absolute left-1/2 top-1.5 z-10 h-4 w-20 -translate-x-1/2 rounded-full bg-[#1a1a1a]"
+        />
+        <iframe
+          key={renderKey}
+          ref={iframeRef}
+          src={src}
+          title={title}
+          loading="lazy"
+          className="h-full w-full bg-white"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/page.tsx
@@ -1,18 +1,16 @@
 import { notFound, redirect } from "next/navigation";
-import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { listClubsForAdmin } from "@/lib/clubs-db";
 import { ClubsAdminClient } from "./ClubsAdminClient";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
 
 /**
- * `/org/[orgId]/maps/[mapId]/clubs` — admin clubs authoring.
- *
- * Lists clubs (name asc) + an inline create form. Backed by the
- * `Club` model from Arc 4 of [[campus-consumer-pivot]].
+ * `/org/[orgId]/maps/[mapId]/clubs` — admin clubs authoring under
+ * the new backoffice IA.
  */
 export default async function ClubsAdminPage({
   params,
@@ -43,23 +41,13 @@ export default async function ClubsAdminPage({
   const clubs = await listClubsForAdmin(mapId);
 
   return (
-    <div className="mx-auto max-w-[960px] px-6 py-10">
-      <Link
-        href={`/org/${orgId}/maps/${mapId}`}
-        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
-      >
-        <ChevronLeft size={14} strokeWidth={1.75} />
-        Back to {project.title}
-      </Link>
-
-      <div className="mt-6">
-        <h1 className="text-2xl font-semibold text-text-primary">Clubs</h1>
-        <p className="mt-1 text-sm text-text-tertiary">
-          Student societies, sport clubs, interest groups. The View
-          button on the consumer site opens the club&apos;s external
-          link — no login on the public site.
-        </p>
-      </div>
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="Clubs"
+        subtitle="Student societies, ranked by weight. Featured clubs appear on the home rail."
+        actions={<OpenPublicAction href={`/campus/${mapId}/clubs`} />}
+      />
 
       <ClubsAdminClient mapId={mapId} initialClubs={clubs} />
     </div>

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/page.tsx
@@ -1,19 +1,16 @@
 import { notFound, redirect } from "next/navigation";
-import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { listDiningForProject } from "@/lib/dining-db";
 import { DiningAdminClient } from "./DiningAdminClient";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
 
 /**
- * `/org/[orgId]/maps/[mapId]/dining` — admin dining authoring.
- *
- * Smallest of the four content admins because dining rows hold
- * less variability — name + description + free-text hours + optional
- * menu link + optional cuisine.
+ * `/org/[orgId]/maps/[mapId]/dining` — admin dining authoring under
+ * the new backoffice IA.
  */
 export default async function DiningAdminPage({
   params,
@@ -47,24 +44,13 @@ export default async function DiningAdminPage({
   const locations = await listDiningForProject(mapId);
 
   return (
-    <div className="mx-auto max-w-[960px] px-6 py-10">
-      <Link
-        href={`/org/${orgId}/maps/${mapId}`}
-        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
-      >
-        <ChevronLeft size={14} strokeWidth={1.75} />
-        Back to {project.title}
-      </Link>
-
-      <div className="mt-6">
-        <h1 className="text-2xl font-semibold text-text-primary">
-          Dining
-        </h1>
-        <p className="mt-1 text-sm text-text-tertiary">
-          Cafeterias, cafes, food courts. Listed alphabetically on
-          the public dining page.
-        </p>
-      </div>
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="Dining"
+        subtitle='Cafes and canteens. "Open now" is computed from weekly hours — no manual toggle.'
+        actions={<OpenPublicAction href={`/campus/${mapId}/dining`} />}
+      />
 
       <DiningAdminClient
         mapId={mapId}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
@@ -1,6 +1,4 @@
 import { notFound, redirect } from "next/navigation";
-import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { listEventsForAdmin } from "@/lib/events-db";
@@ -8,16 +6,16 @@ import { readEventFeeds } from "@/lib/events";
 import { EventsAdminClient } from "./EventsAdminClient";
 import { IcsFeedsManager } from "./IcsFeedsManager";
 import { NotifyForm } from "./NotifyForm";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
 
 /**
- * `/org/[orgId]/maps/[mapId]/events` — admin events authoring.
- *
- * Lists events (newest scheduled first) + an inline create form.
- * Backed by the `EventPost` model from Arc 3 of
- * [[campus-consumer-pivot]]. ICS-feed-sourced recurring events are
- * untouched and continue to render via `events-server.ts`.
+ * `/org/[orgId]/maps/[mapId]/events` — admin events authoring under
+ * the new backoffice IA. Ships under `PageHeader`; the rail handles
+ * "back to campus" so the inline back link is gone. The phone
+ * preview pane lands in a follow-up — News is the Phase 4b pilot.
  */
 export default async function EventsAdminPage({
   params,
@@ -52,37 +50,26 @@ export default async function EventsAdminPage({
   const events = await listEventsForAdmin(mapId);
 
   return (
-    <div className="mx-auto max-w-[960px] px-6 py-10">
-      <Link
-        href={`/org/${orgId}/maps/${mapId}`}
-        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
-      >
-        <ChevronLeft size={14} strokeWidth={1.75} />
-        Back to {project.title}
-      </Link>
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="Events"
+        subtitle="Native events plus synced ICS feeds. Flag the ones that bubble into Happening today."
+        actions={<OpenPublicAction href={`/campus/${mapId}/events`} />}
+      />
 
-      <div className="mt-6">
-        <h1 className="text-2xl font-semibold text-text-primary">
-          Events
-        </h1>
-        <p className="mt-1 text-sm text-text-tertiary">
-          Anything happening on campus — pinned to a building or room.
-          Recurring ICS feeds keep rendering separately.
-        </p>
+      <div className="space-y-6">
+        <EventsAdminClient
+          mapId={mapId}
+          initialEvents={events}
+          indoorMapId={indoorMapId}
+        />
+        <IcsFeedsManager mapId={mapId} initialFeeds={initialFeeds} />
+        <NotifyForm
+          mapId={mapId}
+          enabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}
+        />
       </div>
-
-      <IcsFeedsManager mapId={mapId} initialFeeds={initialFeeds} />
-
-      <NotifyForm
-        mapId={mapId}
-        enabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}
-      />
-
-      <EventsAdminClient
-        mapId={mapId}
-        initialEvents={events}
-        indoorMapId={indoorMapId}
-      />
     </div>
   );
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/CampusHomePageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/home/CampusHomePageClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ExternalLink, LayoutGrid } from "lucide-react";
-import { Button, Panel } from "@klorad/design-system";
+import { LayoutGrid } from "lucide-react";
+import { Panel } from "@klorad/design-system";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 import HomePagePanel from "@/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel";
 
 interface Props {
@@ -26,18 +27,7 @@ export default function CampusHomePageClient({
         eyebrow="Public surface"
         title="Home"
         subtitle="Greeting, hero image and which home sections appear. EL + EN."
-        actions={
-          <a
-            href={`/campus/${mapId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button size="sm" variant="secondary">
-              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
-              Open public
-            </Button>
-          </a>
-        }
+        actions={<OpenPublicAction href={`/campus/${mapId}`} />}
       />
 
       <div className="space-y-6">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/CampusKlioPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/CampusKlioPageClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ExternalLink, MessageSquare, Sliders, Wrench } from "lucide-react";
-import { Button, Panel } from "@klorad/design-system";
+import { MessageSquare, Sliders, Wrench } from "lucide-react";
+import { Panel } from "@klorad/design-system";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 import { AiKeyPanel } from "@/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/AiKeyPanel";
 
 interface Props {
@@ -28,18 +29,7 @@ export default function CampusKlioPageClient({
         eyebrow="Public surface"
         title="Klio"
         subtitle="The AI campus assistant, powered by Claude. BYOK Anthropic key, choose its tools and seed the prompts students see first."
-        actions={
-          <a
-            href={`/campus/${mapId}/klio`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button size="sm" variant="secondary">
-              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
-              Open public
-            </Button>
-          </a>
-        }
+        actions={<OpenPublicAction href={`/campus/${mapId}/klio`} />}
       />
 
       <div className="space-y-6">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/CampusMapPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/CampusMapPageClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Compass, ExternalLink, Route } from "lucide-react";
-import { Button, Panel } from "@klorad/design-system";
+import { Compass, Route } from "lucide-react";
+import { Panel } from "@klorad/design-system";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
 import { IndoorMapIdCard } from "@/app/(dashboard)/components/IndoorMapIdCard";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 
 interface Props {
   orgId: string;
@@ -29,18 +30,7 @@ export default function CampusMapPageClient({ orgId: _orgId, mapId }: Props) {
         eyebrow="Public surface"
         title="Map & Wayfinding"
         subtitle="Link the MappedIn venue and curate the routes worth sharing."
-        actions={
-          <a
-            href={`/campus/${mapId}/map`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button size="sm" variant="secondary">
-              <ExternalLink size={14} strokeWidth={1.75} aria-hidden />
-              Open public
-            </Button>
-          </a>
-        }
+        actions={<OpenPublicAction href={`/campus/${mapId}/map`} />}
       />
 
       <div className="grid gap-4 lg:grid-cols-2">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
@@ -1,20 +1,24 @@
 import { notFound, redirect } from "next/navigation";
-import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { listNewsForAdmin } from "@/lib/news";
 import { NewsAdminClient } from "./NewsAdminClient";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { PhonePreview } from "@/app/(dashboard)/components/PhonePreview";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
 
 /**
- * `/org/[orgId]/maps/[mapId]/news` — the new news authoring surface.
+ * `/org/[orgId]/maps/[mapId]/news` — news authoring under the new
+ * backoffice IA. The left rail handles "back to campus" navigation,
+ * so this page no longer needs an inline back link; `PageHeader` is
+ * the consistent chrome across every rail destination.
  *
- * Lists news posts on this campus + an inline create form. Backed by
- * the `NewsPost` model added in Arc 2 of [[campus-consumer-pivot]].
- * The legacy tab in `CampusProfileClient` (`NewsTab`) is untouched —
- * existing bilingual posts in `sceneData.posts` keep their editor.
+ * The phone preview on the right is the Phase 4b pilot of the
+ * preview pattern — see `PhonePreview`. The pane loads the public
+ * news route; the rector hits Refresh after Save to see the new
+ * post land.
  */
 export default async function NewsAdminPage({
   params,
@@ -48,28 +52,29 @@ export default async function NewsAdminPage({
   const posts = await listNewsForAdmin(mapId);
 
   return (
-    <div className="mx-auto max-w-[960px] px-6 py-10">
-      <Link
-        href={`/org/${orgId}/maps/${mapId}`}
-        className="inline-flex items-center gap-1 text-xs text-text-tertiary transition-colors hover:text-text-primary"
-      >
-        <ChevronLeft size={14} strokeWidth={1.75} />
-        Back to {project.title}
-      </Link>
-
-      <div className="mt-6">
-        <h1 className="text-2xl font-semibold text-text-primary">News</h1>
-        <p className="mt-1 text-sm text-text-tertiary">
-          Geospatial posts pinned to buildings or rooms. They show up on
-          the public campus home and on the map.
-        </p>
-      </div>
-
-      <NewsAdminClient
-        mapId={mapId}
-        initialPosts={posts}
-        indoorMapId={indoorMapId}
+    <div className="mx-auto w-full max-w-[1400px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Public surface"
+        title="News"
+        subtitle="Posts pinned to buildings or rooms. Surface on the public home and the news feed."
+        actions={<OpenPublicAction href={`/campus/${mapId}/news`} />}
       />
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <div className="min-w-0">
+          <NewsAdminClient
+            mapId={mapId}
+            initialPosts={posts}
+            indoorMapId={indoorMapId}
+          />
+        </div>
+        <aside className="hidden lg:block">
+          <PhonePreview
+            src={`/campus/${mapId}/news`}
+            title="Public news preview"
+          />
+        </aside>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Phase 4b of the [backoffice redesign](https://github.com/prieston/klorad/blob/main). Wraps every public-surface authoring screen in the new \`PageHeader\` chrome and pilots the live phone preview pane on the News screen.

## Pragmatic scoping decision

The existing CRUD clients (\`NewsAdminClient\`, \`EventsAdminClient\`, \`ClubsAdminClient\`, \`DiningAdminClient\` — ~1,700 LOC together, already MUI-free) work and were authored carefully. **Replacing them to match the mock's three-pane layout** would risk regressing real authoring behaviour, so this PR keeps the clients intact and changes only the chrome around them. The mock-faithful three-pane refactor (list / form / preview) lands when the CRUD clients are revisited individually — likely with the MappedIn space picker work.

## What ships

- **Per-screen \"Back to campus\" link + inline h1 are removed.** The rail handles navigation now; that chrome was duplicate.
- **\`PageHeader\`** is applied to News, Events, Clubs, Dining — same eyebrow / title / subtitle / actions slot the org tier already uses.
- **\`OpenPublicAction\`** primitive: the \"Open public\" pill. Standardises the verb + target=_blank + icon across all 7 public-surface screens (the four CRUD pages plus Home / Map / Klio retrofitted from Phase 4a).
- **\`PhonePreview\`** primitive: iframe + CSS-only phone bezel + a Refresh chip. Iframe re-mounts when either \`reloadToken\` bumps or the visitor clicks Refresh. No bitmap asset, no broken image on slow networks.
- **News pilots PhonePreview**: left column = existing \`NewsAdminClient\`, right column = sticky \`PhonePreview\` at 300px showing \`/campus/[mapId]/news\`. Visible on lg+ only.

## Why this preview, not a draft channel

The cheapest correct preview is the *real* public route + a Refresh button after Save. A push-based draft channel (websocket / postMessage) is the obvious upgrade but only earns its complexity when rectors need sub-second feedback on every keystroke — which is not the Phase 4b job. The chosen pattern works today, with no backend changes, and the \`reloadToken\` prop hooks into auto-reload-after-save later for free.

## Events / Clubs / Dining

Get the \`PageHeader\` + \`OpenPublicAction\` treatment but **not** the \`PhonePreview\` pane yet. Once the News pilot is validated post-merge we roll the pane across the other three in a small follow-up — same recipe, one block of JSX per page.

## Deferred (still on the roadmap)

Each of these has a placeholder card on screen so the gap is visible but bounded:

- Quick-action tiles drag-reorder editor (Home)
- Klio tool toggles / persona / suggestion chips
- Saved Routes editor (Map & Wayfinding)
- MappedIn space picker — anchor field migration on News / Events / Clubs / Dining

## Test plan

- [ ] \`/org/[orgId]/maps/[mapId]/news\` — PageHeader renders; left form still saves a post; right pane shows phone bezel + live public news; Refresh chip reloads the iframe
- [ ] \`/events\`, \`/clubs\`, \`/dining\` — PageHeader renders; existing form / list still works; Open public link target=_blank to the matching public route
- [ ] Phone preview hidden below lg viewport (no horizontal overflow on tablets/phones)
- [ ] Home / Map / Klio still render with the consolidated OpenPublicAction in their headers
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)