### PR TITLE
feat(klio): inline source cards — deep-link into news/events/clubs/dining/map

### DIFF
--- a/apps/campus/app/api/assistant/route.ts
+++ b/apps/campus/app/api/assistant/route.ts
@@ -8,6 +8,7 @@ import {
   type ToolContext,
 } from "@/lib/assistant/tools";
 import { checkRateLimit, clientIp } from "@/lib/assistant/rate-limit";
+import { loadAssistantSpacesForProject } from "@/lib/assistant/spaces-loader";
 import { prisma } from "@/lib/prisma";
 import { decryptSecret, secretsEnabled } from "@/lib/secrets";
 
@@ -278,7 +279,17 @@ export async function POST(req: Request) {
     );
   }
 
-  const spaces = Array.isArray(body.spaces) ? body.spaces : [];
+  // If the caller already has a MappedIn viewer open it sends the
+  // visible spaces along — use those. Otherwise (Klio tab, home chat,
+  // any tab without a viewer) fall back to a cached server-side load
+  // from the campus's `indoorMapId` so directions / focus questions
+  // don't dead-end with "open the map first". Empty when no venue is
+  // configured.
+  const callerSpaces = Array.isArray(body.spaces) ? body.spaces : [];
+  const spaces =
+    callerSpaces.length > 0
+      ? callerSpaces
+      : await loadAssistantSpacesForProject(body.mapId);
   // Per-campus BYOK first, platform key second. Each chat turn does
   // one extra Project read by id (cuid lookup, fast); per-tenant key
   // means usage + cost scope to the right buyer.

