### PR TITLE
feat(campus): real "What Changed" feed on the dashboard

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -124,7 +124,7 @@
 | 3 | Stat: Push subscribers | ⚠️ → ✅ | Wired in **this** PR using existing `/push-stats` |
 | 4 | Stat: POIs across N buildings | ✅ | From `campus-health` |
 | 5 | Stat: Accessibility % | ✅ | From `campus-health` |
-| 6 | What Changed feed (audit timeline) | ❌ | Empty state; needs Activity log surfaced |
+| 6 | What Changed feed (audit timeline) | ✅ | Synthesised from satellite `updatedAt` columns (news / events / clubs / dining / campus settings) + a rolled-up subscriber tally — no audit-log schema needed. `GET /api/maps/<mapId>/changes` |
 | 7 | Jump-back tiles to recent CRUD | ✅ | `JumpBackInTiles` |
 
 ### A12. Manage organisation members
@@ -188,7 +188,7 @@
 | 2 | Events list + detail | ✅ | `/campus/<token>/events` |
 | 3 | Clubs grid + detail | ✅ | `/campus/<token>/clubs` |
 | 4 | Dining grid (no detail) | ✅ | `/campus/<token>/dining` |
-| 5 | `/explore` page | 🗑 | Empty placeholder — nothing linked to it. Remove or replace with the consolidated explore from #46 |
+| 5 | `/explore` page | ✅ | Working shortlink: `?tab=news\|events\|clubs\|dining` redirects to the matching page; bare `/explore` defaults to `/events`. Used by the home "Explore" tile and notification deep-links |
 
 ### B4. Use the map
 
@@ -251,11 +251,10 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 ### Post-MVP, useful
 | S | U | Item | Pointer |
 |---|---|---|---|
-| S | Low | Delete `/campus/<token>/explore` page (orphan) | B3.5 |
 | M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 |
 | M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 |
 | M | Med | "Open now" structured hours for dining | A7.6 |
-| L | Med | Audit log / What Changed feed | A11.6 |
+| L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — feed shipped synthesised from `updatedAt`; richer trail TBD |
 | M | Med | Broadcast model + history with CTR on `/reach` | A10.5 |
 | S | Med | Org-level "New organisation" form | A2.2 |
 | S | Med | Org-level "Enable Campus app" toggle | A2.4 |

--- a/apps/campus/app/(dashboard)/components/WhatChangedCard.tsx
+++ b/apps/campus/app/(dashboard)/components/WhatChangedCard.tsx
@@ -1,39 +1,188 @@
-import { History } from "lucide-react";
+import Link from "next/link";
+import {
+  ArrowRight,
+  Bell,
+  Calendar,
+  History,
+  Newspaper,
+  Palette,
+  Users,
+  Utensils,
+} from "lucide-react";
+import type { CampusChange, ChangeKind } from "@/lib/changes";
+
+interface Props {
+  items: CampusChange[];
+  isLoading?: boolean;
+}
 
 /**
- * Stub of the What Changed activity feed for the campus dashboard.
+ * "What Changed" feed on the campus dashboard. Renders the merged
+ * activity list synthesised by `lib/changes.ts` — a row per recent
+ * change with an icon, a label, a relative timestamp, and a
+ * deep-link to the screen that owns the entity.
  *
- * The IHU mocks show a list of recent attributed actions ("Maria
- * Georgiou published news …" / "You changed primary colour to …"),
- * but no AuditLog model exists in the schema yet. Rather than
- * sprinkling fake entries that misrepresent the product, this card
- * ships as an empty state until the audit-log arc lands.
+ * Three states:
+ *   - cold (no data yet) → skeleton rows so the layout doesn't pop
+ *   - empty (fresh campus, no edits) → friendly placeholder
+ *   - populated → list
  *
- * When that arc happens, this becomes a thin renderer over a real
- * list — props change, layout stays.
+ * Kept presentational — the parent owns SWR, this just renders. That
+ * way the same component can render server-supplied data on the org
+ * dashboard later without a new variant.
  */
