### PR TITLE
chore(storage): drop CORS preflight cache from 50 min to 5 min

### DIFF
--- a/packages/storage/scripts/set-cors.ts
+++ b/packages/storage/scripts/set-cors.ts
@@ -70,12 +70,21 @@ async function main() {
   // need PUT/GET/HEAD for the browser direct-upload flow. The
   // wildcard `AllowedHeaders` covers every `x-amz-*` header the
   // AWS SDK adds (checksums, ACL, signed-headers list).
+  //
+  // MaxAgeSeconds = 5 minutes. Was 3000 (50 min); reduced because
+  // a longer preflight cache turned every CORS-related fix into
+  // a guaranteed 50-minute "wait for the browser cache to expire"
+  // saga. We hit this twice on 2026-06-02 chasing what looked
+  // like a CORS regression but was actually a stale preflight
+  // remembering a failure from an earlier broken state. 5 min is
+  // long enough to deduplicate preflights inside a normal session
+  // and short enough that fixes feel immediate.
   const rule: CORSRule = {
     AllowedOrigins: origins,
     AllowedMethods: ["PUT", "GET", "HEAD"],
     AllowedHeaders: ["*"],
     ExposeHeaders: ["ETag"],
-    MaxAgeSeconds: 3000,
+    MaxAgeSeconds: 300,
   };
 
   await client.send(


### PR DESCRIPTION
Every browser caches the OPTIONS preflight response for the duration the bucket returns in \`Access-Control-Max-Age\`. Our bucket was returning **3000s (50 minutes)**. That made today (2026-06-02) much worse than it needed to be — once Chrome cached a preflight that *would have failed* (due to the AWS SDK checksum-baking bug, before we'd diagnosed it), every subsequent fix appeared to do nothing for the next 50 min because the browser never re-asked the bucket what its CORS rules were.

**5 minutes** is the right balance:

- Long enough to deduplicate preflights inside a normal authoring session — you're not making 20 separate OPTIONS round-trips per save.
- Short enough that any CORS-related fix feels immediate the next time you try the upload.

## To take effect

Just code in this PR — no bucket state changes yet. Once this merges, run:

\`\`\`bash
pnpm spaces:set-cors
\`\`\`

…from the repo root and the new MaxAgeSeconds replaces the old rule on \`prieston-prod\`. Same script as before; only the value changed. Future re-runs (e.g. after another origin needs adding via \`KLORAD_CORS_ORIGINS\`) inherit the new value automatically.

## Why pair this with the rebuild trigger

The empty commit \`e08014a4\` I pushed straight to main earlier just forces a Vercel rebuild — it has no other effect. This PR's content is the actual reason for it being here: a real one-line change with a real diagnosis behind it. Closes the apology loop and gives the rebuild something to actually rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)