--- a/apps/campus/app/api/assistant/route.ts
+++ b/apps/campus/app/api/assistant/route.ts
@@ -89,6 +89,14 @@ function systemPrompt(campusName: string, locale: string): string {
     "matching `query_*` tool. Filter by anchor when the user names a",
     "building. Don't list more than ~5 results unless asked.",
     "",
+    "**Always cite your sources.** When you mention a specific club,",
+    "event, news post, or dining venue you fetched, call `cite(kind,",
+    "id, name)` so the student gets a tappable card linking to it in",
+    "the app. One `cite` per mention; up to 4 per response. Don't",
+    "cite something you didn't fetch. For spaces, pass the human-",
+    "readable name to `focus` / `route` (`toName`, `fromName`) so the",
+    "directions card reads 'Library' instead of an id.",
+    "",
     locale === "el"
       ? "Απαντήστε στα ελληνικά όταν ο χρήστης γράφει στα ελληνικά."
       : "Reply in the language of the user's question.",

--- a/apps/campus/lib/assistant/spaces-loader.ts
+++ b/apps/campus/lib/assistant/spaces-loader.ts
@@ -1,0 +1,81 @@
+import "server-only";
+import { unstable_cache } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { venueForIndoorMap } from "@/lib/mappedin/config";
+import { loadMappedinSpaces } from "@/lib/mappedin/spaces";
+import type { AssistantSpace } from "@/lib/assistant/tools";
+
+/**
+ * Server-side load of a campus's MappedIn spaces for the assistant.
+ *
+ * Bridges the gap that surfaced after Klio's source-cards work shipped:
+ * the chat tab and the home-page chat input both call `/api/assistant`
+ * without `spaces[]` in the body (they don't have a MappedIn viewer
+ * loaded), so Klio's `search_places` / `focus` / `route` tools were
+ * unconditionally refusing with "open the map first". When the
+ * campus has an indoor venue configured, we can resolve the same
+ * spaces server-side and pass them as context — so Klio answers
+ * directions questions from any tab.
+ *
+ * Cached aggressively: the spaces list rarely changes (it's the
+ * venue's authored geometry), and the per-call cost would otherwise
+ * be a MappedIn round-trip + an SDK init on every assistant turn.
+ * `unstable_cache` keys on the indoor map id and revalidates on a
+ * 1-hour TTL; tagged so a future "venue updated" hook can
+ * invalidate just the affected campus.
+ */
+async function loadSpacesByIndoorMapIdUncached(
+  indoorMapId: string,
+): Promise<AssistantSpace[]> {
+  if (!indoorMapId) return [];
+  try {
+    const venue = venueForIndoorMap(indoorMapId);
+    const options = await loadMappedinSpaces(venue);
+    return options
+      .filter((o) => o.name && o.id)
+      .map((o) => ({
+        id: o.id,
+        name: o.name,
+        type: o.kind,
+      }));
+  } catch (err) {
+    console.error("[assistant] MappedIn space load failed", err);
+    return [];
+  }
+}
+
+function spacesCache(indoorMapId: string) {
+  return unstable_cache(
+    () => loadSpacesByIndoorMapIdUncached(indoorMapId),
+    ["assistant-spaces", indoorMapId],
+    {
+      revalidate: 3600,
+      tags: [`mappedin-spaces:${indoorMapId}`],
+    },
+  );
+}
+
+/**
+ * Top-level entry point for the assistant route. Looks up the
+ * campus's indoorMapId, loads the cached spaces if there is one,
+ * returns `[]` otherwise (no venue → no spatial context, same as
+ * before — Klio just routes around the spatial tools).
+ */
+export async function loadAssistantSpacesForProject(
+  mapId: string,
+): Promise<AssistantSpace[]> {
+  try {
+    const project = await prisma.project.findUnique({
+      where: { id: mapId },
+      select: { sceneData: true },
+    });
+    const indoorMapId =
+      (project?.sceneData as { indoorMapId?: string } | null)?.indoorMapId ??
+      null;
+    if (!indoorMapId) return [];
+    return await spacesCache(indoorMapId)();
+  } catch (err) {
+    console.error("[assistant] indoor map lookup failed", err);
+    return [];
+  }
+}

--- a/apps/campus/lib/assistant/tools.ts
+++ b/apps/campus/lib/assistant/tools.ts
@@ -21,10 +21,38 @@ export interface AssistantSpace {
   type?: string;
 }
 
-/** A client-dispatchable action the LLM asked us to suggest. */
+/**
+ * A client-dispatchable action the LLM asked us to suggest. Two
+ * families:
+ *
+ *   - **Spatial** (`focus`, `route`) — register from `focus` / `route`
+ *     tool calls. The client renders these as "Show on map" /
+ *     "Get directions" cards that deep-link into the MappedIn
+ *     viewer.
+ *   - **Content** (`open_*`) — registered via the `cite` tool. The
+ *     client renders these as compact source cards under the
+ *     assistant message so the student can tap straight into the
+ *     news post / event / club / dining venue Klio mentioned.
+ *
+ * Names are kept on every variant so the frontend can render a
+ * readable label without re-fetching the entity. Spatial actions
+ * carry names too (added 2026-06-02) so the source card shows
+ * "Library" instead of a raw MappedIn space id.
+ */
 export type AssistantAction =
-  | { action: "focus"; toId: string }
-  | { action: "route"; fromId: string; toId: string; accessible: boolean };
+  | { action: "focus"; toId: string; toName?: string }
+  | {
+      action: "route";
+      fromId: string;
+      toId: string;
+      accessible: boolean;
+      fromName?: string;
+      toName?: string;
+    }
+  | { action: "open_news"; id: string; title: string }
+  | { action: "open_event"; id: string; title: string }
+  | { action: "open_club"; id: string; name: string }
+  | { action: "open_dining"; id: string; name: string };
 
 /** Execution context the executor needs to run a tool call. */
 export interface ToolContext {
@@ -146,6 +174,12 @@ export const ASSISTANT_TOOLS = [
           type: "string",
           description: "The MappedIn space id from `search_places`.",
         },
+        toName: {
+          type: "string",
+          description:
+            "Human-readable space name from `search_places` — used as " +
+            "the card label so the student sees 'Library' not the id.",
+        },
       },
       required: ["toId"],
     },
@@ -161,6 +195,14 @@ export const ASSISTANT_TOOLS = [
       properties: {
         fromId: { type: "string" },
         toId: { type: "string" },
+        fromName: {
+          type: "string",
+          description: "Human-readable name for the from space.",
+        },
+        toName: {
+          type: "string",
+          description: "Human-readable name for the to space.",
+        },
         accessible: {
           type: "boolean",
           description:
@@ -169,6 +211,36 @@ export const ASSISTANT_TOOLS = [
         },
       },
       required: ["fromId", "toId"],
+    },
+  },
+  {
+    name: "cite",
+    description:
+      "Surface a source as a tappable card under your reply. Call this " +
+      "once per source you mention by name — a specific club, event, " +
+      "news post, or dining venue you returned from a `query_*` tool. " +
+      "The student can tap the card to open the entity in the app. " +
+      "Don't cite a source you didn't fetch; only entities backed by a " +
+      "real id should be cited. At most 4 citations per response.",
+    input_schema: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["news", "event", "club", "dining"],
+          description: "Which content surface the cited entity lives on.",
+        },
+        id: {
+          type: "string",
+          description: "The entity id from the relevant `query_*` tool.",
+        },
+        name: {
+          type: "string",
+          description:
+            "Human-readable label — title for news/events, name for clubs/dining.",
+        },
+      },
+      required: ["kind", "id", "name"],
     },
   },
 ] as const;
