### PR TITLE
feat(campus): typed env + /api/health probe (production hardening 1/2)

### DIFF
--- a/apps/campus/app/api/health/route.ts
+++ b/apps/campus/app/api/health/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { envValidationSkipped, features } from "@/lib/env";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * `GET /api/health` — public uptime + integrations probe.
+ *
+ * Returns a JSON snapshot of:
+ *  - DB reachability (real `SELECT 1`, not a Prisma type check)
+ *  - which optional features are configured (booleans only — never
+ *    secrets or sample values)
+ *  - the Vercel commit + region (handy when triaging "is the new
+ *    deploy actually serving traffic?")
+ *
+ * Used by:
+ *  - external uptime monitors (Better Uptime, Pingdom, etc.)
+ *  - the buyer-demo check: a quick "is everything wired" glance
+ *    before opening the public viewer
+ *  - the rector-facing settings screen (future) to tell them why
+ *    push or AI chat isn't lit on their deploy
+ *
+ * Returns HTTP 200 when "healthy" (DB reachable), 503 when degraded
+ * — uptime monitors treat 5xx as down even when the JSON body is
+ * fine, so don't change this without checking what's polling.
+ */
+export async function GET() {
+  const startedAt = Date.now();
+
+  let dbOk = false;
+  let dbError: string | undefined;
+  try {
+    // `$queryRaw` forces a real round-trip — `prisma.user.findFirst`
+    // would happily return cached metadata without reaching the DB.
+    await prisma.$queryRaw`SELECT 1`;
+    dbOk = true;
+  } catch (err) {
+    dbError = err instanceof Error ? err.message : "DB query failed";
+  }
+
+  const dbLatencyMs = Date.now() - startedAt;
+
+  const body = {
+    ok: dbOk,
+    timestamp: new Date().toISOString(),
+    version: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "local",
+    region: process.env.VERCEL_REGION ?? "local",
+    envValidationSkipped,
+    db: {
+      ok: dbOk,
+      latencyMs: dbLatencyMs,
+      ...(dbError ? { error: dbError } : {}),
+    },
+    features,
+  };
+
+  return NextResponse.json(body, { status: dbOk ? 200 : 503 });
+}

--- a/apps/campus/lib/env.ts
+++ b/apps/campus/lib/env.ts
@@ -1,0 +1,144 @@
+import "server-only";
+import { z } from "zod";
+
+/**
+ * Typed, validated environment for apps/campus.
+ *
+ * Runs once at module load. Route handlers and lib modules that need
+ * an env var should import `serverEnv` instead of touching
+ * `process.env` directly — a missing var then surfaces at boot
+ * (visible in the deploy logs) instead of as a confusing 500 hours
+ * later when someone hits the obscure path that uses it.
+ *
+ * Two-tier model:
+ *   1. **Boot-blocking** (DATABASE_URL, SECRET) — the app cannot
+ *      meaningfully serve traffic without these. Schema is strict.
+ *   2. **Feature-gating** (DO_SPACES_*, SECRETS_KEY, VAPID_*, etc.) —
+ *      missing values disable a feature, not the whole app. Schema
+ *      is permissive (`.optional()`); the call sites that already
+ *      enforce presence (storage server.ts, secrets.ts) still throw
+ *      on demand, and `features` below exposes booleans so the
+ *      health endpoint can tell us *what's lit*.
+ *
+ * `SKIP_ENV_VALIDATION=1` is honoured for breakglass / Vercel-build
+ * cases where validation would otherwise block the build container.
+ * Don't set it as a default — it negates the whole point.
+ *
+ * NEXT_PUBLIC_* vars are intentionally NOT validated here. Next.js
+ * inlines them client-side at build time; importing them from a
+ * `server-only` module muddles the two. `features` reads them via
+ * raw `process.env` for the same reason.
+ */
+const serverSchema = z.object({
+  // ─ Boot-blocking ──────────────────────────────────────────────
+  DATABASE_URL: z.string().url().describe("Postgres connection string"),
+  SECRET: z
+    .string()
+    .min(16)
+    .describe("NextAuth session-token signing secret"),
+
+  // ─ Feature-gating (optional; degrade gracefully) ──────────────
+  SECRETS_KEY: z.string().optional(),
+  DO_SPACES_REGION: z.string().optional(),
+  DO_SPACES_ENDPOINT: z.string().optional(),
+  DO_SPACES_BUCKET: z.string().optional(),
+  DO_SPACES_KEY: z.string().optional(),
+  DO_SPACES_SECRET: z.string().optional(),
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+  GITHUB_CLIENT_ID: z.string().optional(),
+  GITHUB_CLIENT_SECRET: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+  RESEND_API_KEY: z.string().optional(),
+  EMAIL_FROM: z.string().optional(),
+  VAPID_PRIVATE_KEY: z.string().optional(),
+  VAPID_SUBJECT: z.string().optional(),
+  SENTRY_DSN: z.string().optional(),
+
+  // ─ Mode ───────────────────────────────────────────────────────
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
+  SKIP_ENV_VALIDATION: z.string().optional(),
+});
+
+export type ServerEnv = z.infer<typeof serverSchema>;
+
+/** True when boot-blocking validation was bypassed via SKIP. */
+export let envValidationSkipped = false;
+
+function parse(): ServerEnv {
+  if (process.env.SKIP_ENV_VALIDATION === "1") {
+    envValidationSkipped = true;
+    // Stub the two required keys so the parse succeeds — runtime
+    // call sites still hit the real `process.env` value (or the
+    // existing throw paths) if they actually need it.
+    return serverSchema.parse({
+      ...process.env,
+      DATABASE_URL: process.env.DATABASE_URL ?? "postgres://skip@skip/skip",
+      SECRET: process.env.SECRET ?? "skip-skip-skip-skip-skip-skip-skip-skip",
+    });
+  }
+
+  const result = serverSchema.safeParse(process.env);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    const header = "Invalid or missing environment variables:";
+
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(`${header}\n${issues}`);
+    }
+    // Dev: warn loud, keep going so a frontend-only workflow isn't
+    // blocked by a half-configured local machine.
+    console.warn(`[env] ${header}\n${issues}`);
+    envValidationSkipped = true;
+    return serverSchema.parse({
+      ...process.env,
+      DATABASE_URL: process.env.DATABASE_URL ?? "postgres://dev@dev/dev",
+      SECRET:
+        process.env.SECRET ?? "dev-dev-dev-dev-dev-dev-dev-dev-dev-dev",
+    });
+  }
+  return result.data;
+}
+
+export const serverEnv = parse();
+
+/**
+ * Per-feature flags derived from env. Centralised so route handlers
+ * don't each re-check the same combinations — and so the health
+ * endpoint reports a single source of truth.
+ */
+export const features = {
+  /** AI chat ("Klio") is wired in. */
+  klio: Boolean(serverEnv.ANTHROPIC_API_KEY),
+  /** Server-side push broadcast is configured. */
+  push: Boolean(
+    serverEnv.VAPID_PRIVATE_KEY &&
+      serverEnv.VAPID_SUBJECT &&
+      process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+  ),
+  /** Transactional email (invites, password resets) is wired in. */
+  email: Boolean(serverEnv.RESEND_API_KEY && serverEnv.EMAIL_FROM),
+  /** At least one OAuth sign-in provider is configured. */
+  oauthSignIn: Boolean(
+    (serverEnv.GOOGLE_CLIENT_ID && serverEnv.GOOGLE_CLIENT_SECRET) ||
+      (serverEnv.GITHUB_CLIENT_ID && serverEnv.GITHUB_CLIENT_SECRET),
+  ),
+  /** Object storage (uploads, branding, thumbnails) is configured. */
+  uploads: Boolean(
+    serverEnv.DO_SPACES_REGION &&
+      serverEnv.DO_SPACES_ENDPOINT &&
+      serverEnv.DO_SPACES_BUCKET &&
+      serverEnv.DO_SPACES_KEY &&
+      serverEnv.DO_SPACES_SECRET,
+  ),
+  /** At-rest secret encryption (BYOK Anthropic keys, etc.) is configured. */
+  byokSecrets: Boolean(serverEnv.SECRETS_KEY),
+  /** Server-side error reporting is configured. */
+  sentry: Boolean(serverEnv.SENTRY_DSN),
+} as const;
+
+export type FeatureFlags = typeof features;


