### PR TITLE
feat(campus): first-run welcome card + onboarding hub on new IA

### DIFF
--- a/apps/campus/app/(dashboard)/components/WelcomeFirstRunCard.tsx
+++ b/apps/campus/app/(dashboard)/components/WelcomeFirstRunCard.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { ArrowRight, Palette, Sparkles, Map as MapIcon } from "lucide-react";
+import { Panel } from "@klorad/design-system";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+  campusName: string;
+}
+
+/**
+ * The "fresh campus" welcome — shown on the campus dashboard when the
+ * tenant hasn't done any setup yet (no logo, no MappedIn, no content).
+ * Replaces the all-zero stat cards / empty health checklist that
+ * otherwise greet a brand-new rector with nothing to act on.
+ *
+ * Three big tiles route into onboarding's three highest-leverage
+ * actions: try sample data, brand, connect MappedIn. The fourth link
+ * is the full onboarding hub for anyone who wants the guided tour.
+ *
+ * Disappears the moment the rector saves any of those — so the
+ * dashboard's normal stat/health surface takes over without a
+ * settings toggle.
+ */
+export function WelcomeFirstRunCard({ orgId, mapId, campusName }: Props) {
+  const base = `/org/${orgId}/maps/${mapId}`;
+  return (
+    <Panel className="rounded-2xl p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-accent">
+            Welcome
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-text-primary">
+            {campusName} is empty &mdash; let&rsquo;s fix that.
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-text-secondary">
+            Three quick actions and your students will have something to
+            open. Do them in any order; everything can be changed later.
+          </p>
+        </div>
+        <Link
+          href={`${base}/onboarding`}
+          className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
+        >
+          Guided setup
+          <ArrowRight size={14} strokeWidth={1.75} aria-hidden />
+        </Link>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <ActionTile
+          href={`${base}/onboarding`}
+          icon={<Sparkles size={16} strokeWidth={1.75} aria-hidden />}
+          title="Try with sample data"
+          hint="Believable news, events, clubs and dining so the public page isn't empty."
+        />
+        <ActionTile
+          href={`${base}/identity`}
+          icon={<Palette size={16} strokeWidth={1.75} aria-hidden />}
+          title="Brand the campus"
+          hint="Name, logo, accent colour. Picked up by the public site immediately."
+        />
+        <ActionTile
+          href={`${base}/map`}
+          icon={<MapIcon size={16} strokeWidth={1.75} aria-hidden />}
+          title="Connect MappedIn"
+          hint="Drop in a venue ID to light up the indoor 3D map + wayfinding."
+        />
+      </div>
+    </Panel>
+  );
+}
+
+interface TileProps {
+  href: string;
+  icon: React.ReactNode;
+  title: string;
+  hint: string;
+}
+
+function ActionTile({ href, icon, title, hint }: TileProps) {
+  return (
+    <Link
+      href={href}
+      className="group flex flex-col gap-2 rounded-xl border border-line-soft bg-surface-2/40 p-4 transition-colors hover:border-accent hover:bg-surface-2/70"
+    >
+      <span
+        aria-hidden
+        className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-soft text-accent"
+      >
+        {icon}
+      </span>
+      <div>
+        <p className="text-sm font-medium text-text-primary">{title}</p>
+        <p className="mt-0.5 text-xs text-text-tertiary">{hint}</p>
+      </div>
+      <span className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-text-tertiary transition-colors group-hover:text-accent">
+        Start
+        <ArrowRight size={12} strokeWidth={1.75} aria-hidden />
+      </span>
+    </Link>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
@@ -16,6 +16,7 @@ import { StatCard } from "@/app/(dashboard)/components/StatCard";
 import { CampusHealthCard } from "@/app/(dashboard)/components/CampusHealthCard";
 import { WhatChangedCard } from "@/app/(dashboard)/components/WhatChangedCard";
 import { JumpBackInTiles } from "@/app/(dashboard)/components/JumpBackInTiles";
+import { WelcomeFirstRunCard } from "@/app/(dashboard)/components/WelcomeFirstRunCard";
 import { useCampusHealth } from "@/app/hooks/useCampusHealth";
 import { useOrganization } from "@/app/hooks/useOrganizations";
 
@@ -101,6 +102,21 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
 
   const isPublished = Boolean(map.isPublished);
 
+  // "Fresh" = the rector hasn't set up anything yet. We deliberately
+  // ignore the Klio + Published checks (Klio depends on a server
+  // env var the rector can't change, and publishing is a final step
+  // — pre-publish state shouldn't trigger the welcome banner). The
+  // banner self-dismisses the moment any of these flip; no toggle.
+  const isFresh = Boolean(
+    health &&
+      !health.checks.find((c) => c.key === "branding")?.done &&
+      !health.checks.find((c) => c.key === "mappedin")?.done &&
+      health.counts.news === 0 &&
+      health.counts.events === 0 &&
+      health.counts.clubs === 0 &&
+      health.counts.dining === 0,
+  );
+
   return (
     <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
       <PageHeader
@@ -148,6 +164,16 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
           </>
         }
       />
+
+      {isFresh ? (
+        <div className="mb-6">
+          <WelcomeFirstRunCard
+            orgId={orgId}
+            mapId={mapId}
+            campusName={map.name}
+          />
+        </div>
+      ) : null}
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/OnboardingClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/onboarding/OnboardingClient.tsx
@@ -4,7 +4,14 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
-import { ArrowRight, Check, Palette, Sparkles, Map as MapIcon } from "lucide-react";
+import {
+  ArrowRight,
+  Check,
+  Megaphone,
+  Palette,
+  Sparkles,
+  Map as MapIcon,
+} from "lucide-react";
 import { Button, Panel } from "@klorad/design-system";
 
 interface Props {
@@ -92,10 +99,10 @@ export function OnboardingClient({
         doneLabel="Branding set"
       >
         <Link
-          href={`/org/${orgId}/maps/${mapId}?tab=settings`}
+          href={`/org/${orgId}/maps/${mapId}/identity`}
           className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
         >
-          Open settings
+          Open Identity
           <ArrowRight size={14} strokeWidth={1.75} />
         </Link>
       </StepCard>
@@ -109,31 +116,39 @@ export function OnboardingClient({
         doneLabel="MappedIn linked"
       >
         <Link
-          href={`/org/${orgId}/maps/${mapId}?tab=indoor`}
+          href={`/org/${orgId}/maps/${mapId}/map`}
           className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
         >
-          Open Indoor
+          Open Map &amp; Wayfinding
           <ArrowRight size={14} strokeWidth={1.75} />
         </Link>
       </StepCard>
 
       <Panel className="md:col-span-3 p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-sm font-semibold text-text-primary">
-              Publish when you’re ready
-            </p>
-            <p className="mt-0.5 text-xs text-text-tertiary">
-              {isPublished
-                ? "This campus is live. Edits go out immediately."
-                : "The campus is still a draft. Publish from the Settings tab when you’re ready to share."}
-            </p>
+          <div className="flex items-start gap-3">
+            <span
+              aria-hidden
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent"
+            >
+              <Megaphone size={16} strokeWidth={1.75} />
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-text-primary">
+                {isPublished ? "Share with students" : "Publish &amp; share"}
+              </p>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                {isPublished
+                  ? "This campus is live. Grab the URL, the QR, or push a broadcast from Reach."
+                  : "Publish from Reach, then hand students the URL or scan the QR. Broadcast composer lives there too."}
+              </p>
+            </div>
           </div>
           <Link
-            href={`/org/${orgId}/maps/${mapId}?tab=settings`}
+            href={`/org/${orgId}/maps/${mapId}/reach`}
             className="inline-flex items-center gap-1.5 rounded-full border border-solid border-line-soft bg-surface-1 px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent"
           >
-            {isPublished ? "Manage publishing" : "Publish"}
+            Open Reach
             <ArrowRight size={14} strokeWidth={1.75} />
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- A fresh rector landing on a brand-new campus dashboard now sees a clear, branded welcome card with three big setup actions — replacing the all-zero stat grid and empty health checklist that previously greeted them.
- The existing onboarding hub stops linking into routes that don't exist any more after the backoffice redesign (`?tab=settings`, `?tab=indoor`). Brand → `/identity`, MappedIn → `/map`, publish/share footer → `/reach`.

## What's new
- `components/WelcomeFirstRunCard.tsx` — fresh-state hero on the campus dashboard with Guided setup CTA + three quick-action tiles (Try sample data / Brand / Connect MappedIn).
- Conditional render in `CampusProfileClient`: the card appears when branding **and** MappedIn **and** all four content rails (news/events/clubs/dining) are empty. Self-dismisses the moment any of those flip — no toggle, no cookie, no remembered state.
- `OnboardingClient` CTAs updated to the post-Phase-5 IA. The footer panel now adapts to draft vs. published state and routes into Reach for the URL/QR/broadcast composer.

## What this isn't (deferred)
- Auto-redirect on first sign-in — kept opt-in via the explicit CTAs; auto-routing rectors away from the dashboard the first time was judged too heavy-handed.
- Persistent "I've seen the welcome" state — not needed: the card uses live data and self-hides when the campus stops being empty.

## Test plan
- [ ] Create a fresh campus (no logo, no MappedIn ID, no news/events/clubs/dining). Visit `/org/<orgId>/maps/<mapId>` → welcome card renders above the stats.
- [ ] Open `/onboarding` → click "Open Identity" / "Open Map & Wayfinding" / "Open Reach" — each lands on the new route.
- [ ] Run the sample-data seeder (from the Try sample data card) → return to dashboard → welcome card disappears, normal stat + health surface takes over.
- [ ] Existing campus with branding set: dashboard renders as before, welcome card hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)