@@ -340,6 +412,10 @@ export async function executeTool(
 
       case "focus": {
         const toId = typeof input.toId === "string" ? input.toId : "";
+        const toName =
+          typeof input.toName === "string" && input.toName.trim()
+            ? input.toName.trim()
+            : undefined;
         if (!toId) return { ok: false, error: "toId is required" };
         if (ctx.spaces.length === 0) {
           return {
@@ -348,13 +424,21 @@ export async function executeTool(
               "No MappedIn context — say to open the map instead of focusing.",
           };
         }
-        ctx.collectedActions.push({ action: "focus", toId });
+        ctx.collectedActions.push({ action: "focus", toId, toName });
         return { ok: true };
       }
 
       case "route": {
         const fromId = typeof input.fromId === "string" ? input.fromId : "";
         const toId = typeof input.toId === "string" ? input.toId : "";
+        const fromName =
+          typeof input.fromName === "string" && input.fromName.trim()
+            ? input.fromName.trim()
+            : undefined;
+        const toName =
+          typeof input.toName === "string" && input.toName.trim()
+            ? input.toName.trim()
+            : undefined;
         const accessible = input.accessible === true;
         if (!fromId || !toId) {
           return { ok: false, error: "fromId and toId are required" };
@@ -370,9 +454,47 @@ export async function executeTool(
           action: "route",
           fromId,
           toId,
+          fromName,
+          toName,
           accessible,
         });
         return { ok: true };
+      }
+
+      case "cite": {
+        const kind = typeof input.kind === "string" ? input.kind : "";
+        const id = typeof input.id === "string" ? input.id.trim() : "";
+        const name = typeof input.name === "string" ? input.name.trim() : "";
+        if (!id || !name) {
+          return { ok: false, error: "id and name are required" };
+        }
+        // Hard cap on citations so a confused LLM can't flood the
+        // reply with 20 cards — UX gets noisy past 4.
+        const existing = ctx.collectedActions.filter((a) =>
+          a.action.startsWith("open_"),
+        ).length;
+        if (existing >= 4) {
+          return {
+            ok: false,
+            error: "Citation cap reached (4 per response).",
+          };
+        }
+        switch (kind) {
+          case "news":
+            ctx.collectedActions.push({ action: "open_news", id, title: name });
+            return { ok: true };
+          case "event":
+            ctx.collectedActions.push({ action: "open_event", id, title: name });
+            return { ok: true };
+          case "club":
+            ctx.collectedActions.push({ action: "open_club", id, name });
+            return { ok: true };
+          case "dining":
+            ctx.collectedActions.push({ action: "open_dining", id, name });
+            return { ok: true };
+          default:
+            return { ok: false, error: `Unknown cite kind: ${kind}` };
+        }
       }
 
       default:

--- a/apps/campus/lib/consumer/ConsumerHome.tsx
+++ b/apps/campus/lib/consumer/ConsumerHome.tsx
@@ -105,7 +105,11 @@ export function ConsumerHome({
   mapId,
   campusName,
   accentColor,
-  logoUrl,
+  // `logoUrl` was passed for the old in-page ConsumerNav; the layout
+  // now owns the nav (see [[campus-public-app-feel]]), so this prop
+  // is unused here. Kept on the type so the call site doesn't break;
+  // can be dropped from the interface in a cleanup sweep.
+  logoUrl: _logoUrl,
   locale,
   events,
   dining,

--- a/apps/campus/lib/consumer/KlioPanel.tsx
+++ b/apps/campus/lib/consumer/KlioPanel.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
-import Link from "next/link";
 import { ArrowUp, Sparkles, ArrowRight } from "lucide-react";
+import type { AssistantAction } from "@/lib/assistant/tools";
+import { KlioSourceCards } from "./KlioSourceCards";
 
 interface Message {
   role: "user" | "assistant";
   text: string;
+  /** Structured deep-link cards Klio surfaced for this turn. */
+  actions?: AssistantAction[];
 }
 
 export interface KlioPanelProps {
@@ -16,8 +19,12 @@ export interface KlioPanelProps {
   campusName: string;
   /** UI locale — drives all visible strings + the assistant locale param. */
   locale: "en" | "el";
-  /** Where the deep links land when the assistant suggests a route. */
-  mapHref: string;
+  /**
+   * Deprecated — `KlioSourceCards` builds map URLs from `mapId` + locale
+   * directly. Kept on the props for one release so the existing call
+   * site doesn't break; can be dropped after.
+   */
+  mapHref?: string;
 }
 
 interface Suggestion {
@@ -78,7 +85,7 @@ const COPY = {
  * Empty state mirrors the mockup: hero ("Hi, I'm Klio"), four
  * suggested-prompt pills, a chat thread, an input + send button.
  */
-export function KlioPanel({ mapId, campusName, locale, mapHref }: KlioPanelProps) {
+export function KlioPanel({ mapId, campusName, locale }: KlioPanelProps) {
   const copy = COPY[locale];
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
@@ -114,8 +121,14 @@ export function KlioPanel({ mapId, campusName, locale, mapHref }: KlioPanelProps
         }),
       });
       if (!res.ok) throw new Error("assistant failed");
-      const data = (await res.json()) as { reply: string };
-      setMessages((m) => [...m, { role: "assistant", text: data.reply }]);
+      const data = (await res.json()) as {
+        reply: string;
+        actions?: AssistantAction[];
+      };
+      setMessages((m) => [
+        ...m,
+        { role: "assistant", text: data.reply, actions: data.actions },
+      ]);
     } catch {
       setMessages((m) => [
         ...m,
@@ -195,19 +208,15 @@ export function KlioPanel({ mapId, campusName, locale, mapHref }: KlioPanelProps
                   {m.text}
                 </span>
               ) : (
-                <div className="max-w-[85%] whitespace-pre-wrap rounded-2xl bg-[var(--brand-page)] px-3.5 py-2 leading-relaxed text-[var(--brand-text)]">
-                  {m.text}
-                  {/map\b|χάρτ/i.test(m.text) ? (
-                    <>
-                      {" "}
-                      <Link
-                        href={mapHref}
-                        className="text-[var(--brand-primary)] underline-offset-2 hover:underline"
-                      >
-                        {copy.openMap} →
-                      </Link>
-                    </>
-                  ) : null}
+                <div className="max-w-[85%]">
+                  <div className="whitespace-pre-wrap rounded-2xl bg-[var(--brand-page)] px-3.5 py-2 leading-relaxed text-[var(--brand-text)]">
+                    {m.text}
+                  </div>
+                  <KlioSourceCards
+                    actions={m.actions ?? []}
+                    mapId={mapId}
+                    locale={locale}
+                  />
                 </div>
               )}
             </div>

--- a/apps/campus/lib/consumer/KlioSourceCards.tsx
+++ b/apps/campus/lib/consumer/KlioSourceCards.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowUpRight,
+  Calendar,
+  Compass,
+  MapPin,
+  Newspaper,
+  Users,
+  Utensils,
+  type LucideIcon,
+} from "lucide-react";
+import type { AssistantAction } from "@/lib/assistant/tools";
+import type { Locale } from "@/app/lib/i18n-core";
+
+interface Props {
+  actions: AssistantAction[];
+  /** Project id — also the public route segment (`/campus/[token]`). */
+  mapId: string;
+  /** Locale appended as `?lang=` so language survives the deep link. */
+  locale: Locale;
+}
+
+interface Card {
+  Icon: LucideIcon;
+  label: string;
+  sublabel: string;
+  href: string;
+}
+
+/**
+ * Compact "Open …" affordance label used on every source card. Pulls
+ * EL when the visitor is in Greek so the cards read in their language.
+ */
+const VERB: Record<Locale, Record<AssistantAction["action"], string>> = {
+  en: {
+    focus: "Show on map",
+    route: "Get directions",
+    open_news: "Open news",
+    open_event: "Open event",
+    open_club: "Open club",
+    open_dining: "View dining",
+  },
+  el: {
+    focus: "Δες στον χάρτη",
+    route: "Πάρε διαδρομή",
+    open_news: "Άνοιγμα είδησης",
+    open_event: "Άνοιγμα εκδήλωσης",
+    open_club: "Άνοιγμα συλλόγου",
+    open_dining: "Άνοιγμα φαγητού",
+  },
+};
+
+const STEP_FREE_LABEL: Record<Locale, string> = {
+  en: "step-free",
+  el: "προσβάσιμη",
+};
+
+/**
+ * Translate an `AssistantAction` into a renderable Card. Centralised
+ * here so adding a new action variant is one switch arm — every other
+ * piece of UI inherits the new card shape for free.
+ *
+ * URL conventions:
+ *
+ *   - News / events / clubs each have a detail page at
+ *     `/campus/[token]/<surface>/[id]`.
+ *   - Dining has no detail page yet, so cards land on the list with a
+ *     `#<id>` anchor — the page can scroll into view in a follow-up.
+ *   - `focus` deep-links to the map with `?b=<id>`, the URL-state
+ *     convention the map already consumes for building selection
+ *     (shipped in PR #169 area).
+ *   - `route` uses the existing `?route=1&from&to&a` state from the
+ *     map-page URL contract.
+ */
+function actionToCard(
+  action: AssistantAction,
+  mapId: string,
+  locale: Locale,
+): Card | null {
+  const lang = `lang=${locale}`;
+  const base = `/campus/${mapId}`;
+  const verb = VERB[locale][action.action];
+  switch (action.action) {
+    case "open_news":
+      return {
+        Icon: Newspaper,
+        label: action.title,
+        sublabel: verb,
+        href: `${base}/news/${encodeURIComponent(action.id)}?${lang}`,
+      };
+    case "open_event":
+      return {
+        Icon: Calendar,
+        label: action.title,
+        sublabel: verb,
+        href: `${base}/events/${encodeURIComponent(action.id)}?${lang}`,
+      };
+    case "open_club":
+      return {
+        Icon: Users,
+        label: action.name,
+        sublabel: verb,
+        href: `${base}/clubs/${encodeURIComponent(action.id)}?${lang}`,
+      };
+    case "open_dining":
+      return {
+        Icon: Utensils,
+        label: action.name,
+        sublabel: verb,
+        href: `${base}/dining?${lang}#${encodeURIComponent(action.id)}`,
+      };
+    case "focus":
+      return {
+        Icon: MapPin,
+        label: action.toName ?? "Space",
+        sublabel: verb,
+        href: `${base}/map?b=${encodeURIComponent(action.toId)}&${lang}`,
+      };
+    case "route": {
+      const acc = action.accessible ? `· ${STEP_FREE_LABEL[locale]}` : "";
+      const label =
+        action.fromName && action.toName
+          ? `${action.fromName} → ${action.toName}`
+          : "Route";
+      return {
+        Icon: Compass,
+        label,
+        sublabel: `${verb} ${acc}`.trim(),
+        href: `${base}/map?route=1&from=${encodeURIComponent(action.fromId)}&to=${encodeURIComponent(action.toId)}${
+          action.accessible ? "&a=1" : ""
+        }&${lang}`,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Stack of source cards under an assistant message. Each card is a
+ * tappable deep-link into the rest of the app — the answer Klio gives
+ * + the place to open it without having to click around. Renders
+ * nothing when there are no actions, so message bodies without
+ * citations stay clean.
+ */
+export function KlioSourceCards({ actions, mapId, locale }: Props) {
+  if (!actions || actions.length === 0) return null;
+  const cards = actions
+    .map((a) => actionToCard(a, mapId, locale))
+    .filter((c): c is Card => c !== null);
+  if (cards.length === 0) return null;
+  return (
+    <ul className="mt-2 flex flex-col gap-1.5">
+      {cards.map((card, idx) => (
+        <li key={`${card.href}-${idx}`}>
+          <Link
+            href={card.href}
+            className="group flex items-center gap-3 rounded-xl border border-[var(--brand-line)] bg-white px-3 py-2 transition-colors hover:border-[var(--brand-primary)]"
+          >
+            <span
+              aria-hidden
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--brand-primary-bg)] text-[var(--brand-primary)]"
+            >
+              <card.Icon size={15} strokeWidth={1.75} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium text-[var(--brand-text)]">
+                {card.label}
+              </span>
+              <span className="block truncate text-[11px] text-[var(--brand-text-muted)]">
+                {card.sublabel}
+              </span>
+            </span>
+            <ArrowUpRight
+              size={14}
+              strokeWidth={1.75}
+              className="shrink-0 text-[var(--brand-text-muted)] transition-colors group-hover:text-[var(--brand-primary)]"
+              aria-hidden
+            />
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
Closes the loop on Klio's tool-use scaffold. The backend was already running tool calls and accumulating structured deep-link suggestions in \`actions: AssistantAction[]\` — but the frontend threw the array away and only added a regex-based \"Open the map\" link to replies that happened to mention the word \"map\". **The structured citations Claude fetched never reached the student.**

This wires them through end-to-end.

## What happens now

Ask Klio \"any robotics clubs?\" — under the answer bubble, a tappable card stack appears:

\`\`\`
[Users icon] Robotics Society      → Open club
[Users icon] Aerospace Society     → Open club
\`\`\`

Ask \"step-free route to the library\":

\`\`\`
[Compass icon] Main Gate → Library · step-free   → Get directions
\`\`\`

Each card deep-links into the right campus surface — clubs/[id], events/[id], news/[id], dining, or the map with the right URL state (\`?b=\` for focus, \`?route=1&from&to&a\` for directions). \`?lang=\` survives every link.

## Backend — \`lib/assistant/tools.ts\`

- **Extended \`AssistantAction\`** with content variants:
  - \`open_news { id, title }\`
  - \`open_event { id, title }\`
  - \`open_club { id, name }\`
  - \`open_dining { id, name }\`
- Spatial actions (\`focus\`, \`route\`) gained optional \`toName\` / \`fromName\` / \`toName\` so the card reads \"Library\" instead of a raw MappedIn space id.
- **New \`cite\` tool**: \`{ kind: \"news\"|\"event\"|\"club\"|\"dining\", id, name }\`. Claude calls this after a \`query_*\` tool to register a tappable source card. Hard cap of 4 per response.
- \`focus\` / \`route\` schemas added \`*Name\` fields so Claude passes the names along.

## System prompt

Added an explicit *\"Always cite your sources\"* instruction with the cap + the name-pass-through for spatial actions. Read every call.

## Frontend

- **New \`KlioSourceCards\`** — renders the actions array as a stack of compact tappable cards under each assistant message. Centralised \`actionToCard\` switch — adding a new action variant is one arm.
- **\`KlioPanel\`** reads \`actions\` from the response, stores them per message, drops the regex-based legacy \"Open the map\" fallback (was firing on any reply containing \"map\" or \"χάρτ\"). \`mapHref\` prop kept deprecated for one release so the existing call site doesn't break.

## URL conventions

| Action | Deep link |
|---|---|
| open_news | \`/campus/[token]/news/[id]?lang=\` |
| open_event | \`/campus/[token]/events/[id]?lang=\` |
| open_club | \`/campus/[token]/clubs/[id]?lang=\` |
| open_dining | \`/campus/[token]/dining?lang=#[id]\` |
| focus | \`/campus/[token]/map?b=[id]&lang=\` |
| route | \`/campus/[token]/map?route=1&from&to&a&lang=\` |

All align with the existing map URL state from the URL-state work in PR #169.

## Test plan

- [ ] Set a campus's Anthropic key (or have \`ANTHROPIC_API_KEY\` set platform-side)
- [ ] On Klio tab: ask \"any clubs about coding?\" → Klio fetches via query_clubs + calls cite for each it mentions → cards appear under reply → tap a card → lands on /campus/[token]/clubs/[id]
- [ ] Ask \"what's for lunch?\" → dining cards appear → tap → lands on dining page
- [ ] Ask on the map: \"directions to the library\" → route card appears with \"X → Library\" + \"Get directions\" sublabel → tap → map opens with route state in the URL
- [ ] Greek locale: switch to ΕΛ → ask \"εκδηλώσεις αυτή την εβδομάδα\" → cards render with Greek verbs (\"Άνοιγμα εκδήλωσης\")
- [ ] Without an API key + with the env fallback off → falls back to the regex-based parse, doesn't crash, just shows fewer cards
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)