### PR TITLE
feat(campus): location picker + card image on /identity

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -56,22 +56,19 @@
 
 | # | Step | Status | Notes |
 |---|---|---|---|
-| 1 | Rector picks campus location (address or map pin) | ❌ | **Real gap.** No dedicated form anywhere. Location is read from `sceneData.mapboxScene.center` — only set as a side-effect of using the Workbench 3D editor's camera, and not every campus uses the Workbench |
-| 2 | Location appears as a pin on the org-tier world map | ✅ | `OrgWorldMap.tsx` (org dashboard) — but only when `mapboxScene.center` is non-zero |
-| 3 | Empty state for "no location yet" with CTA to set it | ❌ | World map silently drops the campus pin instead of nudging |
+| 1 | Rector picks campus location (address or map pin) | ✅ | Location panel on `/identity` — Mapbox geocoder + draggable pin + click-to-set. Writes `sceneData.mapboxScene.center` |
+| 2 | Location appears as a pin on the org-tier world map | ✅ | `OrgWorldMap.tsx` (org dashboard) |
+| 3 | Empty state for "no location yet" with CTA to set it | ❌ | World map silently drops campuses with no location — next pass |
 | 4 | Location used by the public viewer for "near me" / outdoor map default centre | ✅ | Public map reads the same `sceneData` |
-
-> 🛠 **Proposed fix.** Add a "Location" panel to `/identity` with a small Mapbox preview, address geocoder, and a draggable pin. Write to `sceneData.mapboxScene.center`. Add an empty-state CTA on the org-tier world map.
 
 ### A6. Set the campus thumbnail (used by the campus list + world map tooltip)
 
 | # | Step | Status | Notes |
 |---|---|---|---|
-| 1 | Rector uploads a campus thumbnail / card image | ❌ | **Real gap.** `Project.thumbnail` is read by `MapsPageClient` (campus list) and used as the public viewer fallback hero, but the only writer is the legacy `PATCH /api/maps/[mapId]` body that no UI currently sends. |
+| 1 | Rector uploads a campus thumbnail / card image | ✅ | "Card image" field on `/identity` (next to Logo + Hero). Writes `Project.thumbnail` |
 | 2 | Thumbnail shown on the campus list card | ✅ | `MapsPageClient` reads it |
-| 3 | Thumbnail shown on the world map pin tooltip | ❌ | Tooltip text only; no image |
-
-> 🛠 **Proposed fix.** Add a "Card image" upload to `/identity` next to logo + hero. Auto-derive from `heroImage` if the rector doesn't set a dedicated one.
+| 3 | Thumbnail shown on the world map pin tooltip | ❌ | Tooltip is text-only today — next pass |
+| 4 | Fallback to hero image when no dedicated card image is set | ✅ | Preview in the Identity form mirrors this behaviour |
 
 ### A7. Author content — news / events / clubs / dining
 
@@ -242,10 +239,11 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 ### V1 MVP blockers
 | S | U | Item | Pointer |
 |---|---|---|---|
-| S | High | Wire push-subscribers stat card | A11.3 — done in this PR |
-| S | High | Add a "Card image" (campus thumbnail) field to `/identity` | A6 |
-| M | High | Add a "Location" panel to `/identity` (Mapbox preview + geocoder + pin) | A5 |
-| M | High | Empty-state CTA on the org world map for campuses with no location | A5.3 |
+| S | High | Wire push-subscribers stat card | A11.3 — shipped |
+| S | High | Add a "Card image" (campus thumbnail) field to `/identity` | A6 — shipped |
+| M | High | Add a "Location" panel to `/identity` (Mapbox preview + geocoder + pin) | A5 — shipped |
+| M | Med | Empty-state CTA on the org world map for campuses with no location | A5.3 |
+| S | Med | World map pin tooltips that show the campus card image | A6.3 |
 | S | Med | Remove `SKIP_ENV_VALIDATION=1` from `apps/campus/vercel.json` | A14.3 |
 | M | Med | Sentry: server + client + edge config, DSN-gated | A14.4 |
 | S | Med | Wire Resend so org invites send a real email | A1.4 / A12.2 |

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/CampusIdentityPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/CampusIdentityPageClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import useSWR, { mutate as globalMutate } from "swr";
 import { toast } from "react-toastify";