-export function WhatChangedCard() {
+export function WhatChangedCard({ items, isLoading }: Props) {
   return (
     <section className="rounded-2xl border border-line-soft bg-surface-1 p-6">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-sm font-semibold text-text-primary">
           What changed
         </h2>
-        <span className="text-xs text-text-tertiary">last 7 days</span>
+        <span className="text-xs text-text-tertiary">last 30 days</span>
       </div>
-      <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
-        <div
-          aria-hidden
-          className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent"
-        >
-          <History size={18} strokeWidth={1.6} />
+
+      {isLoading && items.length === 0 ? (
+        <ul className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <li
+              key={i}
+              className="h-12 animate-pulse rounded-xl bg-surface-2/60"
+            />
+          ))}
+        </ul>
+      ) : items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+          <div
+            aria-hidden
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent"
+          >
+            <History size={18} strokeWidth={1.6} />
+          </div>
+          <p className="text-sm font-medium text-text-primary">
+            No activity yet
+          </p>
+          <p className="max-w-xs text-xs text-text-tertiary">
+            Edits to this campus appear here so the team can see what
+            changed and when.
+          </p>
         </div>
-        <p className="text-sm font-medium text-text-primary">No activity yet</p>
-        <p className="max-w-xs text-xs text-text-tertiary">
-          Edits to this campus appear here so the team can see what changed
-          and by whom.
-        </p>
-      </div>
+      ) : (
+        <ul className="space-y-1.5">
+          {items.map((item) => (
+            <ChangeRow key={item.id} item={item} />
+          ))}
+        </ul>
+      )}
     </section>
   );
