### PR TITLE
feat(campus): Reach authoring screen (Phase 5 / Manage tier)

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/CampusReachPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/CampusReachPageClient.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import useSWR, { mutate as globalMutate } from "swr";
+import { toast } from "react-toastify";
+import QRCode from "qrcode";
+import {
+  Bell,
+  Check,
+  Copy,
+  Download,
+  History,
+  QrCode,
+  Send,
+  Users,
+} from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Select,
+  Textarea,
+} from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+  vapidEnabled: boolean;
+}
+
+interface MapResponse {
+  id: string;
+  title: string;
+  isPublished?: boolean;
+}
+
+interface PushStats {
+  subscribers: number;
+}
+
+const mapFetcher = (url: string): Promise<MapResponse> =>
+  fetch(url).then((r) => r.json());
+
+const pushFetcher = (url: string): Promise<PushStats> =>
+  fetch(url).then((r) => r.json());
+
+/** Targets the broadcast deep-link picker offers. Keep tight — too
+ *  many choices makes the picker noisy. Each maps to a real route on
+ *  the public consumer site. */
+const DEEPLINK_TARGETS = [
+  { key: "home", label: "Home", path: "" },
+  { key: "map", label: "Map", path: "/map" },
+  { key: "events", label: "Events", path: "/events" },
+  { key: "news", label: "News", path: "/news" },
+  { key: "dining", label: "Dining", path: "/dining" },
+  { key: "clubs", label: "Clubs", path: "/clubs" },
+  { key: "klio", label: "Klio (ask)", path: "/klio" },
+] as const;
+
+const TITLE_MAX = 60;
+const BODY_MAX = 160;
+
+/**
+ * Reach — the rector's outbound channel: publish state, the link +
+ * QR they share with students, and the broadcast composer that pushes
+ * to every installed device.
+ *
+ * Layout: two columns on lg+. Left pane is the work the rector did
+ * today (publish + send a broadcast). Right pane is the shareable
+ * artefact (URL + QR + subscriber count) — the things they hand to a
+ * student, paste into a flyer, screenshot for slack. Keeping those
+ * sides separate stopped the screen feeling like a dense form.
+ *
+ * Broadcast history with CTR is deferred — it needs a `Broadcast`
+ * model that doesn't exist yet. The Send button reports the live
+ * delivered / attempted / pruned counts via toast so the rector sees
+ * what just happened.
+ */
+export default function CampusReachPageClient({
+  orgId: _orgId,
+  mapId,
+  vapidEnabled,
+}: Props) {
+  const { data: map } = useSWR<MapResponse>(
+    `/api/maps/${mapId}`,
+    mapFetcher,
+  );
+  const { data: stats } = useSWR<PushStats>(
+    `/api/maps/${mapId}/push-stats`,
+    pushFetcher,
+    { refreshInterval: 30_000 },
+  );
+
+  const [target, setTarget] = useState<(typeof DEEPLINK_TARGETS)[number]["key"]>(
+    "home",
+  );
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const [publishBusy, setPublishBusy] = useState(false);
+  const [qrSvg, setQrSvg] = useState<string>("");
+  const [copied, setCopied] = useState(false);
+
+  const publicUrl = useMemo(() => {
+    if (typeof window === "undefined") return `/campus/${mapId}`;
+    return `${window.location.origin}/campus/${mapId}`;
+  }, [mapId]);
+
+  // Render the QR client-side when the URL is known. SVG is sharp
+  // at any zoom and downloads as a file the rector can drop into
+  // print or paste into Figma without rasterising. `level: 'M'` is
+  // the sweet spot between resilience and dot density at typical
+  // student-phone scan distance.
+  useEffect(() => {
+    let cancelled = false;
+    QRCode.toString(publicUrl, {
+      type: "svg",
+      errorCorrectionLevel: "M",
+      margin: 1,
+      color: { dark: "#1a1a1a", light: "#ffffff" },
+      width: 240,
+    })
+      .then((svg) => {
+        if (!cancelled) setQrSvg(svg);
+      })
+      .catch(() => {
+        if (!cancelled) setQrSvg("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [publicUrl]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(publicUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      toast.error("Couldn't copy the link");
+    }
+  };
+
+  const handleDownloadQr = () => {
+    if (!qrSvg) return;
+    const blob = new Blob([qrSvg], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    // Filename includes the mapId so the rector can save multiple
+    // campus QRs without overwriting in their Downloads folder.
+    a.download = `campus-${mapId}.svg`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleTogglePublish = async () => {
+    if (!map || publishBusy) return;
+    setPublishBusy(true);
+    const next = !map.isPublished;
+    try {
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isPublished: next }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      await globalMutate(`/api/maps/${mapId}`);
+      toast.success(next ? "Campus is now public" : "Campus is now a draft");
+    } catch {
+      toast.error("Couldn't update visibility");
+    } finally {
+      setPublishBusy(false);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!title.trim() || !body.trim() || sending) return;
+    if (!vapidEnabled) {
+      toast.error("Push notifications aren't configured on this server.");
+      return;
+    }
+    setSending(true);
+    try {
+      const targetPath = DEEPLINK_TARGETS.find((t) => t.key === target)?.path ?? "";
+      const res = await fetch(`/api/maps/${mapId}/notify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          url: `/campus/${mapId}${targetPath}`,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        result?: { attempted: number; delivered: number; pruned: number };
+        error?: string;
+      };
+      if (!res.ok || !data.ok) {
+        throw new Error(data.error ?? "Send failed");
+      }
+      toast.success(
+        `Sent to ${data.result?.delivered ?? 0} of ${data.result?.attempted ?? 0} subscribers`,
+      );
+      setTitle("");
+      setBody("");
+      // Subscriber count may have shrunk if any endpoints were
+      // pruned — refresh so the rector sees the live number.
+      await globalMutate(`/api/maps/${mapId}/push-stats`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't send");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const isPublished = Boolean(map?.isPublished);
+  const subscribers = stats?.subscribers ?? 0;
+  const canSend = vapidEnabled && title.trim() && body.trim() && !sending;
+
+  return (
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Manage"
+        title="Reach"
+        subtitle="Publish state, the shareable link &amp; QR, and push broadcasts to every installed student."
+        actions={<OpenPublicAction href={`/campus/${mapId}`} />}
+      />
+
+      {/* ─ Publish toggle ─────────────────────────────────────────── */}
+      <Panel className="mb-6 rounded-2xl p-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-text-primary">
+              Public visibility
+            </h2>
+            <p className="mt-0.5 text-xs text-text-tertiary">
+              {isPublished
+                ? "Live — anyone with the link can open it."
+                : "Draft — only authors can see it."}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant={isPublished ? "secondary" : "primary"}
+            onClick={handleTogglePublish}
+            disabled={publishBusy}
+          >
+            {publishBusy
+              ? "…"
+              : isPublished
+                ? "Unpublish"
+                : "Publish campus"}
+          </Button>
+        </div>
+      </Panel>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        {/* ─ Left: outbound work ─────────────────────────────────── */}
+        <div className="min-w-0 space-y-6">
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <Send size={16} strokeWidth={1.75} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Send a broadcast
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  Push to {subscribers.toLocaleString()} subscriber
+                  {subscribers === 1 ? "" : "s"}. Optionally deep-link to any
+                  campus surface — students tapping the notification land
+                  exactly there.
+                </p>
+              </div>
+            </div>
+
+            {!vapidEnabled ? (
+              <div className="mb-4 rounded-xl border border-line-soft bg-surface-2/40 px-4 py-3 text-xs text-text-tertiary">
+                Push notifications aren&rsquo;t configured on this server.
+                Set <code>NEXT_PUBLIC_VAPID_PUBLIC_KEY</code>,
+                <code> VAPID_PRIVATE_KEY</code> and <code>VAPID_SUBJECT</code>{" "}
+                in the environment to enable.
+              </div>
+            ) : null}
+
+            <div className="space-y-4">
+              <Field
+                label="Title"
+                hint={`${TITLE_MAX - title.length} characters left.`}
+              >
+                <Input
+                  value={title}
+                  onChange={(e) =>
+                    setTitle(e.target.value.slice(0, TITLE_MAX))
+                  }
+                  placeholder="Exam timetable is live"
+                  maxLength={TITLE_MAX}
+                  disabled={!vapidEnabled}
+                />
+              </Field>
+              <Field
+                label="Body"
+                hint={`${BODY_MAX - body.length} characters left.`}
+              >
+                <Textarea
+                  value={body}
+                  onChange={(e) =>
+                    setBody(e.target.value.slice(0, BODY_MAX))
+                  }
+                  placeholder="Tap to view the June exam schedule."
+                  rows={3}
+                  maxLength={BODY_MAX}
+                  disabled={!vapidEnabled}
+                />
+              </Field>
+              <Field label="Deep-link target">
+                <Select
+                  value={target}
+                  onChange={(e) =>
+                    setTarget(
+                      e.target.value as (typeof DEEPLINK_TARGETS)[number]["key"],
+                    )
+                  }
+                  disabled={!vapidEnabled}
+                >
+                  {DEEPLINK_TARGETS.map((t) => (
+                    <option key={t.key} value={t.key}>
+                      {t.label}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  onClick={handleSend}
+                  disabled={!canSend}
+                >
+                  <Send size={12} strokeWidth={1.75} aria-hidden />
+                  {sending ? "Sending…" : "Send broadcast"}
+                </Button>
+              </div>
+            </div>
+          </Panel>
+
+          {/* ─ History placeholder ───────────────────────────────── */}
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <History size={16} strokeWidth={1.75} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Broadcast history
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  Past broadcasts and their delivered / CTR counts.
+                </p>
+              </div>
+            </div>
+            <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+              History lands once we persist broadcasts to a model.
+            </div>
+          </Panel>
+        </div>
+
+        {/* ─ Right: the share card ──────────────────────────────── */}
+        <aside className="space-y-6">
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <QrCode size={16} strokeWidth={1.75} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Share to students
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  The link + QR you hand out. Survives printing — SVG
+                  download is sharp at any size.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col items-center gap-4">
+              <div
+                className="flex h-48 w-48 items-center justify-center rounded-xl bg-white p-2 shadow-sm"
+                aria-label="QR code"
+                dangerouslySetInnerHTML={
+                  qrSvg
+                    ? { __html: qrSvg }
+                    : { __html: "<div style='color:#9ca3af;font-size:11px'>Generating…</div>" }
+                }
+              />
+              <div className="w-full text-center">
+                <div className="truncate font-mono text-xs text-text-secondary">
+                  {publicUrl}
+                </div>
+              </div>
+              <div className="flex w-full flex-col gap-2">
+                <Button size="sm" variant="secondary" onClick={handleCopy}>
+                  {copied ? (
+                    <>
+                      <Check size={12} strokeWidth={1.75} aria-hidden />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy size={12} strokeWidth={1.75} aria-hidden />
+                      Copy URL
+                    </>
+                  )}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleDownloadQr}
+                  disabled={!qrSvg}
+                >
+                  <Download size={12} strokeWidth={1.75} aria-hidden />
+                  Download QR
+                </Button>
+              </div>
+            </div>
+          </Panel>
+
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-3 flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <Users size={16} strokeWidth={1.75} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Subscribers
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  Anonymous, by browser endpoint.
+                </p>
+              </div>
+            </div>
+            <div className="text-3xl font-light text-text-primary">
+              {subscribers.toLocaleString()}
+            </div>
+            <div className="mt-1 inline-flex items-center gap-1 text-[11px] text-text-tertiary">
+              <Bell size={11} strokeWidth={1.75} aria-hidden />
+              {vapidEnabled
+                ? "Push enabled · live count"
+                : "Push not configured"}
+            </div>
+          </Panel>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/page.tsx
@@ -1,11 +1,20 @@
-import { ComingSoonScreen } from "@/app/(dashboard)/components/ComingSoonScreen";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusReachPageClient from "./CampusReachPageClient";
 
-export default function CampusReachPage() {
+export default async function CampusReachPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
   return (
-    <ComingSoonScreen
-      title="Reach"
-      hint="Publish state, public URL + QR, push broadcast composer, subscriber count, broadcast history with CTR."
-      phase="Phase 5"
+    <CampusReachPageClient
+      orgId={orgId}
+      mapId={mapId}
+      vapidEnabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}
     />
   );
 }

--- a/apps/campus/app/api/maps/[mapId]/push-stats/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/push-stats/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { requireCampusAccess } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * `GET /api/maps/[mapId]/push-stats` — push-notification subscriber
+ * count for the Reach screen's "Subscribers" card. Just the headline
+ * total for now; broadcast history with CTR / opt-in % over time is
+ * a follow-up that needs a `Broadcast` model.
+ *
+ * Gated by `requireCampusAccess(mapId, "read")` — only people who
+ * can author the campus see the subscriber count.
+ */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  try {
+    const subscribers = await prisma.pushSubscription.count({
+      where: { projectId: mapId },
+    });
+    return NextResponse.json({ subscribers });
+  } catch (err) {
+    console.error("[push-stats]", err);
+    return NextResponse.json(
+      { subscribers: 0, error: "stats unavailable" },
+      { status: 200 },
+    );
+  }
+}

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -46,6 +46,7 @@
     "next": "^15.1.9",
     "next-auth": "5.0.0-beta.30",
     "node-ical": "^0.26.1",
+    "qrcode": "^1.5.4",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-toastify": "^11.0.5",
@@ -61,6 +62,7 @@
   "devDependencies": {
     "@types/culori": "^4.0.1",
     "@types/mapbox__mapbox-gl-draw": "^1.4.9",
+    "@types/qrcode": "^1.5.6",
     "@types/uuid": "^9.0.8",
     "@types/web-push": "^3.6.4",
     "autoprefixer": "10.4.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       node-ical:
         specifier: ^0.26.1
         version: 0.26.1
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -357,6 +360,9 @@ importers:
       '@types/mapbox__mapbox-gl-draw':
         specifier: ^1.4.9
         version: 1.4.9
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -3860,6 +3866,9 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -4567,6 +4576,10 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
@@ -4644,6 +4657,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4858,6 +4874,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -4964,6 +4984,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -5427,6 +5450,10 @@ packages:
 
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -6222,6 +6249,10 @@ packages:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -6642,6 +6673,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -6650,6 +6685,10 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -6657,6 +6696,10 @@ packages:
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -6774,6 +6817,10 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7001,6 +7048,11 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -7202,6 +7254,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   requirejs-config-file@4.0.0:
     resolution: {integrity: sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==}
     engines: {node: '>=10.13.0'}
@@ -7359,6 +7414,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8256,6 +8314,9 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which-typed-array@1.1.19:
     resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
     engines: {node: '>= 0.4'}
@@ -8328,6 +8389,10 @@ packages:
   workbox-window@7.1.0:
     resolution: {integrity: sha512-ZHeROyqR+AS5UPzholQRDttLFqGMwP0Np8MKWAdyxsDETxq3qOAyXvqessc3GniohG6e0mAqSQyKOHmT8zPF7g==}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -8375,6 +8440,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -8391,9 +8459,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -11702,6 +11778,10 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 20.19.24
+
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
       '@types/react': 19.2.7
@@ -12473,6 +12553,8 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
+  camelcase@5.3.1: {}
+
   camelize@1.0.1: {}
 
   camera-controls@3.1.2(three@0.170.0):
@@ -12547,6 +12629,12 @@ snapshots:
       string-width: 8.1.0
 
   client-only@0.0.1: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
@@ -12733,6 +12821,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
@@ -12845,6 +12935,8 @@ snapshots:
       wrappy: 1.0.2
 
   didyoumean@1.2.2: {}
+
+  dijkstrajs@1.0.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -13507,6 +13599,11 @@ snapshots:
       to-regex-range: 5.0.1
 
   find-root@1.1.0: {}
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -14338,6 +14435,10 @@ snapshots:
       emojis-list: 3.0.0
       json5: 2.2.3
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -14783,6 +14884,10 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -14791,6 +14896,10 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.1
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -14798,6 +14907,8 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+
+  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -14888,6 +14999,8 @@ snapshots:
       fsevents: 2.3.2
 
   pluralize@8.0.0: {}
+
+  pngjs@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -15139,6 +15252,12 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -15372,6 +15491,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-main-filename@2.0.0: {}
+
   requirejs-config-file@4.0.0:
     dependencies:
       esprima: 4.0.1
@@ -15542,6 +15663,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -16630,6 +16753,8 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
+  which-module@2.0.1: {}
+
   which-typed-array@1.1.19:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -16814,6 +16939,12 @@ snapshots:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.1.0
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -16842,6 +16973,8 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -16850,7 +16983,26 @@ snapshots:
 
   yaml@2.8.1: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Reach is the rector's outbound channel — publish toggle, shareable public URL + downloadable SVG QR, live subscriber count, and a push-broadcast composer that deep-links into any campus surface and reports delivered / attempted / pruned counts.
- Pairs with Identity (#191) to complete the two main Manage-tier screens. Hooks the existing `Megaphone` nav entry in `DashboardShell` to a real page.

## What's new
- `app/(dashboard)/org/[orgId]/maps/[mapId]/reach/page.tsx` + `CampusReachPageClient.tsx` — two-column layout (left: publish + send-broadcast + history placeholder; right: share card with URL + QR + subscriber stat).
- `app/api/maps/[mapId]/push-stats/route.ts` — `GET` returns `{ subscribers }` from `prisma.pushSubscription.count({ where: { projectId }})`. Read-gated, returns 0 on error so the panel stays mounted while DB is flaky.
- QR rendered client-side as SVG with `qrcode` so it scales cleanly for print and downloads as `campus-<mapId>.svg`.
- Deep-link picker constrained to seven real consumer routes (home, map, events, news, dining, clubs, klio). The notify body's `url` is built relative to `/campus/<mapId>` so push lands on the right tenant.
- Stat card refreshes after each Send so pruned endpoints don't keep inflating the displayed total.

## Deferred (out of scope)
- Broadcast history with CTR — needs a `Broadcast` model + click tracking. Shown as a placeholder so the section exists in the IA.
- Campus-tier Members + Settings (split from Phase 5).

## Test plan
- [ ] Visit `/org/<orgId>/maps/<mapId>/reach` as a campus author.
- [ ] Toggle publish — Open Public reflects state, toast confirms.
- [ ] Copy URL → clipboard contains `https://.../campus/<mapId>`. Download QR → SVG file saves.
- [ ] With `NEXT_PUBLIC_VAPID_PUBLIC_KEY` unset, the composer disables itself and shows the env hint.
- [ ] With VAPID configured + at least one subscribed device, Send broadcast → notification arrives, taps land on the chosen deep-link target.
- [ ] Subscribers card auto-refreshes every 30s and after a Send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)