### PR TITLE
chore(campus): single `campus-app/` upload prefix per surface

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
@@ -13,6 +13,7 @@ import {
   Textarea,
 } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import {
   deriveInitials,
   type Club,
@@ -60,7 +61,7 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   const handleImage = async (file: File) => {
     setUploading(true);
     try {
-      const result = await uploadFile(file, { prefix: "campus-news" });
+      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.clubs });
       setImageUrl(result.publicUrl);
     } catch (e) {
       console.error(e);

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -12,6 +12,7 @@ import {
   Textarea,
 } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import { type DiningLocation } from "@/lib/dining-db";
 import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
 
@@ -52,7 +53,7 @@ export function DiningAdminClient({
   const handleImage = async (file: File) => {
     setUploading(true);
     try {
-      const result = await uploadFile(file, { prefix: "campus-news" });
+      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.dining });
       setImageUrl(result.publicUrl);
     } catch (e) {
       console.error(e);

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -13,6 +13,7 @@ import {
   Textarea,
 } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import {
   formatEventWhen,
   type EventPost,
@@ -84,7 +85,7 @@ export function EventsAdminClient({
   const handleImage = async (file: File) => {
     setUploading(true);
     try {
-      const result = await uploadFile(file, { prefix: "campus-news" });
+      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.events });
       setImageUrl(result.publicUrl);
     } catch (e) {
       console.error(e);

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -13,6 +13,7 @@ import {
   Textarea,
 } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import {
   formatNewsDate,
   type NewsPost,
@@ -69,7 +70,7 @@ export function NewsAdminClient({
   const handleImage = async (file: File) => {
     setUploading(true);
     try {
-      const result = await uploadFile(file, { prefix: "campus-news" });
+      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.news });
       setImageUrl(result.publicUrl);
     } catch (e) {
       console.error(e);

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/HomePagePanel.tsx
@@ -5,6 +5,7 @@ import useSWR, { mutate } from "swr";
 import { toast } from "react-toastify";
 import { uploadFile } from "@klorad/storage/client";
 import { Button, Field, Input, Panel, Textarea } from "@klorad/design-system";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import { type HomePageConfig, readHomePage } from "@/lib/home-page";
 import {
   type Localizable,
@@ -84,7 +85,7 @@ export default function HomePagePanel({ mapId }: Props) {
   const handleUpload = async (file: File) => {
     setUploading(true);
     try {
-      const { publicUrl } = await uploadFile(file, { prefix: "campus-hero" });
+      const { publicUrl } = await uploadFile(file, { prefix: UPLOAD_PREFIXES.branding });
       setHeroImage(publicUrl);
       toast.success("Hero image uploaded — Save to apply");
     } catch {

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/IndoorTab.tsx
@@ -6,6 +6,7 @@ import { toast } from "react-toastify";
 import { mutate } from "swr";
 import { Button } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import {
   MappedinViewer,
   type MappedinViewerHandle,
@@ -63,7 +64,7 @@ export default function IndoorTab({ map, onConfigure }: Props) {
         type: blob.type || "image/png",
       });
       const { publicUrl } = await uploadFile(file, {
-        prefix: "campus-thumbnails",
+        prefix: UPLOAD_PREFIXES.thumbnails,
       });
       const res = await fetch(`/api/maps/${mapId}`, {
         method: "PATCH",

--- a/apps/campus/lib/uploads/prefixes.ts
+++ b/apps/campus/lib/uploads/prefixes.ts
@@ -1,0 +1,39 @@
+/**
+ * Single source of truth for upload prefixes used by the campus app.
+ *
+ * Before this file existed, six different screens passed inline string
+ * prefixes to `uploadFile` — three distinct top-level "folders" at the
+ * bucket root (`campus-hero/`, `campus-thumbnails/`, `campus-news/`)
+ * plus four screens (clubs / news / dining / events) that all dumped
+ * into `campus-news/` because the string got copy-pasted between
+ * admin clients. The bucket root was a mess and the data was
+ * mislabelled.
+ *
+ * Every campus upload now lives under `campus-app/<surface>/`, named
+ * by the public surface the file belongs to. Adding a new upload site
+ * is one entry here + one import at the call site.
+ *
+ * **Existing files are not moved.** Persisted `imageUrl` values in
+ * Postgres point at the old keys (`campus-hero/...`, etc.) and those
+ * keep working — DO Spaces serves them unchanged. Only *new* uploads
+ * land under the new tree. A one-shot migration script can move the
+ * old files later if we want a clean bucket; it's intentionally not
+ * part of this change.
+ */
+export const UPLOAD_PREFIXES = {
+  /** Hero banner + logo + any tenant-branding asset for a campus. */
+  branding: "campus-app/branding",
+  /** Auto-captured MappedIn snapshots shown as the campus card thumbnail. */
+  thumbnails: "campus-app/thumbnails",
+  /** Per-row image on a NewsPost. */
+  news: "campus-app/news",
+  /** Per-row image on an EventPost. */
+  events: "campus-app/events",
+  /** Per-row image / avatar on a Club. */
+  clubs: "campus-app/clubs",
+  /** Per-row image on a DiningLocation. */
+  dining: "campus-app/dining",
+} as const;
+
+export type UploadPrefix =
+  (typeof UPLOAD_PREFIXES)[keyof typeof UPLOAD_PREFIXES];


### PR DESCRIPTION
Before this PR, six call sites scattered inline string prefixes across **three** top-level "folders" at the bucket root (`campus-hero/`, `campus-thumbnails/`, `campus-news/`), and **four screens** (clubs / news / dining / events) all dumped into `campus-news/` because the string got copy-pasted between admin clients. The bucket root was a mess and the content was mislabelled — a dining venue's hero image lived under `campus-news/...`.

After, every campus upload lives under `campus-app/<surface>/`:

| Prefix | Source |
|---|---|
| `campus-app/branding/` | home hero + future logo / tenant assets |
| `campus-app/thumbnails/` | auto-captured MappedIn snapshots |
| `campus-app/news/` | NewsPost per-row images |
| `campus-app/events/` | EventPost per-row images |
| `campus-app/clubs/` | Club avatars / per-row images |
| `campus-app/dining/` | DiningLocation hero images |

Defined once in `apps/campus/lib/uploads/prefixes.ts` so adding a new upload site is **one entry + one import** — no more string copy-paste drift across screens.

## Migration

**None.** Existing files stay where they are — persisted `imageUrl` values in Postgres point at the old keys (`campus-hero/...`, etc.) and DO Spaces serves them unchanged. Only new uploads land under the new tree. A one-shot migration script can move the old files later if you want a clean bucket; intentionally not part of this change since:

- It would need rewriting every `imageUrl` in News / Events / Clubs / Dining / Project rows
- It's not blocking anything
- The longer the rector tests, the more files would need migrating — easier to do all-at-once later

## Out of scope

`apps/campus/lib/workbench/operations/upload-floor-plan.tsx` uses `prefix: "floor-plans"` but lives in the parked workbench per [[campus-indoor-mappedin-decision]]. Left untouched.

## Test plan

- [ ] Upload a hero on the dashboard's Home tab → file lands at `campus-app/branding/...` (visible in the DO Spaces console)
- [ ] Upload a news post image → `campus-app/news/...`
- [ ] Upload a dining venue image → `campus-app/dining/...` (not the old `campus-news/`!)
- [ ] Capture a MappedIn thumbnail on Indoor → `campus-app/thumbnails/...`
- [ ] Existing campus content still renders — old `imageUrl` values keep working
- [ ] Build clean: `pnpm build:campus` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)