### PR TITLE
feat(campus): Manage tier Members + Settings (Backoffice Phase 5)

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -133,7 +133,8 @@
 |---|---|---|---|
 | 1 | List members, change role, remove | ✅ | `/org/[orgId]/settings/members` |
 | 2 | Send invite email | ✅ (env-gated) | Sends via Resend when configured, otherwise hands the owner the link (see A1.4) |
-| 3 | Per-campus member assignment (some campuses for some members) | ❌ | Role is org-wide today |
+| 3 | See "who can edit this campus" from the campus IA | ✅ | Campus-tier `/members` screen — read-only roll, separates editors from viewers, deep-link to the org-tier screen for management |
+| 4 | Per-campus role overrides (some campuses for some members) | ❌ | Role is still org-wide today; the campus-tier screen acknowledges this |
 
 ### A13. Organisation tier
 
@@ -251,8 +252,9 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 ### Post-MVP, useful
 | S | U | Item | Pointer |
 |---|---|---|---|
-| M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 |
-| M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 |
+| M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 — read-only view shipped; per-campus *overrides* are the bigger arc still queued |
+| M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 — shipped |
+| S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up |
 | M | Med | "Open now" structured hours for dining | A7.6 |
 | L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — feed shipped synthesised from `updatedAt`; richer trail TBD |
 | M | Med | Broadcast model + history with CTR on `/reach` | A10.5 |

--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -255,6 +255,18 @@ function campusNavGroups(
           icon: <Globe2 size={16} strokeWidth={1.7} />,
           active: is("/identity"),
         },
