### PR TITLE
fix(campus): drop unused logoUrl from map/page.tsx — unbreak main's Vercel build

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -49,7 +49,6 @@ export default async function CampusMapPage({
       ? scene.branding.primaryColor
       : undefined;
   const campusName = scene?.branding?.name || map.title;
-  const logoUrl = scene?.branding?.logo;
 
   if (indoorMapId) {
     const lang = `?lang=${locale}`;


### PR DESCRIPTION
Hotfix for main. Vercel's stricter typescript-eslint config caught a leftover from the persistent-chrome refactor (#179) and failed the build:

```
./app/(public)/campus/[token]/map/page.tsx
52:9  Error: 'logoUrl' is assigned a value but never used.  @typescript-eslint/no-unused-vars
```

`ConsumerNav` moved into the layout in #179 and pages stopped passing `logoUrl` through, but the local variable was left assigned in `map/page.tsx`. Local lint treats this as a warning; Vercel treats it as an error.

One-line fix — drop the dead assignment. Build verified clean locally before push (`pnpm exec next build apps/campus` → exit 0).

Should be a quick merge — main's currently red until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)