### PR TITLE
feat(campus): Identity & branding authoring screen (Phase 5 / Manage tier)

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/CampusIdentityPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/CampusIdentityPageClient.tsx
@@ -1,0 +1,661 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import useSWR, { mutate as globalMutate } from "swr";
+import { toast } from "react-toastify";
+import { Palette, Upload } from "lucide-react";
+import { Button, Field, Input, Panel } from "@klorad/design-system";
+import { uploadFile } from "@klorad/storage/client";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
+import { PhonePreview } from "@/app/(dashboard)/components/PhonePreview";
+import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
+import { deriveCampusPalette } from "@/lib/palette";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+interface CampusBranding {
+  name?: string;
+  nameEl?: string;
+  shortName?: string;
+  logo?: string;
+  primaryColor?: string;
+  indoorMapId?: string;
+}
+
+interface HomePageConfig {
+  heroImage?: string;
+  headline?: { en?: string; el?: string };
+  tagline?: { en?: string; el?: string };
+}
+
+interface SceneData {
+  branding?: CampusBranding;
+  homePage?: HomePageConfig;
+  [k: string]: unknown;
+}
+
+interface MapResponse {
+  id: string;
+  title: string;
+  sceneData?: SceneData;
+}
+
+const fetcher = (url: string): Promise<MapResponse> =>
+  fetch(url).then((r) => r.json());
+
+/** Eight curated brand-colour starters. Hand-picked across the OKLCH
+ *  hue wheel so the swatches stay visually distinct + every option
+ *  produces a coherent derived palette via `deriveCampusPalette`. */
+const COLOR_PRESETS = [
+  "#534ab7", // Klorad purple
+  "#158ca3", // teal (IHU)
+  "#1976d2", // royal blue
+  "#0e7c4a", // forest
+  "#c25700", // burnt orange
+  "#b22d68", // berry
+  "#7e3a98", // amethyst
+  "#1f2937", // slate near-black
+];
+
+/** Limit for the PWA install label. iOS truncates anything longer. */
+const SHORT_NAME_MAX = 12;
+
+function isHex(value: string): boolean {
+  return /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value.trim());
+}
+
+/** Short version of a campus name — used as the PWA home-screen
+ *  label when the rector hasn't typed their own. Trim, cap at the
+ *  iOS limit, keep words intact when possible. */
+function deriveShortName(name: string): string {
+  const clean = name.trim();
+  if (clean.length <= SHORT_NAME_MAX) return clean;
+  const words = clean.split(/\s+/);
+  let out = "";
+  for (const w of words) {
+    const next = out ? `${out} ${w}` : w;
+    if (next.length > SHORT_NAME_MAX) break;
+    out = next;
+  }
+  return out || clean.slice(0, SHORT_NAME_MAX);
+}
+
+/**
+ * Identity & branding — the screen rectors land on to white-label
+ * their campus. Single page, no tabs: name, logo, hero, colour, all
+ * visible at once. Live phone preview on the right (lg+) so every
+ * change shows up in the iframe after a save.
+ *
+ * Persistence model: everything lives in `Project.sceneData`. We
+ * read once on mount via SWR, the form holds the in-flight edit
+ * state, Save PATCHes the merged scene back. The public consumer
+ * routes pick up the new state on their next request (60s cache TTL
+ * via `getPublicCampusByToken`); the preview is refreshed in-place
+ * via `PhonePreview`'s reloadToken.
+ *
+ * Zero-required-input principle: if the rector hits Save with no
+ * logo or hero uploaded, the public surface still works — the nav
+ * falls back to a clean wordmark, the home falls back to the
+ * platform hero image. Their primary colour cascades into every
+ * tinted surface via the layout's CSS-var injection.
+ */
+export default function CampusIdentityPageClient({
+  orgId: _orgId,
+  mapId,
+}: Props) {
+  const { data: server, isLoading } = useSWR<MapResponse>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
+
+  // Form state — initialised once from the server, edits stay local
+  // until Save. Lang toggle is UI-only, not persisted.
+  const [lang, setLang] = useState<"en" | "el">("en");
+  const [name, setName] = useState("");
+  const [nameEl, setNameEl] = useState("");
+  const [shortName, setShortName] = useState("");
+  const [logoUrl, setLogoUrl] = useState("");
+  const [heroUrl, setHeroUrl] = useState("");
+  const [primaryColor, setPrimaryColor] = useState("");
+  const [hydrated, setHydrated] = useState(false);
+
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [uploadingHero, setUploadingHero] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [previewKey, setPreviewKey] = useState(0);
+
+  // Hydrate the form from the server response — exactly once. SWR
+  // revalidates on focus (which the file picker triggers!); re-running
+  // this on every revalidation would clobber unsaved edits including
+  // a just-uploaded image.
+  useEffect(() => {
+    if (hydrated || !server) return;
+    const branding = server.sceneData?.branding ?? {};
+    const home = server.sceneData?.homePage ?? {};
+    setName(branding.name ?? server.title ?? "");
+    setNameEl(branding.nameEl ?? "");
+    setShortName(branding.shortName ?? "");
+    setLogoUrl(branding.logo ?? "");
+    setHeroUrl(home.heroImage ?? "");
+    setPrimaryColor(branding.primaryColor ?? "");
+    setHydrated(true);
+  }, [hydrated, server]);
+
+  // Derived palette preview — recompute on every primaryColor change.
+  // Memoised so the 8 tile re-render doesn't cost a parse-per-paint.
+  const palette = useMemo(
+    () => deriveCampusPalette(primaryColor || undefined),
+    [primaryColor],
+  );
+
+  // Compare current form state to what the server has — `Save` is
+  // disabled when nothing changed. The shortName comparison treats
+  // empty as equivalent to the auto-derived value so flipping the
+  // box and back doesn't look dirty.
+  const dirty = useMemo(() => {
+    if (!hydrated || !server) return false;
+    const b = server.sceneData?.branding ?? {};
+    const h = server.sceneData?.homePage ?? {};
+    return (
+      name !== (b.name ?? server.title ?? "") ||
+      nameEl !== (b.nameEl ?? "") ||
+      shortName !== (b.shortName ?? "") ||
+      logoUrl !== (b.logo ?? "") ||
+      heroUrl !== (h.heroImage ?? "") ||
+      primaryColor !== (b.primaryColor ?? "")
+    );
+  }, [
+    hydrated,
+    server,
+    name,
+    nameEl,
+    shortName,
+    logoUrl,
+    heroUrl,
+    primaryColor,
+  ]);
+
+  const handleUpload = async (
+    file: File,
+    target: "logo" | "hero",
+  ) => {
+    const setter = target === "logo" ? setLogoUrl : setHeroUrl;
+    const busy = target === "logo" ? setUploadingLogo : setUploadingHero;
+    busy(true);
+    try {
+      const result = await uploadFile(file, {
+        prefix: UPLOAD_PREFIXES.branding,
+      });
+      setter(result.publicUrl);
+      toast.success(target === "logo" ? "Logo uploaded" : "Hero uploaded");
+    } catch (err) {
+      console.error(err);
+      toast.error("Upload failed");
+    } finally {
+      busy(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!server || !dirty || saving) return;
+    setSaving(true);
+    try {
+      // Merge — never replace — `sceneData`. The Map screen owns
+      // `indoorMapId`, the Home screen owns the headline / tagline,
+      // and we don't want to wipe their edits.
+      const trimmedShort = shortName.trim();
+      const nextBranding: CampusBranding = {
+        ...(server.sceneData?.branding ?? {}),
+        name: name.trim() || undefined,
+        nameEl: nameEl.trim() || undefined,
+        shortName:
+          trimmedShort && trimmedShort !== deriveShortName(name)
+            ? trimmedShort
+            : undefined,
+        logo: logoUrl.trim() || undefined,
+        primaryColor:
+          primaryColor.trim() && isHex(primaryColor) ? primaryColor : undefined,
+      };
+      const nextHome: HomePageConfig = {
+        ...(server.sceneData?.homePage ?? {}),
+        heroImage: heroUrl.trim() || undefined,
+      };
+      const nextScene: SceneData = {
+        ...(server.sceneData ?? {}),
+        branding: nextBranding,
+        homePage: nextHome,
+      };
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneData: nextScene }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      await globalMutate(`/api/maps/${mapId}`);
+      toast.success("Branding updated");
+      // Bump the preview's reload token so the iframe reruns its
+      // server fetch and the rector sees the change immediately.
+      setPreviewKey((k) => k + 1);
+    } catch (err) {
+      console.error(err);
+      toast.error("Couldn't save changes");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (isLoading || !hydrated) {
+    return (
+      <div className="mx-auto w-full max-w-[1400px] space-y-4 px-6 py-8 md:px-10">
+        <div className="h-12 w-1/3 animate-pulse rounded-md bg-surface-2" />
+        <div className="h-64 animate-pulse rounded-2xl bg-surface-2" />
+      </div>
+    );
+  }
+
+  // Derive an effective short-name preview — what would land on the
+  // home-screen install today.
+  const effectiveShortName =
+    shortName.trim() || deriveShortName(name) || "Campus";
+
+  return (
+    <div className="mx-auto w-full max-w-[1400px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Manage"
+        title="Identity & branding"
+        subtitle="Everything that makes the campus look like itself. Edits here recolor the public viewer and the mobile install icon."
+        actions={
+          <>
+            <OpenPublicAction href={`/campus/${mapId}`} />
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!dirty || saving}
+            >
+              {saving ? "Saving…" : "Save changes"}
+            </Button>
+          </>
+        }
+      />
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="min-w-0 space-y-6">
+          {/* ─ Campus identity ────────────────────────────────────── */}
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Campus identity
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  Used in the nav, share card and PWA install icon.
+                </p>
+              </div>
+              <LangToggle lang={lang} onChange={setLang} />
+            </div>
+            <div className="space-y-5">
+              <Field
+                label={
+                  lang === "en" ? "Campus name · EN" : "Campus name · ΕΛ"
+                }
+                hint="Shown in the top nav and the share card title."
+              >
+                <Input
+                  value={lang === "en" ? name : nameEl}
+                  onChange={(e) =>
+                    (lang === "en" ? setName : setNameEl)(e.target.value)
+                  }
+                  placeholder={lang === "en" ? "Thermi (HQ)" : "Θέρμη"}
+                />
+              </Field>
+              <Field
+                label="Short name"
+                hint={`Label under the PWA install icon. Up to ${SHORT_NAME_MAX} chars. Defaults to a smart trim of the name.`}
+              >
+                <Input
+                  value={shortName}
+                  onChange={(e) =>
+                    setShortName(e.target.value.slice(0, SHORT_NAME_MAX))
+                  }
+                  placeholder={effectiveShortName}
+                  maxLength={SHORT_NAME_MAX}
+                />
+              </Field>
+            </div>
+          </Panel>
+
+          {/* ─ Brand assets ───────────────────────────────────────── */}
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Logo &amp; hero
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Skip them and the campus still looks great — we derive a
+                clean wordmark from the campus name + your primary colour.
+              </p>
+            </div>
+            <div className="space-y-6">
+              <UploadField
+                label="Logo"
+                hint="Square-ish PNG or SVG, transparent background. Used in the nav and as the install icon."
+                value={logoUrl}
+                preview={
+                  logoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={logoUrl}
+                      alt=""
+                      className="h-12 w-12 rounded-lg object-contain"
+                    />
+                  ) : (
+                    <LogoPlaceholder
+                      name={name || "Campus"}
+                      color={palette.primary}
+                    />
+                  )
+                }
+                accept="image/png,image/svg+xml,image/jpeg,image/webp"
+                uploading={uploadingLogo}
+                onUpload={(file) => handleUpload(file, "logo")}
+                onClear={() => setLogoUrl("")}
+              />
+              <UploadField
+                label="Hero image"
+                hint="Wide image (≈1600×600), used behind the greeting on the public home."
+                value={heroUrl}
+                preview={
+                  heroUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={heroUrl}
+                      alt=""
+                      className="block h-20 w-32 rounded-md object-cover"
+                    />
+                  ) : (
+                    <HeroPlaceholder
+                      color={palette.primary}
+                      fill={palette.primaryFill}
+                    />
+                  )
+                }
+                accept="image/png,image/jpeg,image/webp"
+                uploading={uploadingHero}
+                onUpload={(file) => handleUpload(file, "hero")}
+                onClear={() => setHeroUrl("")}
+              />
+            </div>
+          </Panel>
+
+          {/* ─ Primary colour ─────────────────────────────────────── */}
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <Palette size={16} strokeWidth={1.75} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Primary colour
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  One hex — the entire public surface derives from this:
+                  accents, buttons, the mobile browser chrome tint, even
+                  the dot-pattern in the share card.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-5">
+              <div className="flex flex-wrap items-center gap-2">
+                {COLOR_PRESETS.map((hex) => {
+                  const active =
+                    primaryColor.toLowerCase() === hex.toLowerCase();
+                  return (
+                    <button
+                      key={hex}
+                      type="button"
+                      onClick={() => setPrimaryColor(hex)}
+                      aria-label={`Use ${hex}`}
+                      aria-pressed={active}
+                      className={`h-8 w-8 rounded-full ring-2 transition-all ${
+                        active
+                          ? "ring-offset-2 ring-offset-bg ring-text-primary"
+                          : "ring-transparent hover:ring-line-strong"
+                      }`}
+                      style={{ backgroundColor: hex }}
+                    />
+                  );
+                })}
+              </div>
+
+              <Field label="Custom hex">
+                <div className="flex items-center gap-3">
+                  <input
+                    type="color"
+                    aria-label="Pick a colour"
+                    value={isHex(primaryColor) ? primaryColor : palette.primary}
+                    onChange={(e) => setPrimaryColor(e.target.value)}
+                    className="h-9 w-12 cursor-pointer rounded-md border border-line-soft bg-transparent"
+                  />
+                  <Input
+                    value={primaryColor}
+                    onChange={(e) => setPrimaryColor(e.target.value)}
+                    placeholder="#534ab7"
+                    spellCheck={false}
+                  />
+                </div>
+              </Field>
+
+              <div>
+                <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+                  Derived palette
+                </div>
+                <div className="grid grid-cols-4 gap-2 sm:grid-cols-8">
+                  {[
+                    ["Primary", palette.primary],
+                    ["Fill", palette.primaryFill],
+                    ["Soft", palette.primarySoft],
+                    ["Bg", palette.primaryBg],
+                    ["Ink", palette.primaryInk],
+                    ["Warm", palette.accentWarm],
+                    ["Cool", palette.accentCool],
+                    ["Comp.", palette.accentComplement],
+                  ].map(([label, color]) => (
+                    <div key={label} className="text-center">
+                      <div
+                        className="mb-1 h-12 w-full rounded-lg"
+                        style={{ backgroundColor: color }}
+                        aria-label={`${label}: ${color}`}
+                      />
+                      <div className="truncate text-[10px] font-medium text-text-secondary">
+                        {label}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Panel>
+        </div>
+
+        {/* ─ Live preview ─────────────────────────────────────────── */}
+        <aside className="hidden lg:block">
+          <PhonePreview
+            src={`/campus/${mapId}`}
+            title="Public campus preview"
+            reloadToken={previewKey}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+function LangToggle({
+  lang,
+  onChange,
+}: {
+  lang: "en" | "el";
+  onChange: (l: "en" | "el") => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Language"
+      className="inline-flex rounded-full border border-line-soft p-0.5"
+    >
+      {(["en", "el"] as const).map((l) => {
+        const active = l === lang;
+        return (
+          <button
+            key={l}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(l)}
+            className={
+              active
+                ? "rounded-full bg-accent px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white"
+                : "rounded-full px-2.5 py-1 text-[10px] font-medium uppercase tracking-wide text-text-secondary hover:text-text-primary"
+            }
+          >
+            {l === "en" ? "EN" : "ΕΛ"}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface UploadFieldProps {
+  label: string;
+  hint?: string;
+  value: string;
+  preview: React.ReactNode;
+  accept: string;
+  uploading: boolean;
+  onUpload: (file: File) => void;
+  onClear: () => void;
+}
+
+/**
+ * Compact upload row — visible preview on the left, Upload + Clear
+ * buttons on the right, file input hidden under the label so the
+ * whole control reads as one tap target.
+ */
+function UploadField({
+  label,
+  hint,
+  value,
+  preview,
+  accept,
+  uploading,
+  onUpload,
+  onClear,
+}: UploadFieldProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <div>
+      <div className="mb-2 text-sm font-medium text-text-primary">{label}</div>
+      <div className="flex items-center gap-4 rounded-xl border border-line-soft bg-surface-2/40 p-3">
+        <div className="flex h-20 w-32 shrink-0 items-center justify-center overflow-hidden rounded-md bg-surface-1">
+          {preview}
+        </div>
+        <div className="min-w-0 flex-1">
+          {hint ? (
+            <p className="mb-2 text-xs text-text-tertiary">{hint}</p>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              ref={inputRef}
+              type="file"
+              accept={accept}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) onUpload(f);
+                e.target.value = "";
+              }}
+              className="hidden"
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => inputRef.current?.click()}
+              disabled={uploading}
+            >
+              <Upload size={12} strokeWidth={1.75} aria-hidden />
+              {uploading ? "Uploading…" : value ? "Replace" : "Upload"}
+            </Button>
+            {value ? (
+              <Button size="sm" variant="ghost" onClick={onClear}>
+                Remove
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * Default logo placeholder — clean monogram in the rector's primary
+ * colour. Renders the first 1-2 letters of the campus name on a
+ * tinted square. Better than a generic stock logo because it's
+ * *theirs*: campus name + their colour.
+ */
+function LogoPlaceholder({ name, color }: { name: string; color: string }) {
+  const initials = useMemo(() => {
+    const parts = name
+      .replace(/[^A-Za-zΑ-Ωα-ω\s]/g, "")
+      .split(/\s+/)
+      .filter(Boolean);
+    if (parts.length === 0) return "K";
+    return parts
+      .slice(0, 2)
+      .map((p) => p[0]?.toUpperCase() ?? "")
+      .join("");
+  }, [name]);
+  return (
+    <div
+      className="flex h-12 w-12 items-center justify-center rounded-lg text-base font-semibold text-white"
+      style={{ backgroundColor: color }}
+    >
+      {initials}
+    </div>
+  );
+}
+
+/**
+ * Default hero placeholder — gradient using the rector's primary +
+ * primaryFill, dot-pattern overlay. Same visual register as the
+ * campus cards in the org grid; gives the rector "their colour, in
+ * real estate" before they upload a real photo.
+ */
+function HeroPlaceholder({
+  color,
+  fill,
+}: {
+  color: string;
+  fill: string;
+}) {
+  return (
+    <div
+      className="block h-20 w-32 rounded-md"
+      aria-hidden
+      style={{
+        background: `radial-gradient(rgba(255,255,255,0.15) 1px, transparent 1px) 0 0/12px 12px, linear-gradient(135deg, ${color} 0%, ${fill} 100%)`,
+      }}
+    />
+  );
+}
+

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/page.tsx
@@ -1,11 +1,14 @@
-import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusIdentityPageClient from "./CampusIdentityPageClient";
 
-export default function CampusIdentityPage() {
-  return (
-    <ComingSoonScreen
-      title="Identity & branding"
-      hint="Campus name, display name, tagline and description in EL+EN. Logo, hero image, primary colour."
-      phase="Phase 5"
-    />
-  );
+export default async function CampusIdentityPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
+  return <CampusIdentityPageClient orgId={orgId} mapId={mapId} />;
 }


### PR DESCRIPTION
First Phase 5 screen — replaces the `ComingSoonScreen` stub at `/maps/[mapId]/identity` with the real authoring surface. This is the screen rectors land on to white-label their campus.

## Best-effort UX for v1

- **Zero required input.** Hit Save with no logo, no hero, no short-name — the public surface still looks intentional. A clean monogram fills the logo slot (campus initials in the chosen colour); a gradient + dot-pattern fills the hero slot using the same palette. Better than generic stock assets because the placeholders are *theirs*.
- **Single screen, no tabs.** Three Panel cards stacked: Identity, Brand assets, Primary colour. Everything visible on a desktop window with no scroll.
- **Colour drives everything.** 8 curated brand-colour starters across the OKLCH hue wheel + custom hex + native picker. The 8-tile derived palette previews live as the rector types — they see what `--brand-fill / --brand-soft / --brand-bg / --brand-ink` and the three accents will look like before they save.
- **Auto-derived short-name.** PWA install label defaults to a word-aware trim of the campus name (capped at 12 chars for iOS). Rector only overrides when they want a different feel.
- **Live phone preview** via the existing `PhonePreview` primitive from Phase 4b. Refreshes after Save (`reloadToken` bump).
- **Save disabled until dirty.** Edits live in form state until explicit save; the comparison treats empty short-name as equivalent to the auto-derived value so flipping it doesn't show as a real edit.

## Persistence — merge, never replace

Updates `sceneData.branding.{name, nameEl, shortName, logo, primaryColor}` and `sceneData.homePage.heroImage`. Everything else under `sceneData` (indoorMapId, headline, tagline, eventFeeds, …) is preserved exactly. The existing PATCH at `/api/maps/[mapId]` already accepts this shape.

## Image uploads

Uses the now-stable `uploadFile` flow with `UPLOAD_PREFIXES.branding` — lands at `campus-app/branding/`, public-read, the right colour to land under the rector's brand assets prefix.

## Bilingual

`name` (EN) + `nameEl` (ΕΛ) persisted as separate strings. EN / ΕΛ pill toggle inline in the Identity panel, same convention as `HomePagePanel`.

## What's deliberately left for follow-ups

- **Tagline + description fields on Identity** — for v1 the campus `title` covers the share-card title; tagline lives on Home.
- **Stock photo library for hero** — the gradient placeholder is good enough that uploading a real photo is a *want*, not a blocker.
- **Custom domain** — Phase 2 waitlisted per the existing Settings panel.
- **Draft-channel iframe sync** — preview refreshes on Save, not on every keystroke. Real polish step but adds infra; Save → refresh cycle is fine for v1.

## Test plan

- [ ] Visit `/org/[orgId]/maps/[mapId]/identity` → form populated from existing sceneData
- [ ] Switch EN / ΕΛ → name field swaps with correct value
- [ ] Pick a colour swatch → derived palette tiles update; phone preview tints update after save
- [ ] Upload a logo → preview replaces monogram; file lands at `campus-app/branding/`
- [ ] Upload a hero → preview replaces gradient
- [ ] Type custom hex → native picker syncs; palette previews update
- [ ] Hit Save with no changes → button disabled
- [ ] Open public viewer → renders with new branding after refresh
- [ ] Build clean: `pnpm build:campus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)