### PR TITLE
fix(storage): stop AWS SDK from baking CRC32 into every presigned PUT (real fix for image uploads)

### DIFF
--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -33,6 +33,18 @@ function makeClient(cfg: StorageConfig): S3Client {
       accessKeyId: cfg.accessKeyId,
       secretAccessKey: cfg.secretAccessKey,
     },
+    // AWS SDK v3 ≥ 3.729 defaults to `WHEN_SUPPORTED`, which bakes a
+    // CRC32 of an *empty* body into every presigned PUT URL (the SDK
+    // computes the checksum at sign time, but a presigned URL has no
+    // body to checksum yet). DigitalOcean Spaces — and every other
+    // S3-compatible service that isn't AWS S3 — then 403s when the
+    // browser PUTs the real (non-empty) body because the signed
+    // checksum doesn't match. Reverting to `WHEN_REQUIRED` skips
+    // automatic checksums; we only get them when we ask for them.
+    // See AWS SDK release notes around 3.729 and the GitHub issue
+    // thread `aws-sdk-js-v3#6810`.
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
   });
 }
 


### PR DESCRIPTION
**This is what was actually breaking image uploads in production — not CORS, despite the browser surfacing it as one.**

## The actual root cause

AWS SDK v3 ≥ 3.729 (released ~2024-07) changed the default `requestChecksumCalculation` from `WHEN_REQUIRED` to `WHEN_SUPPORTED`. Now every `PutObjectCommand` automatically gets a CRC32 checksum — and when that command is turned into a presigned URL, the SDK signs the **empty-body** CRC32 (`AAAAAA==`) into the URL as the `x-amz-checksum-crc32` query param.

The browser then PUTs the real (non-empty) body, the server recomputes the CRC32, the two don't match, and DigitalOcean Spaces returns 403.

A 403 response without CORS headers attached then surfaces in the browser as *"No 'Access-Control-Allow-Origin' header is present on the requested resource"* — which is why this looked like a CORS regression and we kept reapplying the CORS rule. **The rule was always there. The request was getting rejected on integrity before CORS headers ever got attached to the response.**

The smoking gun in the failed URL: `x-amz-checksum-crc32=AAAAAA%3D%3D` — decode that base64 and you get four zero bytes, the CRC32 of an empty body.

## The fix

Pin both `requestChecksumCalculation` and `responseChecksumValidation` to `WHEN_REQUIRED` on the storage `S3Client`. Matches the historical pre-3.729 AWS SDK behaviour and the official guidance from DigitalOcean Spaces, Cloudflare R2, Backblaze B2, and MinIO for browser-direct uploads.

No surface API change — `presignUpload` callers don't notice. The next PUT signs without a body-checksum query param and DO accepts it.

## Why this affects every Klorad upload

Every `presignUpload` caller. That's the campus hero / logo / thumbnail uploads, plus the per-row image uploads on news / events / clubs / dining. Once this lands the entire image-upload surface across the campus dashboard works again.

## Test plan

- [ ] Deploy + try the hero upload on a published campus → 200, file lands at the public DO Spaces URL
- [ ] Try a news post image upload → same
- [ ] Try a clubs avatar upload → same
- [ ] Try a dining venue image → same
- [ ] Build clean: `pnpm build:campus`
- [ ] Storage package typechecks: `cd packages/storage && pnpm exec tsc --noEmit --skipLibCheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)