+}
+
+function ChangeRow({ item }: { item: CampusChange }) {
+  const Icon = ICONS[item.kind];
+  const verb = verbFor(item);
+  const inner = (
+    <>
+      <span
+        aria-hidden
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent"
+      >
+        <Icon size={14} strokeWidth={1.75} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs font-medium text-text-tertiary">
+            {verb}
+          </span>
+          <span className="truncate text-sm font-medium text-text-primary">
+            {item.title}
+          </span>
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-text-tertiary">
+          <time dateTime={item.at}>{relative(item.at)}</time>
+          {item.detail ? (
+            <>
+              <span aria-hidden>·</span>
+              <span>{item.detail}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+      {item.href ? (
+        <ArrowRight
+          size={14}
+          strokeWidth={1.75}
+          aria-hidden
+          className="shrink-0 text-text-tertiary"
+        />
+      ) : null}
+    </>
+  );
+
+  if (item.href) {
+    return (
+      <li>
+        <Link
+          href={item.href}
+          className="group flex items-center gap-3 rounded-xl px-2 py-2 transition-colors hover:bg-surface-2/60"
+        >
+          {inner}
+        </Link>
+      </li>
+    );
+  }
+  return (
+    <li className="flex items-center gap-3 px-2 py-2">{inner}</li>
+  );
+}
+
+const ICONS: Record<ChangeKind, typeof Newspaper> = {
+  news: Newspaper,
+  event: Calendar,
+  club: Users,
+  dining: Utensils,
+  campus: Palette,
+  subscribers: Bell,
+};
+
+/** Verb phrase used as the row's eyebrow. Kept short — the entity's
+ *  own title carries the specifics. */
+function verbFor(item: CampusChange): string {
+  if (item.kind === "subscribers") return "Subscribers";
+  if (item.kind === "campus") return item.isNew ? "Created" : "Updated";
+  const verb = item.isNew ? "New" : "Updated";
+  const noun = {
+    news: "news",
+    event: "event",
+    club: "club",
+    dining: "dining",
+    campus: "",
+    subscribers: "",
+  }[item.kind];
+  return `${verb} ${noun}`;
+}
+
+const RELATIVE_THRESHOLDS = [
+  { ms: 60_000, label: "just now" },
+  { ms: 60 * 60_000, divisor: 60_000, suffix: "m" },
+  { ms: 24 * 60 * 60_000, divisor: 60 * 60_000, suffix: "h" },
+  { ms: 7 * 24 * 60 * 60_000, divisor: 24 * 60 * 60_000, suffix: "d" },
+  { ms: 30 * 24 * 60 * 60_000, divisor: 7 * 24 * 60 * 60_000, suffix: "w" },
+] as const;
+
+/** Compact relative time, e.g. `"3h"`, `"2d"`. Falls back to a
+ *  short locale date for anything older than a month. */
+function relative(iso: string): string {
+  const ageMs = Date.now() - new Date(iso).getTime();
+  if (ageMs < 0) return "just now";
+  for (const t of RELATIVE_THRESHOLDS) {
+    if (ageMs < t.ms) {
+      if ("label" in t) return t.label;
+      const n = Math.max(1, Math.floor(ageMs / t.divisor));
+      return `${n}${t.suffix}`;
+    }
+  }
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/CampusProfileClient.tsx
@@ -19,6 +19,7 @@ import { WhatChangedCard } from "@/app/(dashboard)/components/WhatChangedCard";
 import { JumpBackInTiles } from "@/app/(dashboard)/components/JumpBackInTiles";
 import { WelcomeFirstRunCard } from "@/app/(dashboard)/components/WelcomeFirstRunCard";
 import { useCampusHealth } from "@/app/hooks/useCampusHealth";
+import { useCampusChanges } from "@/app/hooks/useCampusChanges";
 import { useOrganization } from "@/app/hooks/useOrganizations";
 
 interface Props {
@@ -63,6 +64,8 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
     fetcher,
   );
   const { health, isLoading: healthLoading } = useCampusHealth(mapId);
+  const { items: changes, isLoading: changesLoading } =
+    useCampusChanges(mapId);
   // Reuse Reach's stat endpoint so the dashboard's Subscribers card
   // and the Reach screen agree to the unit. 30s refresh matches Reach.
   const { data: pushStats } = useSWR<PushStats>(
@@ -228,7 +231,7 @@ export default function CampusProfileClient({ orgId, mapId }: Props) {
 
       <div className="mt-8 grid gap-4 lg:grid-cols-[2fr_1fr]">
         <CampusHealthCard health={health} isLoading={healthLoading} />
-        <WhatChangedCard />
+        <WhatChangedCard items={changes} isLoading={changesLoading} />
       </div>
 
       <div className="mt-4">

--- a/apps/campus/app/api/maps/[mapId]/changes/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/changes/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import { readCampusChanges } from "@/lib/changes";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * `GET /api/maps/[mapId]/changes` — recent activity feed for the
+ * campus dashboard's "What Changed" card.
+ *
+ * Built from satellite-model `updatedAt` columns rather than a
+ * dedicated audit log — see `lib/changes.ts` for the rationale.
+ * Read-gated so only campus members see the feed; the data leaks
+ * nothing the dashboard itself doesn't already show, but the URL
+ * shouldn't be a probe vector for external scanners.
+ */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  // The dashboard scopes itself by org id (used for the hrefs); we
+  // resolve it from the project rather than asking the client to
+  // pass it on a URL it could spoof.
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ items: [] }, { status: 404 });
+  }
+
+  try {
+    const items = await readCampusChanges({
+      mapId,
+      orgId: project.organizationId,
+      limit: 8,
+    });
+    return NextResponse.json({ items });
+  } catch (err) {
+    console.error("[changes]", err);
+    // Empty-state degradation — the card stays mounted with its
+    // "No activity yet" message instead of the whole dashboard
+    // rendering an error.
+    return NextResponse.json({ items: [] }, { status: 200 });
+  }
+}

--- a/apps/campus/app/global-error.tsx
+++ b/apps/campus/app/global-error.tsx
@@ -54,7 +54,12 @@ export default function GlobalError({ error }: Props) {
             We&rsquo;ve been notified and are taking a look. Try again, or
             head back to the dashboard.
           </p>
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
+            // Plain anchor on purpose: this boundary renders when the
+            // React tree itself has died, so a full document reload is
+            // the correct recovery — soft navigation would re-mount
+            // into the same broken state.
             href="/"
             style={{
               display: "inline-block",

--- a/apps/campus/app/hooks/useCampusChanges.ts
+++ b/apps/campus/app/hooks/useCampusChanges.ts
@@ -1,0 +1,32 @@
+import useSWR from "swr";
+import type { CampusChange } from "@/lib/changes";
+
+interface ChangesResponse {
+  items: CampusChange[];
+}
+
+const fetcher = (url: string): Promise<ChangesResponse> =>
+  fetch(url, { credentials: "include" }).then((r) => {
+    if (!r.ok) throw new Error(String(r.status));
+    return r.json() as Promise<ChangesResponse>;
+  });
+
+/**
+ * SWR-backed read of `/api/maps/<mapId>/changes` — drives the campus
+ * dashboard's What Changed card. 30s revalidation matches push-stats
+ * so the two side-by-side cards refresh together; focus revalidation
+ * is on so coming back to the tab refreshes after a content edit.
+ */
+export function useCampusChanges(mapId: string | null | undefined) {
+  const { data, error, isLoading, mutate } = useSWR<ChangesResponse>(
+    mapId ? `/api/maps/${mapId}/changes` : null,
+    fetcher,
+    { revalidateOnFocus: true, dedupingInterval: 5000, refreshInterval: 30_000 },
+  );
+  return {
+    items: data?.items ?? [],
+    error,
+    isLoading,
+    mutate,
+  };
+}

--- a/apps/campus/lib/changes.ts
+++ b/apps/campus/lib/changes.ts
@@ -1,0 +1,228 @@
+import "server-only";
+import { prisma } from "@/lib/prisma";
+
+export type ChangeKind =
+  | "news"
+  | "event"
+  | "club"
+  | "dining"
+  | "campus"
+  | "subscribers";
+
+export interface CampusChange {
+  /** Stable identifier — composed `<kind>:<rowId>` so React keys never clash. */
+  id: string;
+  kind: ChangeKind;
+  /** Human-readable label, e.g. `"Exam schedule"` or `"Branding updated"`. */
+  title: string;
+  /** Optional deep-link into the dashboard. */
+  href?: string;
+  /** Optional one-line context, e.g. `"3 new"` or `"posted by Maria"`. */
+  detail?: string;
+  /** True for creations (createdAt ≈ updatedAt), false for updates. */
+  isNew: boolean;
+  /** ISO timestamp — the change's `updatedAt`. */
+  at: string;
+}
+
+/** How many rows to read per satellite model before merging. The merged
+ *  list is capped at `limit`; over-reading per model keeps the merge
+ *  fair when one model has a sustained edit burst. */
+const PER_MODEL_LIMIT = 10;
+/** "Created" vs "updated" — Prisma stamps `createdAt` and `updatedAt`
+ *  in the same write, but they can drift by a few ms. Treat the gap
+ *  as a creation. */
+const CREATION_GAP_MS = 5_000;
+/** Activity window — anything older than this drops out of the feed
+ *  even if there's slack in the per-model cap. */
+const WINDOW_DAYS = 30;
+
+interface BuildOpts {
+  /** Project / campus id. */
+  mapId: string;
+  /** Org id — used to scope the org-tier hrefs. */
+  orgId: string;
+  /** How many changes to return after merging. */
+  limit?: number;
+}
+
+/**
+ * "What changed" feed for a campus dashboard.
+ *
+ * We don't have a dedicated audit-log model — every write would need
+ * to be re-routed through one — so this builds the feed from the
+ * `updatedAt` columns we already maintain on news / events / clubs /
+ * dining + the project itself. Good enough to answer "what did the
+ * team do this week?" without a schema change; we can swap in a real
+ * `Activity` reader later without touching the UI (just this file).
+ *
+ * Subscriber growth is rolled up into a single entry so a one-tab
+ * burst of installs doesn't drown the rest of the feed.
+ */
+export async function readCampusChanges({
+  mapId,
+  orgId,
+  limit = 8,
+}: BuildOpts): Promise<CampusChange[]> {
+  const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const dashBase = `/org/${orgId}/maps/${mapId}`;
+
+  const [project, news, events, clubs, dining, recentSubs] =
+    await Promise.all([
+      prisma.project.findUnique({
+        where: { id: mapId },
+        select: {
+          id: true,
+          title: true,
+          updatedAt: true,
+          createdAt: true,
+          isPublished: true,
+        },
+      }),
+      prisma.newsPost
+        .findMany({
+          where: { projectId: mapId, updatedAt: { gte: since } },
+          orderBy: { updatedAt: "desc" },
+          take: PER_MODEL_LIMIT,
+          select: {
+            id: true,
+            title: true,
+            updatedAt: true,
+            createdAt: true,
+          },
+        })
+        .catch(() => []),
+      prisma.eventPost
+        .findMany({
+          where: { projectId: mapId, updatedAt: { gte: since } },
+          orderBy: { updatedAt: "desc" },
+          take: PER_MODEL_LIMIT,
+          select: {
+            id: true,
+            title: true,
+            updatedAt: true,
+            createdAt: true,
+          },
+        })
+        .catch(() => []),
+      prisma.club
+        .findMany({
+          where: { projectId: mapId, updatedAt: { gte: since } },
+          orderBy: { updatedAt: "desc" },
+          take: PER_MODEL_LIMIT,
+          select: {
+            id: true,
+            name: true,
+            updatedAt: true,
+            createdAt: true,
+          },
+        })
+        .catch(() => []),
+      prisma.diningLocation
+        .findMany({
+          where: { projectId: mapId, updatedAt: { gte: since } },
+          orderBy: { updatedAt: "desc" },
+          take: PER_MODEL_LIMIT,
+          select: {
+            id: true,
+            name: true,
+            updatedAt: true,
+            createdAt: true,
+          },
+        })
+        .catch(() => []),
+      prisma.pushSubscription
+        .count({
+          where: {
+            projectId: mapId,
+            createdAt: {
+              gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+            },
+          },
+        })
+        .catch(() => 0),
+    ]);
+
+  const items: CampusChange[] = [];
+
+  for (const row of news) {
+    items.push(makeRow("news", row.id, row.title, row.createdAt, row.updatedAt, `${dashBase}/news`));
+  }
+  for (const row of events) {
+    items.push(makeRow("event", row.id, row.title, row.createdAt, row.updatedAt, `${dashBase}/events`));
+  }
+  for (const row of clubs) {
+    items.push(makeRow("club", row.id, row.name, row.createdAt, row.updatedAt, `${dashBase}/clubs`));
+  }
+  for (const row of dining) {
+    items.push(makeRow("dining", row.id, row.name, row.createdAt, row.updatedAt, `${dashBase}/dining`));
+  }
+
+  // Project-level change: branding / publish state / scene edits.
+  // We can't tell what specifically moved without an audit log, so
+  // we label it as either "Branding & settings updated" or "Campus
+  // published" — the latter only if isPublished is true and updatedAt
+  // is fresh.
+  if (project && project.updatedAt >= since) {
+    const projectIsNew =
+      project.updatedAt.getTime() - project.createdAt.getTime() <
+      CREATION_GAP_MS;
+    items.push({
+      id: `campus:${project.id}:${project.updatedAt.getTime()}`,
+      kind: "campus",
+      title: projectIsNew
+        ? "Campus created"
+        : project.isPublished
+          ? "Campus settings updated"
+          : "Draft settings updated",
+      href: `${dashBase}/identity`,
+      isNew: projectIsNew,
+      at: project.updatedAt.toISOString(),
+    });
+  }
+
+  // Push subscribers rolled up into one entry. The endpoint is the
+  // dashboard's Reach screen — clicking through gives the live total
+  // and the broadcast composer in one place.
+  if (recentSubs > 0) {
+    items.push({
+      id: `subscribers:${mapId}:7d`,
+      kind: "subscribers",
+      title:
+        recentSubs === 1
+          ? "1 new push subscriber"
+          : `${recentSubs} new push subscribers`,
+      detail: "last 7 days",
+      href: `${dashBase}/reach`,
+      isNew: true,
+      // Timestamp at "now" so this floats to the top when activity is
+      // otherwise thin — feels right because the count IS current,
+      // not a single past event.
+      at: new Date().toISOString(),
+    });
+  }
+
+  // Newest first, capped.
+  items.sort((a, b) => b.at.localeCompare(a.at));
+  return items.slice(0, limit);
+}
+
+function makeRow(
+  kind: ChangeKind,
+  id: string,
+  title: string,
+  createdAt: Date,
+  updatedAt: Date,
+  href: string,
+): CampusChange {
+  const isNew =
+    updatedAt.getTime() - createdAt.getTime() < CREATION_GAP_MS;
+  return {
+    id: `${kind}:${id}`,
+    kind,
+    title,
+    href,
+    isNew,
+    at: updatedAt.toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary
Replaces the empty-state placeholder on the campus dashboard with a working activity feed. No new schema, no extra writes — the `updatedAt` columns on news / events / clubs / dining / the project itself already tell us what moved this week.

## What's in
- **`lib/changes.ts`** — server-only synthesiser. Reads top N rows per satellite model in the last 30 days, plus the project's own `updatedAt` (for branding / publish-state edits), plus a 7-day rolled-up subscriber tally so a burst of installs doesn't drown the rest of the feed.
- **`GET /api/maps/<mapId>/changes`** — read-gated endpoint. Returns `{ items }`; degrades to `[]` on error so the card stays mounted with its empty state instead of the dashboard rendering a 500.
- **`useCampusChanges`** hook — SWR with 30s refresh + focus revalidation, matching `push-stats` so the two side-by-side cards refresh together.
- **`WhatChangedCard`** rewritten as a presentational list with three states (cold / empty / populated), per-row icons by kind, compact relative timestamps (`3h`, `2d`), and deep-links into the right authoring screen.

## Why synthesise instead of writing an audit log
A real per-write audit table is a meaningful piece of infra: schema, write path through every route, a backfill story. We can ship the dashboard signal today with what's already in the DB and add the real log later — same UI, swap the data source. The blueprint's punch list reflects that.

## Drive-by corrections
- `global-error.tsx` (from #197) — Next's "use Link not a tag" lint rule was complaining; the recovery flow there *should* be a hard reload, so plain `<a>` with a one-line ESLint disable + a why comment.
- `/campus/<token>/explore` was flagged as an orphan in the blueprint (§B3.5) but is actually a working shortlink — consumer home links to it, `?tab=…` redirects to the matching list page. Blueprint flipped to ✅.

## Test plan
- [ ] `pnpm build` succeeds (verified locally; `/api/maps/[mapId]/changes` appears in the route list).
- [ ] Fresh campus with no edits: dashboard shows the same "No activity yet" empty state as before — no regression.
- [ ] Campus with recent news + events + clubs + dining + a branding save: card lists them newest-first with the right icon, verb (`New news` vs `Updated news`), and timestamp; row click lands on the matching screen.
- [ ] Campus with new push subscribers in last 7 days: rolled-up "N new push subscribers" row appears at the top, linking to `/reach`.
- [ ] Network tab: `/api/maps/<mapId>/changes` returns 200 with up to 8 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)