### PR DESCRIPTION
## Summary
- Adds a typed, Zod-validated server env loader and a public `/api/health` probe — the two pieces of production hardening that don't add deploy-time risk on their own (Sentry follows in a separate PR).
- Existing call sites continue to throw the way they already did; this PR just lifts the validation to one place and surfaces *what's configured* so we can verify a deploy at a glance.

## What's new
- `apps/campus/lib/env.ts` — two-tier schema: `DATABASE_URL` + `SECRET` are boot-blocking (throw in prod, warn in dev); every other var is feature-gating (`.optional()`). Honours `SKIP_ENV_VALIDATION=1`. Exports a `features` object so route handlers and the health probe share one source of truth instead of each re-deriving combinations.
- `apps/campus/app/api/health/route.ts` — public probe at `/api/health`. Real `SELECT 1` round-trip, DB latency, the seven feature flags (klio, push, email, oauthSignIn, uploads, byokSecrets, sentry), Vercel commit + region, and an `envValidationSkipped` flag so it's visible when SKIP bypassed the schema. Returns 503 on DB-unreachable so uptime monitors can page.

## Follow-ups noted in the commit
- `SKIP_ENV_VALIDATION=1` is currently set in `apps/campus/vercel.json` (carried over from an earlier setup attempt). Once we verify the Vercel runtime env matches the new schema, we can remove that override so production actually enforces validation. The health endpoint now tells us when SKIP is active.
- Sentry: separate PR. Wraps `next.config.mjs` with `withSentryConfig`, DSN-gated so it no-ops when `SENTRY_DSN` is unset.

## Test plan
- [ ] `curl https://<host>/api/health` returns 200 with `db.ok: true`, latency under ~200ms, and the seven feature booleans.
- [ ] Toggle an env var off in Vercel preview → that feature's flag flips to `false` on the next deploy.
- [ ] Locally with no `.env.local`: dev server boots with a `[env] Invalid or missing environment variables` warning; production build fails fast.
- [ ] Importing `@/lib/env` from a client component fails the build (the `server-only` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)