### PR TITLE
fix(storage): restore x-amz-acl request header so uploads are public-read

### DIFF
--- a/packages/storage/src/client.ts
+++ b/packages/storage/src/client.ts
@@ -68,19 +68,22 @@ export function uploadToSignedUrl(
       "Content-Type",
       opts.contentType || file.type || "application/octet-stream"
     );
-    // ACL is already baked into the presigned URL as a query parameter
-    // (`x-amz-acl=...`) by the server. Sending it *also* as an HTTP
-    // header here means the request carries an `x-amz-*` header that
-    // *isn't* in the URL's `X-Amz-SignedHeaders=host` list — DO Spaces
-    // (and other strict S3-compatibles) reject that combination with
-    // 403, treating the unsigned header as signature tampering even
-    // though the value matches the query string. AWS S3 itself is
-    // lenient and accepts it; this is one of the spots S3-compatible
-    // services diverge from S3. Don't send it.
+    // ACL must be sent as a request header for DigitalOcean Spaces
+    // to honour it. The signed URL also carries `?x-amz-acl=...` as
+    // a query parameter, but in practice Spaces falls back to the
+    // bucket-default ACL (private) when only the query string is
+    // present and no matching header is sent — so without this line
+    // every upload lands as a private object, even though the URL
+    // was signed for `public-read`. DO Spaces is lenient about the
+    // unsigned-header / signed-headers mismatch when the values
+    // agree, so re-adding the header here doesn't break signature
+    // verification.
     //
-    // `opts.acl` is kept on the type for back-compat with any
-    // hypothetical caller that builds its own request — the wrapped
-    // `uploadFile` flow no longer needs it.
+    // This briefly went away in #189 chasing a 403 that turned out
+    // to be a Vercel-side secret mismatch (not an unsigned-header
+    // rejection). With the secret fixed the request shape was fine;
+    // removing this line just made the resulting objects private.
+    if (opts.acl) xhr.setRequestHeader("x-amz-acl", opts.acl);
     xhr.send(file);
   });
 }


### PR DESCRIPTION
## What

Revert of the client-side change in #189 — restoring `xhr.setRequestHeader('x-amz-acl', opts.acl)`.

## Why

#189 was my fix for what I thought was a 'DO Spaces strict on unsigned x-amz-acl header' 403. It turned out the actual 403 was a Vercel-side `DO_SPACES_SECRET` mismatch (different secret than the one that goes with the access key). Once the secret was corrected, uploads succeed — **but they land as private objects** because DO Spaces ignores the `?x-amz-acl=public-read` query parameter on the signed URL and falls back to the bucket-default ACL when no matching request header is sent.

Net result of #189 + the secret fix: uploads work, but every hero image, news image, club avatar, dining photo lands as a 403 to the public viewer because the object isn't readable.

The DO Spaces behaviour I thought I was working around in #189 — the strict 'unsigned header in request invalidates signature' — turns out not to apply. DO Spaces is lenient about the header being absent from `X-Amz-SignedHeaders=host` as long as the value matches the signed query parameter. Same behaviour as AWS S3 itself.

## What this PR does

Single line — re-add the `setRequestHeader` call I removed in #189:

```diff
+    if (opts.acl) xhr.setRequestHeader("x-amz-acl", opts.acl);
```

Net effect on the codebase: nothing different from main *before* #189 was opened. The commit history + memory now record why we briefly removed it and why we put it back.

## Lessons

Memory updated — the 'DO Spaces strict on unsigned x-amz-* headers' note from earlier today was wrong. The real rule: when a presigned URL gets a 403 `SignatureDoesNotMatch` from any S3-compatible target, **always check the server-side secret first** — credentials are the #1 cause of that error code. Header-shape diagnoses come second.

## Test plan

- [ ] Once deployed, upload a hero image. Open the file's public URL in an incognito tab — it should render (not return 403 / AccessDenied).
- [ ] Same for news / events / clubs / dining image uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)