+        {
+          label: "Members",
+          href: `${prefix}/members`,
+          icon: <Users size={16} strokeWidth={1.7} />,
+          active: is("/members"),
+        },
+        {
+          label: "Settings",
+          href: `${prefix}/settings`,
+          icon: <Settings size={16} strokeWidth={1.7} />,
+          active: is("/settings"),
+        },
       ],
     },
   ];

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/members/CampusMembersPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/members/CampusMembersPageClient.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import Link from "next/link";
+import useSWR from "swr";
+import { ArrowRight, Crown, Eye, Pencil, Users } from "lucide-react";
+import { Panel } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+type Role = "owner" | "admin" | "member" | "publicViewer";
+
+interface Member {
+  id: string;
+  userId: string;
+  role: Role;
+  user: {
+    id: string;
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+  };
+}
+
+interface MembersResponse {
+  members: Member[];
+}
+
+const fetcher = (url: string): Promise<MembersResponse> =>
+  fetch(url).then((r) => r.json());
+
+/**
+ * Campus-tier Members — read-only roll of everyone in the
+ * organisation who can edit this campus. Per-campus role overrides
+ * are deferred (see USER-PATH §A12.3); today everyone with the right
+ * org role automatically gets access to every campus, so this view
+ * mirrors the org-tier list.
+ *
+ * We keep the screen because the IA is clearer with it than without:
+ * a rector standing on a campus dashboard shouldn't have to know
+ * that "members" live one level up. The "Manage members" CTA hands
+ * them off to the org-tier screen where the actual mutations happen.
+ *
+ * Filtered to roles that can read or write — `publicViewer` accounts
+ * (auth-required-but-read-only campuses, USER-PATH §A13.2) are
+ * counted separately so the list stays focused on the working team.
+ */
+export default function CampusMembersPageClient({ orgId, mapId }: Props) {
+  const { data, isLoading } = useSWR<MembersResponse>(
+    `/api/organizations/${orgId}/members`,
+    fetcher,
+  );
+
+  const all = data?.members ?? [];
+  const editors = all.filter((m) => m.role !== "publicViewer");
+  const viewers = all.filter((m) => m.role === "publicViewer");
+
+  return (
+    <div className="mx-auto w-full max-w-[920px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Manage"
+        title="Members"
+        subtitle="Who can edit or view this campus. Manage roles and invites from the organisation settings."
+        actions={
+          <Link
+            href={`/org/${orgId}/settings/members`}
+            className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
+          >
+            Manage members
+            <ArrowRight size={14} strokeWidth={1.75} aria-hidden />
+          </Link>
+        }
+      />
+
+      <Panel className="mb-6 rounded-2xl p-6">
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+            <Users size={16} strokeWidth={1.75} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-text-primary">
+              Roles are organisation-wide
+            </h2>
+            <p className="mt-0.5 text-xs text-text-tertiary">
+              Anyone with an editor role on the organisation can author
+              every campus inside it. Per-campus role overrides are on
+              the roadmap.
+            </p>
+          </div>
+        </div>
+      </Panel>
+
+      <Panel className="rounded-2xl p-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Editors
+          </h2>
+          <span className="text-xs text-text-tertiary">
+            {editors.length} {editors.length === 1 ? "person" : "people"}
+          </span>
+        </div>
+
+        {isLoading && !data ? (
+          <ul className="space-y-2">
+            {[0, 1, 2].map((i) => (
+              <li
+                key={i}
+                className="h-14 animate-pulse rounded-xl bg-surface-2/60"
+              />
+            ))}
+          </ul>
+        ) : editors.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <ul className="space-y-1.5">
+            {editors.map((m) => (
+              <MemberRow key={m.id} member={m} />
+            ))}
+          </ul>
+        )}
+      </Panel>
+
+      {viewers.length > 0 ? (
+        <Panel className="mt-6 rounded-2xl p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-text-primary">
+              Viewers
+            </h2>
+            <span className="text-xs text-text-tertiary">
+              {viewers.length}{" "}
+              {viewers.length === 1 ? "person" : "people"}
+            </span>
+          </div>
+          <ul className="space-y-1.5">
+            {viewers.map((m) => (
+              <MemberRow key={m.id} member={m} />
+            ))}
+          </ul>
+        </Panel>
+      ) : null}
+
+      {/* mapId is referenced so the file's "scoped to this campus"
+          contract is type-checked even though the screen currently
+          fetches org-level data; per-campus member assignment is the
+          follow-up that uses it. */}
+      <div className="hidden" data-map-id={mapId} />
+    </div>
+  );
+}
+
+function MemberRow({ member }: { member: Member }) {
+  const name =
+    member.user.name?.trim() ||
+    member.user.email?.split("@")[0] ||
+    "Unnamed";
+  const initials = name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((s) => s[0]?.toUpperCase() ?? "")
+    .join("");
+
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-line-soft bg-surface-2/30 p-3">
+      <span
+        aria-hidden
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-soft text-xs font-semibold text-accent"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        {member.user.image ? (
+          <img
+            src={member.user.image}
+            alt=""
+            className="h-9 w-9 rounded-full object-cover"
+          />
+        ) : (
+          initials || "?"
+        )}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-text-primary">
+          {name}
+        </p>
+        <p className="truncate text-xs text-text-tertiary">
+          {member.user.email}
+        </p>
+      </div>
+      <RoleBadge role={member.role} />
+    </li>
+  );
+}
+
+function RoleBadge({ role }: { role: Role }) {
+  const meta = ROLE_META[role];
+  const Icon = meta.icon;
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium ${meta.classes}`}
+    >
+      <Icon size={11} strokeWidth={1.75} aria-hidden />
+      {meta.label}
+    </span>
+  );
+}
+
+const ROLE_META: Record<
+  Role,
+  { label: string; icon: typeof Crown; classes: string }
+> = {
+  owner: {
+    label: "Owner",
+    icon: Crown,
+    classes: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  },
+  admin: {
+    label: "Admin",
+    icon: Pencil,
+    classes: "bg-purple-500/10 text-purple-700 dark:text-purple-300",
+  },
+  member: {
+    label: "Editor",
+    icon: Pencil,
+    classes: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  },
+  publicViewer: {
+    label: "Viewer",
+    icon: Eye,
+    classes: "bg-text-tertiary/10 text-text-tertiary",
+  },
+};
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-2 py-10 text-center">
+      <p className="text-sm font-medium text-text-primary">
+        No editors yet
+      </p>
+      <p className="max-w-xs text-xs text-text-tertiary">
+        Invite teammates from the organisation settings — they&rsquo;ll
+        appear here once they accept.
+      </p>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/members/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/members/page.tsx
@@ -1,0 +1,14 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusMembersPageClient from "./CampusMembersPageClient";
+
+export default async function CampusMembersPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
+  return <CampusMembersPageClient orgId={orgId} mapId={mapId} />;
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/settings/CampusSettingsPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/settings/CampusSettingsPageClient.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import useSWR, { mutate as globalMutate } from "swr";
+import { toast } from "react-toastify";
+import {
+  AlertTriangle,
+  Globe2,
+  Languages,
+  Lock,
+  Trash2,
+} from "lucide-react";
+import { Button, Field, Panel, Select } from "@klorad/design-system";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
+
+interface Props {
+  orgId: string;
+  mapId: string;
+}
+
+interface SceneData {
+  /** Locale shown to visitors who arrive with no explicit `?lang=` —
+   *  defaults to `"en"` when unset. */
+  defaultLocale?: "en" | "el";
+  [k: string]: unknown;
+}
+
+interface MapResponse {
+  id: string;
+  title: string;
+  isPublished?: boolean;
+  isPublic?: boolean;
+  sceneData?: SceneData;
+}
+
+interface OrgResponse {
+  isPersonal?: boolean;
+}
+
+const mapFetcher = (url: string): Promise<MapResponse> =>
+  fetch(url).then((r) => r.json());
+const orgFetcher = (url: string): Promise<OrgResponse> =>
+  fetch(url).then((r) => r.json());
+
+/**
+ * Campus-tier Settings — the publishing controls, language defaults
+ * and danger zone that don't belong on the content authoring screens.
+ *
+ * Three panels, ordered by reversibility (most-reversible first so the
+ * destructive action is harder to mis-click):
+ *   1. Visibility — published / draft + auth requirement
+ *   2. Localisation — default locale for visitors who arrive with no
+ *      `?lang=` query
+ *   3. Danger zone — delete this campus
+ *
+ * The publish toggle is intentionally mirrored from Reach so a rector
+ * landing here in "I need to publish" mode doesn't have to context-
+ * switch. SWR keeps both screens in sync.
+ */
+export default function CampusSettingsPageClient({ orgId, mapId }: Props) {
+  const router = useRouter();
+  const { data: map } = useSWR<MapResponse>(
+    `/api/maps/${mapId}`,
+    mapFetcher,
+  );
+  const { data: org } = useSWR<OrgResponse>(
+    `/api/organizations/${orgId}`,
+    orgFetcher,
+  );
+
+  const [defaultLocale, setDefaultLocale] = useState<"en" | "el">("en");
+  const [isPublic, setIsPublic] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [publishBusy, setPublishBusy] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState("");
+
+  useEffect(() => {
+    if (hydrated || !map) return;
+    setDefaultLocale(map.sceneData?.defaultLocale ?? "en");
+    setIsPublic(map.isPublic ?? true);
+    setHydrated(true);
+  }, [hydrated, map]);
+
+  const dirty = useMemo(() => {
+    if (!hydrated || !map) return false;
+    return (
+      defaultLocale !== (map.sceneData?.defaultLocale ?? "en") ||
+      isPublic !== (map.isPublic ?? true)
+    );
+  }, [hydrated, map, defaultLocale, isPublic]);
+
+  // Personal organisations can't have private campuses — the schema
+  // pins `isPublic` to `true` for them. Surface that as a disabled
+  // toggle with a hint rather than silently dropping the control,
+  // so the rector understands why it's locked.
+  const canChangeVisibility = !(org?.isPersonal ?? false);
+
+  const handleTogglePublish = async () => {
+    if (!map || publishBusy) return;
+    setPublishBusy(true);
+    const next = !map.isPublished;
+    try {
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isPublished: next }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      await globalMutate(`/api/maps/${mapId}`);
+      toast.success(next ? "Campus is now public" : "Campus is now a draft");
+    } catch {
+      toast.error("Couldn't update visibility");
+    } finally {
+      setPublishBusy(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!map || !dirty || saving) return;
+    setSaving(true);
+    try {
+      const nextScene: SceneData = {
+        ...(map.sceneData ?? {}),
+        defaultLocale,
+      };
+      const body: Record<string, unknown> = { sceneData: nextScene };
+      if (canChangeVisibility) {
+        body.isPublic = isPublic;
+      }
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Failed");
+      await globalMutate(`/api/maps/${mapId}`);
+      toast.success("Settings saved");
+    } catch {
+      toast.error("Couldn't save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!map || deleting) return;
+    if (deleteConfirm.trim() !== map.title) {
+      toast.error("Type the campus name exactly to confirm");
+      return;
+    }
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}`, { method: "DELETE" });
+      if (!res.ok && res.status !== 204) throw new Error("Failed");
+      toast.success(`${map.title} deleted`);
+      router.push(`/org/${orgId}/maps`);
+    } catch {
+      toast.error("Couldn't delete");
+      setDeleting(false);
+    }
+  };
+
+  const isPublished = Boolean(map?.isPublished);
+
+  return (
+    <div className="mx-auto w-full max-w-[920px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Manage"
+        title="Settings"
+        subtitle="Publishing, language, and the danger zone."
+        actions={
+          <>
+            <OpenPublicAction href={`/campus/${mapId}`} />
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!dirty || saving}
+            >
+              {saving ? "Saving…" : "Save changes"}
+            </Button>
+          </>
+        }
+      />
+
+      <div className="space-y-6">
+        {/* ─ Visibility ──────────────────────────────────────────── */}
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              <Globe2 size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Visibility
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Who can open this campus and whether they need to be
+                signed in.
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-line-soft bg-surface-2/40 p-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-text-primary">
+                  Publication state
+                </p>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  {isPublished
+                    ? "Live — anyone with the link can open it."
+                    : "Draft — only authors can see it."}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant={isPublished ? "secondary" : "primary"}
+                onClick={handleTogglePublish}
+                disabled={publishBusy}
+              >
+                {publishBusy
+                  ? "…"
+                  : isPublished
+                    ? "Unpublish"
+                    : "Publish campus"}
+              </Button>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-line-soft bg-surface-2/40 p-4">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <Lock
+                    size={12}
+                    strokeWidth={1.75}
+                    aria-hidden
+                    className="text-text-tertiary"
+                  />
+                  <p className="text-sm font-medium text-text-primary">
+                    Require sign-in
+                  </p>
+                </div>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  {canChangeVisibility
+                    ? isPublic
+                      ? "Anyone can read the campus once published."
+                      : "Only signed-in members of the organisation can open it."
+                    : "Personal organisations can&rsquo;t restrict access — every published campus is public."}
+                </p>
+              </div>
+              <label
+                className={`relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full transition-colors ${
+                  !canChangeVisibility
+                    ? "cursor-not-allowed opacity-50"
+                    : ""
+                } ${
+                  !isPublic ? "bg-accent" : "bg-surface-2"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={!isPublic}
+                  disabled={!canChangeVisibility}
+                  onChange={(e) => setIsPublic(!e.target.checked)}
+                />
+                <span
+                  className={`inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                    !isPublic ? "translate-x-6" : "translate-x-1"
+                  }`}
+                  aria-hidden
+                />
+              </label>
+            </div>
+          </div>
+        </Panel>
+
+        {/* ─ Localisation ────────────────────────────────────────── */}
+        <Panel className="rounded-2xl p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+              <Languages size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Localisation
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Visitors landing without a `?lang=` parameter see this
+                language by default. They can switch via the language
+                toggle in the consumer nav.
+              </p>
+            </div>
+          </div>
+          <Field label="Default language">
+            <Select
+              value={defaultLocale}
+              onChange={(e) =>
+                setDefaultLocale(e.target.value as "en" | "el")
+              }
+              className="max-w-[220px]"
+            >
+              <option value="en">English</option>
+              <option value="el">Ελληνικά (Greek)</option>
+            </Select>
+          </Field>
+        </Panel>
+
+        {/* ─ Danger zone ─────────────────────────────────────────── */}
+        <Panel className="rounded-2xl border-red-500/30 p-6">
+          <div className="mb-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-red-500/10 text-red-600 dark:text-red-400">
+              <AlertTriangle size={16} strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold text-text-primary">
+                Danger zone
+              </h2>
+              <p className="mt-0.5 text-xs text-text-tertiary">
+                Deletes the campus and every piece of content under it —
+                news, events, clubs, dining, members&rsquo; push
+                subscriptions. This cannot be undone.
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-3 rounded-xl border border-red-500/20 bg-red-500/[0.03] p-4">
+            <Field
+              label={`Type "${map?.title ?? ""}" to confirm`}
+              hint="Case-sensitive."
+            >
+              <input
+                type="text"
+                value={deleteConfirm}
+                onChange={(e) => setDeleteConfirm(e.target.value)}
+                placeholder={map?.title ?? ""}
+                spellCheck={false}
+                className="w-full rounded-md border border-line-strong bg-surface-1 px-3 py-2 text-sm text-text-primary outline-none transition-colors placeholder:text-text-tertiary focus:border-red-500"
+              />
+            </Field>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={
+                  deleting ||
+                  !map ||
+                  deleteConfirm.trim() !== map.title
+                }
+                className="inline-flex items-center gap-1.5 rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Trash2 size={14} strokeWidth={1.75} aria-hidden />
+                {deleting ? "Deleting…" : "Delete campus"}
+              </button>
+            </div>
+          </div>
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/settings/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/settings/page.tsx
@@ -1,0 +1,14 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import CampusSettingsPageClient from "./CampusSettingsPageClient";
+
+export default async function CampusSettingsPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; mapId: string }>;
+}) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+  const { orgId, mapId } = await params;
+  return <CampusSettingsPageClient orgId={orgId} mapId={mapId} />;
+}


### PR DESCRIPTION
## Summary
Completes the Manage tier IA — the rector dock now ends with all four screens (Reach, Identity, Members, Settings) instead of trailing off at Identity. Both new screens use only what the API already exposes; no schema migrations.

## What's in
- **`/maps/[mapId]/settings`** — three panels ordered by reversibility (destructive last, hardest to mis-click):
  - **Visibility**: publish toggle (mirror of Reach so SWR keeps both in sync) + require-sign-in toggle wired to the existing `Project.isPublic` column. Personal-org case disables the second toggle with a hint since the schema pins it open.
  - **Localisation**: `sceneData.defaultLocale` (en / el) — which language a visitor sees when they arrive without `?lang=`. Save-only for now; the 10 public routes still fall back to the platform default until a follow-up threads it through (queued in `USER-PATH §A13`).
  - **Danger zone**: typed-confirm delete that hits the existing `DELETE /api/maps/[mapId]` and bounces back to `/maps`.
- **`/maps/[mapId]/members`** — read-only roll of who can edit / view this campus. Per-campus role overrides aren't possible today (every org editor reaches every campus), and the screen says so directly so the rector doesn't hunt for a knob that doesn't exist. CTA hands off to org-tier `/settings/members` for mutations.
- `DashboardShell` Manage group gains the two new entries with `Users` and `Settings` icons.

## What's deferred (acknowledged in the blueprint)
- **Wire `defaultLocale` through public routes** (10 call sites of `detectLocale`). Settings persists the value today; the public viewer reads platform default until the follow-up. Tracked under §A13.
- **Per-campus role overrides** (`A12.4`). Requires a new `ProjectMember` model + auth-helper changes; the read-only Members screen is the surface that one will eventually mutate.

## Test plan
- [ ] `pnpm build` clean (verified — Settings 4.31 kB, Members 3.06 kB).
- [ ] Open `/settings`: toggling publish reflects on Reach (SWR sync), saving with a new default locale persists into `sceneData.defaultLocale` and the form goes clean.
- [ ] Personal org: "Require sign-in" toggle is disabled with the explanatory copy.
- [ ] Typed-confirm delete: button stays disabled until the name matches exactly; on click → `DELETE /api/maps/[mapId]` → redirect to `/maps`.
- [ ] Open `/members`: roll matches `/org/[orgId]/settings/members`. Empty state if 0 editors. CTA opens the org-tier screen.
- [ ] Manage tier nav now shows Reach / Identity / Members / Settings in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)