-import { Palette, Upload } from "lucide-react";
+import { MapPin, Palette, Upload } from "lucide-react";
 import { Button, Field, Input, Panel } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
@@ -11,6 +12,19 @@ import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction"
 import { PhonePreview } from "@/app/(dashboard)/components/PhonePreview";
 import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import { deriveCampusPalette } from "@/lib/palette";
+
+// LocationPicker pulls in mapbox-gl (~half a megabyte). Most rectors
+// brand first and scroll to Location later, so defer the chunk —
+// the panel mounts with a skeleton until the user reaches it.
+const LocationPicker = dynamic(
+  () => import("./LocationPicker").then((m) => m.LocationPicker),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[340px] animate-pulse rounded-xl bg-surface-2" />
+    ),
+  },
+);
 
 interface Props {
   orgId: string;
@@ -35,12 +49,23 @@ interface HomePageConfig {
 interface SceneData {
   branding?: CampusBranding;
   homePage?: HomePageConfig;
+  /** Mapbox scene bundle written by the Workbench. The campus's
+   *  geographic location lives at `mapboxScene.center` as `[lng, lat]`. */
+  mapboxScene?: {
+    center?: [number, number];
+    [k: string]: unknown;
+  };
+  /** Legacy field (pre-Workbench rows wrote here). Still read by the
+   *  org world map as a fallback, but new writes always go to
+   *  `mapboxScene.center`. */
+  center?: [number, number];
   [k: string]: unknown;
 }
 
 interface MapResponse {
   id: string;
   title: string;
+  thumbnail?: string | null;
   sceneData?: SceneData;
 }
 
@@ -120,11 +145,14 @@ export default function CampusIdentityPageClient({
   const [shortName, setShortName] = useState("");
   const [logoUrl, setLogoUrl] = useState("");
   const [heroUrl, setHeroUrl] = useState("");
+  const [thumbnailUrl, setThumbnailUrl] = useState("");
   const [primaryColor, setPrimaryColor] = useState("");
+  const [center, setCenter] = useState<[number, number] | null>(null);
   const [hydrated, setHydrated] = useState(false);
 
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const [uploadingHero, setUploadingHero] = useState(false);
+  const [uploadingThumbnail, setUploadingThumbnail] = useState(false);
   const [saving, setSaving] = useState(false);
   const [previewKey, setPreviewKey] = useState(0);
 
@@ -136,12 +164,26 @@ export default function CampusIdentityPageClient({
     if (hydrated || !server) return;
     const branding = server.sceneData?.branding ?? {};
     const home = server.sceneData?.homePage ?? {};
+    // Coordinates live at `mapboxScene.center`; pre-Workbench rows
+    // wrote to `sceneData.center`. Read both, write only the new
+    // location on save. `[0, 0]` is the legacy "not set" sentinel
+    // used by OrgWorldMap, treat it as null here so the picker
+    // doesn't show a bogus pin off the coast of Africa.
+    const rawCenter =
+      server.sceneData?.mapboxScene?.center ?? server.sceneData?.center;
+    const isRealCenter =
+      Array.isArray(rawCenter) &&
+      typeof rawCenter[0] === "number" &&
+      typeof rawCenter[1] === "number" &&
+      !(rawCenter[0] === 0 && rawCenter[1] === 0);
     setName(branding.name ?? server.title ?? "");
     setNameEl(branding.nameEl ?? "");
     setShortName(branding.shortName ?? "");
     setLogoUrl(branding.logo ?? "");
     setHeroUrl(home.heroImage ?? "");
+    setThumbnailUrl(server.thumbnail ?? "");
     setPrimaryColor(branding.primaryColor ?? "");
+    setCenter(isRealCenter ? [rawCenter[0], rawCenter[1]] : null);
     setHydrated(true);
   }, [hydrated, server]);
 
@@ -160,13 +202,30 @@ export default function CampusIdentityPageClient({
     if (!hydrated || !server) return false;
     const b = server.sceneData?.branding ?? {};
     const h = server.sceneData?.homePage ?? {};
+    const rawCenter =
+      server.sceneData?.mapboxScene?.center ?? server.sceneData?.center;
+    const savedCenter: [number, number] | null =
+      Array.isArray(rawCenter) &&
+      typeof rawCenter[0] === "number" &&
+      typeof rawCenter[1] === "number" &&
+      !(rawCenter[0] === 0 && rawCenter[1] === 0)
+        ? [rawCenter[0], rawCenter[1]]
+        : null;
+    const centerChanged =
+      (center === null) !== (savedCenter === null) ||
+      (center !== null &&
+        savedCenter !== null &&
+        (Math.abs(center[0] - savedCenter[0]) > 0.000001 ||
+          Math.abs(center[1] - savedCenter[1]) > 0.000001));
     return (
       name !== (b.name ?? server.title ?? "") ||
       nameEl !== (b.nameEl ?? "") ||
       shortName !== (b.shortName ?? "") ||
       logoUrl !== (b.logo ?? "") ||
       heroUrl !== (h.heroImage ?? "") ||
-      primaryColor !== (b.primaryColor ?? "")
+      thumbnailUrl !== (server.thumbnail ?? "") ||
+      primaryColor !== (b.primaryColor ?? "") ||
+      centerChanged
     );
   }, [
     hydrated,
@@ -176,22 +235,45 @@ export default function CampusIdentityPageClient({
     shortName,
     logoUrl,
     heroUrl,
+    thumbnailUrl,
     primaryColor,
+    center,
   ]);
 
   const handleUpload = async (
     file: File,
-    target: "logo" | "hero",
+    target: "logo" | "hero" | "thumbnail",
   ) => {
-    const setter = target === "logo" ? setLogoUrl : setHeroUrl;
-    const busy = target === "logo" ? setUploadingLogo : setUploadingHero;
+    const setter =
+      target === "logo"
+        ? setLogoUrl
+        : target === "hero"
+          ? setHeroUrl
+          : setThumbnailUrl;
+    const busy =
+      target === "logo"
+        ? setUploadingLogo
+        : target === "hero"
+          ? setUploadingHero
+          : setUploadingThumbnail;
+    // The card image lives in a different prefix so it's bucketed
+    // alongside the existing list-card thumbnails for tooling /
+    // moderation reviews.
+    const prefix =
+      target === "thumbnail"
+        ? UPLOAD_PREFIXES.thumbnails
+        : UPLOAD_PREFIXES.branding;
     busy(true);
     try {
-      const result = await uploadFile(file, {
-        prefix: UPLOAD_PREFIXES.branding,
-      });
+      const result = await uploadFile(file, { prefix });
       setter(result.publicUrl);
-      toast.success(target === "logo" ? "Logo uploaded" : "Hero uploaded");
+      const label =
+        target === "logo"
+          ? "Logo"
+          : target === "hero"
+            ? "Hero"
+            : "Card image";
+      toast.success(`${label} uploaded`);
     } catch (err) {
       console.error(err);
       toast.error("Upload failed");
@@ -199,6 +281,16 @@ export default function CampusIdentityPageClient({
       busy(false);
     }
   };
+
+  // Stable reference — `LocationPicker` calls this from inside its
+  // own effects, so an unstable inline lambda would re-trigger its
+  // mount/sync passes on every parent render.
+  const handleLocationChange = useCallback(
+    (next: [number, number] | null) => {
+      setCenter(next);
+    },
+    [],
+  );
 
   const handleSave = async () => {
     if (!server || !dirty || saving) return;
@@ -224,15 +316,35 @@ export default function CampusIdentityPageClient({
         ...(server.sceneData?.homePage ?? {}),
         heroImage: heroUrl.trim() || undefined,
       };
+      // Write coordinates to `mapboxScene.center` — same shape the
+      // Workbench writes — so the org-tier world map and any future
+      // Workbench-side reads agree. We also strip the legacy
+      // top-level `center` on save so the two locations don't
+      // diverge over time.
+      const existingScene = { ...(server.sceneData?.mapboxScene ?? {}) };
+      if (center !== null) {
+        existingScene.center = center;
+      } else {
+        delete existingScene.center;
+      }
+      const sceneWithoutLegacyCenter = { ...(server.sceneData ?? {}) };
+      delete sceneWithoutLegacyCenter.center;
       const nextScene: SceneData = {
-        ...(server.sceneData ?? {}),
+        ...sceneWithoutLegacyCenter,
         branding: nextBranding,
         homePage: nextHome,
+        mapboxScene: existingScene,
       };
       const res = await fetch(`/api/maps/${mapId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sceneData: nextScene }),
+        body: JSON.stringify({
+          sceneData: nextScene,
+          // Card image is a top-level Project column, not part of
+          // sceneData — that's where the campus list + public viewer
+          // fallback hero both read it from.
+          thumbnail: thumbnailUrl.trim() || null,
+        }),
       });
       if (!res.ok) throw new Error("Save failed");
       await globalMutate(`/api/maps/${mapId}`);
@@ -388,7 +500,58 @@ export default function CampusIdentityPageClient({
                 onUpload={(file) => handleUpload(file, "hero")}
                 onClear={() => setHeroUrl("")}
               />
+              <UploadField
+                label="Card image"
+                hint="Shown on the campus list card and the org world map's pin tooltip. Falls back to the hero if you skip it."
+                value={thumbnailUrl}
+                preview={
+                  thumbnailUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={thumbnailUrl}
+                      alt=""
+                      className="block h-20 w-32 rounded-md object-cover"
+                    />
+                  ) : heroUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={heroUrl}
+                      alt=""
+                      className="block h-20 w-32 rounded-md object-cover opacity-60"
+                    />
+                  ) : (
+                    <HeroPlaceholder
+                      color={palette.primary}
+                      fill={palette.primaryFill}
+                    />
+                  )
+                }
+                accept="image/png,image/jpeg,image/webp"
+                uploading={uploadingThumbnail}
+                onUpload={(file) => handleUpload(file, "thumbnail")}
+                onClear={() => setThumbnailUrl("")}
+              />
             </div>
+          </Panel>
+
+          {/* ─ Location ────────────────────────────────────────────── */}
+          <Panel className="rounded-2xl p-6">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+                <MapPin size={16} strokeWidth={1.75} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  Location
+                </h2>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  Drops a pin on the org dashboard&rsquo;s world map and lets
+                  the public viewer centre on the right place. Search an
+                  address or click anywhere to set.
+                </p>
+              </div>
+            </div>
+            <LocationPicker value={center} onChange={handleLocationChange} />
           </Panel>
 
           {/* ─ Primary colour ─────────────────────────────────────── */}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/LocationPicker.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/identity/LocationPicker.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import mapboxgl, { type Map as MapboxMap, type Marker } from "mapbox-gl";
+import { MapPin, Search } from "lucide-react";
+import { Field, Input } from "@klorad/design-system";
+
+interface Props {
+  /** Stored as `[lng, lat]`, matching the rest of the app. `null` = not set. */
+  value: [number, number] | null;
+  onChange: (next: [number, number] | null) => void;
+}
+
+const FALLBACK_CENTER: [number, number] = [23.7275, 37.9838]; // Athens
+const FALLBACK_ZOOM = 4;
+const PIN_COLOR = "#158ca3";
+const SEARCH_DEBOUNCE_MS = 250;
+
+interface GeocodeFeature {
+  id: string;
+  place_name: string;
+  center: [number, number];
+}
+
+/**
+ * Map-based location picker on the Identity screen — the only place
+ * the rector actually sets a campus's geographic coordinate. Mirrors
+ * the same `sceneData.mapboxScene.center` field the org-tier world
+ * map reads on the dashboard, so a save here lights up the pin
+ * straight away.
+ *
+ * Three ways to set the pin:
+ *   1. Type an address / venue / city — first match wins; arrow-keys
+ *      navigate the suggestion list, Enter / click commits.
+ *   2. Drag the pin on the inline mini-map.
+ *   3. Click anywhere on the map.
+ *
+ * Why not pull this from the Workbench's 3D scene like before? The
+ * Workbench is opt-in (some rectors only ever upload a logo and a
+ * MappedIn id); coordinates would never get written without a
+ * dedicated form. See USER-PATH.md §A5.
+ */
+export function LocationPicker({ value, onChange }: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapboxMap | null>(null);
+  const markerRef = useRef<Marker | null>(null);
+  const lastValueRef = useRef<[number, number] | null>(null);
+  const [ready, setReady] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GeocodeFeature[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  const token =
+    typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+      : undefined;
+
+  // Mount the Mapbox instance exactly once. The marker is recreated
+  // when `value` flips between set/unset; in-place updates use
+  // `setLngLat`.
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current || !token) return;
+    mapboxgl.accessToken = token;
+    const initialCenter = value ?? FALLBACK_CENTER;
+    const initialZoom = value ? 14 : FALLBACK_ZOOM;
+    const map = new mapboxgl.Map({
+      container: containerRef.current,
+      style: "mapbox://styles/mapbox/light-v11",
+      center: initialCenter,
+      zoom: initialZoom,
+      attributionControl: false,
+      interactive: true,
+      cooperativeGestures: true,
+    });
+    map.on("load", () => setReady(true));
+    map.on("click", (e) => {
+      onChange([e.lngLat.lng, e.lngLat.lat]);
+    });
+    mapRef.current = map;
+    return () => {
+      markerRef.current?.remove();
+      markerRef.current = null;
+      map.remove();
+      mapRef.current = null;
+    };
+    // We intentionally do not re-run on value/onChange changes —
+    // see effects below for those.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  // Sync the marker (and recentre) when `value` changes — including
+  // when the parent clears it. Using a ref to compare the previous
+  // value avoids fluttering the map on no-op re-renders.
+  useEffect(() => {
+    if (!ready || !mapRef.current) return;
+    const prev = lastValueRef.current;
+    lastValueRef.current = value;
+    if (!value) {
+      markerRef.current?.remove();
+      markerRef.current = null;
+      return;
+    }
+    if (!markerRef.current) {
+      const el = document.createElement("div");
+      el.style.width = "16px";
+      el.style.height = "16px";
+      el.style.borderRadius = "50%";
+      el.style.background = PIN_COLOR;
+      el.style.border = "2px solid #fff";
+      el.style.boxShadow = "0 1px 6px rgba(0,0,0,0.35)";
+      el.style.cursor = "grab";
+      const marker = new mapboxgl.Marker({ element: el, draggable: true })
+        .setLngLat(value)
+        .addTo(mapRef.current);
+      marker.on("dragend", () => {
+        const { lng, lat } = marker.getLngLat();
+        onChange([lng, lat]);
+      });
+      markerRef.current = marker;
+    } else {
+      markerRef.current.setLngLat(value);
+    }
+    // Recentre only when the value actually moved meaningfully — not
+    // when the parent passes through the same coords during a sibling
+    // re-render. Threshold is ~10m, well below pin-drag resolution.
+    if (
+      !prev ||
+      Math.abs(prev[0] - value[0]) > 0.0001 ||
+      Math.abs(prev[1] - value[1]) > 0.0001
+    ) {
+      mapRef.current.flyTo({ center: value, zoom: 14, duration: 600 });
+    }
+  }, [value, ready, onChange]);
+
+  // Mapbox Geocoding API, REST. No SDK — one fetch, debounced. We
+  // ship the first 5 matches; the list closes on selection or blur.
+  useEffect(() => {
+    if (!token) return;
+    const trimmed = query.trim();
+    if (trimmed.length < 3) {
+      setResults([]);
+      return;
+    }
+    const handle = window.setTimeout(async () => {
+      setSearching(true);
+      try {
+        const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
+          trimmed,
+        )}.json?access_token=${token}&autocomplete=true&limit=5&types=address,place,poi,locality,neighborhood`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("geocode failed");
+        const body = (await res.json()) as { features?: GeocodeFeature[] };
+        setResults(body.features ?? []);
+      } catch {
+        setResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [query, token]);
+
+  const handlePickResult = (feature: GeocodeFeature) => {
+    onChange(feature.center);
+    setQuery(feature.place_name);
+    setResults([]);
+    setFocused(false);
+  };
+
+  if (!token) {
+    return (
+      <div className="rounded-xl border border-line-soft bg-surface-2/40 p-4 text-xs text-text-tertiary">
+        Set <code>NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN</code> to enable the
+        location picker.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <Field label="Address or place">
+        <div className="relative">
+          <div className="relative">
+            <Search
+              size={14}
+              strokeWidth={1.75}
+              aria-hidden
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary"
+            />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onFocus={() => setFocused(true)}
+              // Delay blur so a click on a suggestion lands before
+              // the list unmounts.
+              onBlur={() => window.setTimeout(() => setFocused(false), 120)}
+              placeholder="International Hellenic University, Thermi"
+              className="!pl-9"
+            />
+          </div>
+          {focused && results.length > 0 ? (
+            <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-md border border-line-soft bg-surface-1 shadow-lg">
+              {results.map((r) => (
+                <button
+                  key={r.id}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handlePickResult(r);
+                  }}
+                  className="block w-full truncate px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-surface-2"
+                >
+                  {r.place_name}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {searching && focused ? (
+            <p className="mt-1 text-[11px] text-text-tertiary">Searching…</p>
+          ) : null}
+        </div>
+      </Field>
+
+      <div className="relative h-[280px] w-full overflow-hidden rounded-xl border border-line-soft bg-surface-1">
+        <div ref={containerRef} className="absolute inset-0" />
+        {value ? (
+          <div className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-line-soft bg-surface-1/90 px-2.5 py-1 font-mono text-[10px] text-text-secondary shadow-sm backdrop-blur">
+            <MapPin size={11} strokeWidth={1.75} aria-hidden />
+            {value[1].toFixed(4)}, {value[0].toFixed(4)}
+          </div>
+        ) : null}
+        {!value && ready ? (
+          <div className="pointer-events-none absolute inset-x-3 bottom-3 rounded-md bg-surface-1/95 px-3 py-2 text-center text-[11px] text-text-tertiary shadow-sm backdrop-blur">
+            Click the map or pick a place above to drop a pin.
+          </div>
+        ) : null}
+      </div>
+
+      {value ? (
+        <button
+          type="button"
+          onClick={() => {
+            onChange(null);
+            setQuery("");
+          }}
+          className="text-[11px] font-medium text-text-tertiary underline-offset-2 hover:text-text-primary hover:underline"
+        >
+          Clear location
+        </button>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes the two highest-leverage V1 gaps surfaced by the USER-PATH blueprint (§A5 and §A6). The rector now has a single Identity screen where they can drop a real pin on a real campus and pick the image that represents it everywhere.

- **Location panel** — Mapbox geocoder + draggable pin + click-to-set, mounted on `/identity`. Writes `sceneData.mapboxScene.center` — the exact shape `OrgWorldMap` already reads — so a save lights up the org-tier world map without any extra plumbing.
- **Card image upload** next to Logo + Hero. Writes the top-level `Project.thumbnail` column (used today by the campus list card and the public viewer's fallback hero). Preview falls back to the hero image when no dedicated card image is set, so the empty state shows what the rector will actually get.
- Save handler strips the legacy `sceneData.center` field whenever it persists, so old rows migrate to canonical `mapboxScene.center` the first time a rector touches Identity.

## Bundle cost
`LocationPicker` pulls in mapbox-gl (~half a megabyte). It's lazy-loaded via `next/dynamic` with an SSR-disabled skeleton, so it only ships when the rector scrolls to the panel — `/identity` first-load went from 158 kB → 160 kB (vs. 608 kB with eager import).

## Blueprint updated
Both §A5 and §A6 flipped to ✅. Two follow-ups carry forward:
- §A5.3 — empty-state CTA on the org world map for campuses with no location
- §A6.3 — show the card image inside the world map's pin tooltip

## Test plan
- [ ] `pnpm build` in `apps/campus` succeeds with the new route at ~22 kB.
- [ ] Open `/org/<orgId>/maps/<mapId>/identity` on a campus with no coordinates → Location panel shows the world map zoomed to Athens with a hint to click or search.
- [ ] Type "International Hellenic University Thermi" in the address box → suggestions appear, picking one drops a pin and the map flies to it.
- [ ] Drag the pin or click somewhere else on the map → coordinates update in the readout pill in the top-right.
- [ ] Hit Save → check `/api/maps/<mapId>` response: `sceneData.mapboxScene.center = [lng, lat]` and the legacy `sceneData.center` is gone.
- [ ] Open the org dashboard's world map → pin appears at the saved location.
- [ ] Upload a card image → after Save, hit `/api/maps?orgId=<orgId>` → response includes `thumbnail` URL.
- [ ] Open `/org/<orgId>/maps` → campus card shows the new thumbnail.
- [ ] On a campus with no thumbnail but a hero set: Card image preview shows the hero at 60% opacity as a fallback hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)