### PR TITLE
feat(campus): public app-feel — instant nav + pull-to-refresh + iOS zoom + map aspect toggle

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/layout.tsx
+++ b/apps/campus/app/(public)/campus/[token]/layout.tsx
@@ -7,6 +7,7 @@ import { deriveCampusPalette, paletteToCssVars } from "@/lib/palette";
 import { SWRProvider } from "@/lib/swr/SWRProvider";
 import { ServiceWorkerRegistrar } from "@/lib/consumer/ServiceWorkerRegistrar";
 import { InstallPrompt } from "@/lib/consumer/InstallPrompt";
+import { PullToRefresh } from "@/lib/consumer/PullToRefresh";
 
 interface CampusBranding {
   name?: string;
@@ -130,6 +131,7 @@ export default async function CampusPublicLayout({
         />
         {children}
         <CampusBottomNav token={token} />
+        <PullToRefresh />
         <InstallPrompt />
         <ServiceWorkerRegistrar />
       </div>

--- a/apps/campus/app/(public)/campus/[token]/map/MapPageClient.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/MapPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Compass, Search, X } from "lucide-react";
+import { ChevronDown, ChevronUp, Compass, Search, X } from "lucide-react";
 // Lucide's `X` is also imported here for the building header's close
 // chip. Renamed to disambiguate from the search-clear button below.
 import {
@@ -108,6 +108,12 @@ export function MapPageClient({
   const viewerRef = useRef<MappedinViewerHandle | null>(null);
   const [buildings, setBuildings] = useState<BuildingsListItem[]>([]);
   const [spaces, setSpaces] = useState<SpaceOption[]>([]);
+  // Bottom-container aspect: `false` = default 4:3 split (map gets more
+  // vertical room), `true` = inverted 2:5 (the buildings list / route
+  // steps get more room). The user toggles this on mobile via the
+  // chevron in the bottom container's header — desktop has plenty of
+  // vertical room so the toggle is hidden there.
+  const [listExpanded, setListExpanded] = useState(false);
 
   // ── URL state ───────────────────────────────────────────────────
   // Every shareable piece of state — selected building, open detail,
@@ -452,13 +458,15 @@ export function MapPageClient({
         </div>
       )}
 
-      {/* Map — 4 parts of the 4:3 split. On mobile the map runs
-          edge-to-edge (no padding, no rounded card) so the bottom
-          sheet can overlap it via its negative top margin; the
-          rounded-card treatment is desktop-only. */}
+      {/* Map — flex share depends on the user's aspect toggle.
+          Default 4 parts (of 4:3 split with the bottom container);
+          shrinks to 2 parts when the visitor pulls the list up to
+          read more. On mobile the map runs edge-to-edge so the
+          bottom sheet can overlap it via its negative top margin;
+          the rounded-card treatment is desktop-only. */}
       <div
-        className="min-h-0 md:px-6 md:pt-3"
-        style={{ flex: "4 1 0" }}
+        className="min-h-0 transition-[flex-grow] duration-200 ease-out md:px-6 md:pt-3"
+        style={{ flex: listExpanded ? "2 1 0" : "4 1 0" }}
       >
         <div className="h-full overflow-hidden bg-white md:rounded-2xl">
           <MappedinViewer
@@ -487,9 +495,32 @@ export function MapPageClient({
           the scroll surface ends with `pb-24` to clear the
           floating nav. */}
       <div
-        className="relative z-10 -mt-6 flex min-h-0 flex-col rounded-t-3xl bg-[var(--brand-page)] md:mt-0 md:rounded-none"
-        style={{ flex: "3 1 0" }}
+        className="relative z-10 -mt-6 flex min-h-0 flex-col rounded-t-3xl bg-[var(--brand-page)] transition-[flex-grow] duration-200 ease-out md:mt-0 md:rounded-none"
+        style={{ flex: listExpanded ? "5 1 0" : "3 1 0" }}
       >
+        {/* Aspect toggle — mobile only. Trades vertical room between
+            the map viewer above and the list / route panel below.
+            Doubles as the bottom-sheet's drag handle: the visible
+            pill reads as a grab affordance even before the visitor
+            sees the chevron. */}
+        <button
+          type="button"
+          onClick={() => setListExpanded((v) => !v)}
+          aria-label={listExpanded ? "Shrink list" : "Expand list"}
+          className="flex shrink-0 items-center justify-center gap-1 px-3 pt-2 pb-1 md:hidden"
+        >
+          <span
+            aria-hidden
+            className="flex h-6 items-center gap-1 rounded-full bg-white px-2.5 text-[10px] font-medium text-[var(--brand-text-muted)] shadow-sm"
+          >
+            {listExpanded ? (
+              <ChevronDown size={11} strokeWidth={2.25} />
+            ) : (
+              <ChevronUp size={11} strokeWidth={2.25} />
+            )}
+            {listExpanded ? "Show map" : "Show more"}
+          </span>
+        </button>
         {inRoute && routePhase === "viewing" ? (
           <RouteStatsCard
             status={routeStatus.kind}

--- a/apps/campus/app/global.css
+++ b/apps/campus/app/global.css
@@ -36,6 +36,29 @@ html {
    every consumer route on phones — give those pages bottom padding
    so the footer + last list row clear the nav's height. Desktop
    uses the top `ConsumerNav` instead, so no padding needed there. */
+/* iOS Safari zooms the viewport when an input is focused and its
+   effective font-size is below 16px. Lock every text-y control on
+   the public surface to 16px+ so focusing the search bar / chat
+   composer doesn't shove the whole page sideways. Scoped to the
+   consumer surface so the dashboard's smaller inputs aren't
+   affected — desktop browsers don't trigger the zoom in the first
+   place. */
+:where([data-consumer], [data-mappedin])
+  :where(
+    input[type="text"],
+    input[type="search"],
+    input[type="email"],
+    input[type="password"],
+    input[type="number"],
+    input[type="tel"],
+    input[type="url"],
+    input:not([type]),
+    textarea,
+    select
+  ) {
+  font-size: max(16px, 1em);
+}
+
 /* Consumer pages scroll the page body — `main[data-consumer]` IS
    the scroll container, so `padding-bottom` here is "inner padding"
    that lets the last item clear the floating nav while still letting

--- a/apps/campus/lib/consumer/CampusBottomNav.tsx
+++ b/apps/campus/lib/consumer/CampusBottomNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { Home, Map as MapIcon, LayoutGrid, Sparkles } from "lucide-react";
@@ -56,13 +57,36 @@ function resolveActiveTab(pathname: string, token: string): TabKey {
  *
  * Hidden on desktop (`md:hidden`) where the top `ConsumerNav` takes
  * over.
+ *
+ * **Optimistic active state** — taps flip the pill immediately
+ * instead of waiting for the route to commit. Next's `Link` already
+ * navigates inside a React transition, but the pathname doesn't
+ * update until the new route's HTML streams in (~100-500ms on a
+ * cold cache), and `usePathname` resolves to the *previous* URL
+ * during that window. Tracking a `pendingKey` and rendering it as
+ * active until the pathname catches up closes the perceived gap to
+ * zero — the rest of the body still shows the skeleton from
+ * `loading.tsx` until the new page lands.
  */
 export function CampusBottomNav({ token }: Props) {
   const pathname = usePathname() ?? `/campus/${token}`;
   const searchParams = useSearchParams();
   const locale = detectLocale(searchParams?.get("lang") ?? null);
-  const activeKey = resolveActiveTab(pathname, token);
+  const activeFromPath = resolveActiveTab(pathname, token);
+  const [pendingKey, setPendingKey] = useState<TabKey | null>(null);
+  const activeKey = pendingKey ?? activeFromPath;
   const lang = `?lang=${locale}`;
+
+  // Clear the optimistic pending state the moment the URL catches up.
+  // Doing this in an effect rather than inline avoids a flash where
+  // both `pendingKey` and `activeFromPath` briefly agree and we
+  // re-render with stale state.
+  useEffect(() => {
+    if (pendingKey && activeFromPath === pendingKey) {
+      setPendingKey(null);
+    }
+  }, [activeFromPath, pendingKey]);
+
   const hrefForKey = (key: TabKey): string => {
     switch (key) {
       case "home":
@@ -99,6 +123,10 @@ export function CampusBottomNav({ token }: Props) {
             href={hrefForKey(item.key as TabKey)}
             aria-current={isActive ? "page" : undefined}
             aria-label={item.label}
+            onClick={() => {
+              const key = item.key as TabKey;
+              if (key !== activeFromPath) setPendingKey(key);
+            }}
             className="flex w-full items-center justify-center"
           >
             {content}

--- a/apps/campus/lib/consumer/PullToRefresh.tsx
+++ b/apps/campus/lib/consumer/PullToRefresh.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowDown, Loader2 } from "lucide-react";
+
+/** Distance the visitor has to pull before release triggers a refresh. */
+const THRESHOLD = 64;
+/** Maximum damped pull (rubbery feel past this). */
+const MAX_PULL = 120;
+/** Minimum spinner visibility so a sub-100ms refresh doesn't flash. */
+const MIN_SPINNER_MS = 500;
+
+/**
+ * Pull-to-refresh — Instagram-style swipe-down gesture that triggers
+ * `router.refresh()` to re-run the server components for the current
+ * route. Mounted from the campus layout so every public surface
+ * picks it up; opts out automatically inside the map's
+ * `data-mappedin` viewport (the viewer eats vertical drags for
+ * panning so the gesture would fight itself there).
+ *
+ * Lifecycle: track a `touchstart` while the page is scrolled to the
+ * top; on `touchmove`, damp the downward delta into a render-able
+ * pull distance; on `touchend` past the threshold, fire
+ * `router.refresh()`. The spinner stays visible at least
+ * MIN_SPINNER_MS so a fast refresh doesn't flicker.
+ *
+ * `preventDefault` on `touchmove` is gated to the active pull only —
+ * otherwise normal horizontal scrolls / map gestures break.
+ */
+export function PullToRefresh() {
+  const router = useRouter();
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Refs survive renders without re-binding the touch listeners.
+  const startY = useRef(0);
+  const pulling = useRef(false);
+  // Read `pull` inside the touch handlers without re-binding them.
+  const pullRef = useRef(0);
+  useEffect(() => {
+    pullRef.current = pull;
+  }, [pull]);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    const started = Date.now();
+    try {
+      router.refresh();
+    } finally {
+      // Keep the spinner visible for a minimum so the user actually
+      // perceives the refresh — without this a fast route refresh
+      // (cached SWR, no DB hit) hides the spinner before the eye
+      // can register it.
+      const elapsed = Date.now() - started;
+      const wait = Math.max(0, MIN_SPINNER_MS - elapsed);
+      window.setTimeout(() => {
+        setRefreshing(false);
+        setPull(0);
+      }, wait);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    const isOnMap = () => Boolean(document.querySelector("[data-mappedin]"));
+
+    const onStart = (e: TouchEvent) => {
+      if (refreshing || isOnMap()) return;
+      if (window.scrollY > 0) return;
+      // Only single-finger pulls — pinch-zoom etc shouldn't trigger.
+      if (e.touches.length !== 1) return;
+      startY.current = e.touches[0].clientY;
+      pulling.current = true;
+    };
+
+    const onMove = (e: TouchEvent) => {
+      if (!pulling.current) return;
+      if (window.scrollY > 0) {
+        pulling.current = false;
+        setPull(0);
+        return;
+      }
+      const delta = e.touches[0].clientY - startY.current;
+      if (delta <= 0) {
+        setPull(0);
+        return;
+      }
+      // Damped curve — past MAX_PULL we just don't grow any further
+      // so the pull feels like it's hitting a soft wall.
+      const damped = Math.min(MAX_PULL, delta * 0.55);
+      setPull(damped);
+      // Stop iOS's native rubber-band while we own the gesture.
+      // Only call when the listener was registered non-passive.
+      if (e.cancelable) e.preventDefault();
+    };
+
+    const onEnd = () => {
+      if (!pulling.current) return;
+      pulling.current = false;
+      if (pullRef.current >= THRESHOLD) {
+        void refresh();
+      } else {
+        setPull(0);
+      }
+    };
+
+    document.addEventListener("touchstart", onStart, { passive: true });
+    // touchmove must be non-passive so preventDefault works.
+    document.addEventListener("touchmove", onMove, { passive: false });
+    document.addEventListener("touchend", onEnd);
+    document.addEventListener("touchcancel", onEnd);
+    return () => {
+      document.removeEventListener("touchstart", onStart);
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onEnd);
+      document.removeEventListener("touchcancel", onEnd);
+    };
+  }, [refresh, refreshing]);
+
+  if (!refreshing && pull === 0) return null;
+
+  const ready = pull >= THRESHOLD;
+  const visibleHeight = refreshing ? 56 : Math.max(pull, 0);
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: visibleHeight,
+        // Smooth spring-back when we're done; no transition while the
+        // finger is actively dragging.
+        transition: refreshing || pull === 0 ? "height 220ms ease" : "none",
+        pointerEvents: "none",
+        zIndex: 30,
+      }}
+      className="flex items-end justify-center pb-2"
+    >
+      <div
+        className="flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md"
+        style={{
+          transform: refreshing
+            ? "none"
+            : `rotate(${Math.min(180, (pull / THRESHOLD) * 180)}deg)`,
+          transition: "transform 80ms linear",
+        }}
+      >
+        {refreshing ? (
+          <Loader2
+            size={16}
+            strokeWidth={2}
+            className="animate-spin text-[var(--brand-primary)]"
+          />
+        ) : (
+          <ArrowDown
+            size={16}
+            strokeWidth={2}
+            className={
+              ready
+                ? "text-[var(--brand-primary)]"
+                : "text-[var(--brand-text-muted)]"
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/lib/consumer/SegmentedTabs.tsx
+++ b/apps/campus/lib/consumer/SegmentedTabs.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
 export type SegmentedTabKey = "news" | "events" | "clubs" | "dining";
@@ -31,6 +34,11 @@ const ORDER: SegmentedTabKey[] = ["news", "events", "clubs", "dining"];
  * Each tab is a real `<Link>` so the URL stays canonical
  * (`/campus/[token]/events`) and back/forward works naturally —
  * client-side switching would silently lose the deep-link.
+ *
+ * Optimistic active state — taps flip the pill before the new route
+ * has committed. Same pattern as `CampusBottomNav`: track the
+ * pending tab, render it as active, clear once the `active` prop
+ * (server-resolved from the URL) catches up.
  */
 export function SegmentedTabs({
   token,
@@ -38,18 +46,27 @@ export function SegmentedTabs({
   locale,
   active,
 }: SegmentedTabsProps) {
+  const [pending, setPending] = useState<SegmentedTabKey | null>(null);
+  const activeKey = pending ?? active;
+  useEffect(() => {
+    if (pending && active === pending) setPending(null);
+  }, [active, pending]);
+
   return (
     <nav
       aria-label="Explore"
       className="mt-6 flex items-center gap-1 overflow-x-auto rounded-full border border-[var(--brand-line)] bg-white p-1"
     >
       {ORDER.map((key) => {
-        const isActive = key === active;
+        const isActive = key === activeKey;
         return (
           <Link
             key={key}
             href={`/campus/${token}/${key}${lang}`}
             aria-current={isActive ? "page" : undefined}
+            onClick={() => {
+              if (key !== active) setPending(key);
+            }}
             className={
               isActive
                 ? "inline-flex items-center justify-center rounded-full bg-[var(--brand-primary)] px-4 py-2 text-sm font-semibold text-white transition-colors"


### PR DESCRIPTION
Four UX wins for the public surface, bundled because they all serve the same goal — make the campus app feel native instead of webby.

## 1. Instant nav active state

The mobile bottom nav + the inner Explore \`SegmentedTabs\` both relied on \`usePathname\` for their active styling — but pathname only updates *after* the destination route's HTML streams in, so tapping Map showed Home still highlighted for the ~100-500ms the new page took to load.

Tracking a local \`pendingKey\` (or \`pending\` for the segmented control) and rendering it as active until the URL catches up closes the perceived gap to **zero**. \`<Link>\` already wraps the navigation in a React transition; \`loading.tsx\` (shipped earlier) fills the body slot with a skeleton during that window — so visitors now see the active pill flip instantly **and** a body skeleton, like every native tab swap.

Applied to:
- \`CampusBottomNav\` (Home / Map / Explore / Klio)
- \`SegmentedTabs\` (News / Events / Clubs / Dining inside Explore)

## 2. Pull-to-refresh

New \`PullToRefresh\` mounted in the campus layout. Tracks \`touchstart\` while \`scrollY === 0\`, damps the downward delta into a render-able pull distance, and on \`touchend\` past the 64px threshold fires \`router.refresh()\` (the right primitive in Next 15 — re-runs the server components for the current route).

Spinner stays visible at least 500ms so a fast refresh doesn't flash. Auto-disabled inside \`data-mappedin\` so the gesture doesn't fight MappedIn's vertical pan.

## 3. iOS Safari input-focus zoom — fixed

iOS shoves the viewport sideways the moment focus lands on an input whose effective font-size is below 16px. Global CSS inside \`[data-consumer]\` / \`[data-mappedin]\` clamps every text-y control (\`input[type=text|search|email|…]\`, \`textarea\`, \`select\`) to \`max(16px, 1em)\`. The dashboard's smaller inputs are untouched — desktop browsers don't trigger the zoom in the first place.

## 4. Map aspect toggle on mobile

The bottom container under the MappedIn viewer was crowded on small screens. Mobile-only toggle at the top of the container swaps the flex split:

| Mode | Map flex | List flex |
|---|---|---|
| Default | 4 | 3 |
| Expanded | 2 | 5 |

\`flex-grow\` transitions for 200ms so the swap feels physical. Chevron icon + label changes (\"Show more\" ↔ \"Show map\"). Hidden on md+ where vertical room isn't tight.

## Test plan

- [ ] Tap a bottom-nav tab → pill flips instantly, body shows the skeleton, real content streams in shortly after
- [ ] Tap a SegmentedTabs pill (News / Events / …) → same: instant pill flip + skeleton
- [ ] On a phone (or DevTools touch emulation), swipe down from the top of any non-map public page → refresh indicator appears + rotates + a tap-release past 64px refreshes
- [ ] Try the same gesture on the map page → no refresh fires; MappedIn pan still works
- [ ] On iOS, focus any input on the public side → no viewport zoom
- [ ] On the map, tap the \"Show more\" pill at the top of the bottom container → list grows, map shrinks; tap \"Show map\" to revert
- [ ] Build clean: \`pnpm build:campus\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)