### PR TITLE
chore(storage): add `pnpm spaces:get-cors` to inspect current CORS rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "audits:light": "pnpm --filter @klorad/dev-audits audits:light",
     "prisma:generate": "pnpm --filter @klorad/prisma generate",
     "spaces:set-cors": "node --env-file=apps/campus/.env.local --env-file-if-exists=apps/campus/.env --import tsx packages/storage/scripts/set-cors.ts",
+    "spaces:get-cors": "node --env-file=apps/campus/.env.local --env-file-if-exists=apps/campus/.env --import tsx packages/storage/scripts/get-cors.ts",
     "prisma:migrate:dev": "./scripts/migrate.sh dev",
     "prisma:migrate:deploy": "./scripts/migrate.sh deploy",
     "vercel:build:editor": "pnpm prisma:generate && pnpm --filter @klorad/prisma prisma migrate deploy && pnpm clean && pnpm build:packages && cd apps/editor && pnpm build",

--- a/packages/storage/scripts/get-cors.ts
+++ b/packages/storage/scripts/get-cors.ts
@@ -1,0 +1,77 @@
+/**
+ * Print the current CORS rules on the configured DigitalOcean Space.
+ *
+ * Companion to `set-cors.ts` — when an upload is failing with
+ * "No 'Access-Control-Allow-Origin' header is present", run this
+ * first to see whether the rule is actually applied. Three common
+ * outcomes:
+ *
+ *   - `No CORS configuration found.` — the rule was removed; run
+ *     `pnpm spaces:set-cors` to re-apply.
+ *   - Rules listed but the visitor's origin isn't in `AllowedOrigins`
+ *     — add it via `KLORAD_CORS_ORIGINS` + re-run set-cors.
+ *   - Rules listed and look correct — the issue is elsewhere
+ *     (signed-headers mismatch, bucket policy, signing clock skew).
+ *
+ * Reads the same env vars as `set-cors.ts`:
+ *
+ *   DO_SPACES_REGION
+ *   DO_SPACES_ENDPOINT
+ *   DO_SPACES_BUCKET
+ *   DO_SPACES_KEY
+ *   DO_SPACES_SECRET
+ *
+ * Usage from repo root:
+ *
+ *   pnpm spaces:get-cors
+ */
+
+import { GetBucketCorsCommand, S3Client } from "@aws-sdk/client-s3";
+import { storageConfigFromEnv } from "../src/server";
+
+async function main() {
+  const cfg = storageConfigFromEnv();
+  const client = new S3Client({
+    region: cfg.region,
+    endpoint: cfg.endpoint,
+    credentials: {
+      accessKeyId: cfg.accessKeyId,
+      secretAccessKey: cfg.secretAccessKey,
+    },
+  });
+
+  try {
+    const result = await client.send(
+      new GetBucketCorsCommand({ Bucket: cfg.bucket }),
+    );
+    const rules = result.CORSRules ?? [];
+    if (rules.length === 0) {
+      console.log(
+        `ℹ️  s3://${cfg.bucket} has zero CORS rules — uploads from the browser will fail. Run \`pnpm spaces:set-cors\`.`,
+      );
+      return;
+    }
+    console.log(`✅ s3://${cfg.bucket} CORS rules (${rules.length}):\n`);
+    rules.forEach((r, i) => {
+      console.log(`  [${i}]`);
+      console.log(`    AllowedOrigins: ${JSON.stringify(r.AllowedOrigins ?? [])}`);
+      console.log(`    AllowedMethods: ${JSON.stringify(r.AllowedMethods ?? [])}`);
+      console.log(`    AllowedHeaders: ${JSON.stringify(r.AllowedHeaders ?? [])}`);
+      console.log(`    ExposeHeaders:  ${JSON.stringify(r.ExposeHeaders ?? [])}`);
+      console.log(`    MaxAgeSeconds:  ${r.MaxAgeSeconds ?? "(unset)"}`);
+      console.log("");
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/NoSuchCORSConfiguration|404/i.test(msg)) {
+      console.log(
+        `ℹ️  s3://${cfg.bucket} has no CORS configuration. Run \`pnpm spaces:set-cors\` to apply one.`,
+      );
+      return;
+    }
+    console.error(`❌ Failed to read CORS: ${msg}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Diagnostic companion to the existing `spaces:set-cors`. When an upload fails with *"No 'Access-Control-Allow-Origin' header is present"* — which is happening again on prod now — `pnpm spaces:get-cors` answers "is the rule even applied?" in one second instead of guessing.

Three common outcomes:

| Output | Meaning |
|---|---|
| `No CORS configuration found` | Rule was removed — re-run `spaces:set-cors` |
| Rules listed but visitor's origin not in AllowedOrigins | Add via `KLORAD_CORS_ORIGINS`, re-run set-cors |
| Rules listed and look correct | Look elsewhere (signing, bucket policy, clock skew) |

No new deps — uses the same `@aws-sdk/client-s3` already pulled in by the storage package, same `DO_SPACES_*` env vars as set-cors, same Node 20+ `--env-file` flag pattern.

Context: this PR is small + isolated from the current image-upload outage. **The actual fix for the outage is the user running `pnpm spaces:set-cors` to re-apply the rule that got cleared between PR #171 and now.** This script just makes the next round-trip diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)