### PR TITLE
feat(campus): wire sceneData.defaultLocale through public routes

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -254,7 +254,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 |---|---|---|---|
 | M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 — read-only view shipped; per-campus *overrides* are the bigger arc still queued |
 | M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 — shipped |
-| S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up |
+| S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up — shipped |
 | M | Med | "Open now" structured hours for dining | A7.6 |
 | L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — feed shipped synthesised from `updatedAt`; richer trail TBD |
 | M | Med | Broadcast model + history with CTR on `/reach` | A10.5 |

--- a/apps/campus/app/(public)/campus/[token]/PublicViewerClient.tsx
+++ b/apps/campus/app/(public)/campus/[token]/PublicViewerClient.tsx
@@ -59,13 +59,23 @@ function MapLoadingFallback() {
 
 interface Props {
   mapId: string;
+  /** The campus's stored `sceneData.defaultLocale`, threaded through
+   *  from the server page so a fresh visit with no `?lang=` matches
+   *  the rector's chosen default instead of the platform fallback. */
+  defaultLocale?: Locale | null;
 }
 
 type Section = "home" | "directions" | "tour";
 
-export default function PublicViewerClient({ mapId }: Props) {
+export default function PublicViewerClient({
+  mapId,
+  defaultLocale,
+}: Props) {
   const searchParams = useSearchParams();
-  const initialLocale: Locale = detectLocale(searchParams.get("lang"));
+  const initialLocale: Locale = detectLocale(
+    searchParams.get("lang"),
+    defaultLocale,
+  );
   return (
     <LocaleProvider initial={initialLocale}>
       <PublicViewerInner mapId={mapId} />

--- a/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/[id]/page.tsx
@@ -3,7 +3,11 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ChevronLeft, ExternalLink, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
+import {
+  detectLocale,
+  pickDefaultLocale,
+  pickLocalized,
+} from "@/app/lib/i18n-core";
 import { getClub } from "@/lib/clubs-db";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
 
@@ -59,14 +63,19 @@ export default async function ClubDetailPage({
 }) {
   const { token, id } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
   const club = await getClub(id);
   if (!club || club.projectId !== map.id) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickDefaultLocale } from "@/app/lib/i18n-core";
 import { listTopClubsForProject } from "@/lib/clubs-db";
 import { SegmentedTabs } from "@/lib/consumer/SegmentedTabs";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
@@ -52,12 +52,17 @@ export default async function ClubsPage({
 }) {
   const { token } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/(public)/campus/[token]/dining/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/dining/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickDefaultLocale } from "@/app/lib/i18n-core";
 import { listDiningForProject } from "@/lib/dining-db";
 import { SegmentedTabs } from "@/lib/consumer/SegmentedTabs";
 import { ConsumerFooter } from "@/lib/consumer/ConsumerFooter";
@@ -52,12 +52,17 @@ export default async function DiningPage({
 }) {
   const { token } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
@@ -9,7 +9,11 @@ import {
   MapPin,
 } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
+import {
+  detectLocale,
+  pickDefaultLocale,
+  pickLocalized,
+} from "@/app/lib/i18n-core";
 import {
   formatEventWhen,
   getEventPost,
@@ -77,14 +81,19 @@ export default async function EventDetailPage({
 }) {
   const { token, id } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
   const event = await getEventPost(id);
   if (!event || event.projectId !== map.id) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
 

--- a/apps/campus/app/(public)/campus/[token]/events/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Compass } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickDefaultLocale } from "@/app/lib/i18n-core";
 import { listUpcomingEventsForProject } from "@/lib/events-db";
 import { readEventFeeds, type CampusEvent } from "@/lib/events";
 import { fetchCampusEvents } from "@/lib/events-server";
@@ -57,12 +57,17 @@ export default async function EventsPage({
 }) {
   const { token } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/(public)/campus/[token]/klio/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/klio/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickDefaultLocale } from "@/app/lib/i18n-core";
 import { KlioPanel } from "@/lib/consumer/KlioPanel";
 import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
 
@@ -49,14 +49,19 @@ export default async function KlioPage({
 }) {
   const { token } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
+
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   if (!map.isPublished)
     return <NotPublishedPlaceholder name={map.title} locale={locale} />;
-
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
 import { venueForIndoorMap } from "@/lib/mappedin/config";
-import { detectLocale } from "@/app/lib/i18n-core";
+import { detectLocale, pickDefaultLocale } from "@/app/lib/i18n-core";
 import PublicViewerClient from "../PublicViewerClient";
 import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
 import { MapPageClient } from "./MapPageClient";
@@ -30,18 +30,21 @@ export default async function CampusMapPage({
   const { token } = await params;
   const sp = await searchParams;
   const focusSpaceId = typeof sp.space === "string" ? sp.space : undefined;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
   const map = await getPublicCampusByToken(token);
 
   if (!map) notFound();
-  if (!map.isPublished)
-    return <NotPublishedPlaceholder name={map.title} locale={locale} />;
-
   const scene = (map.sceneData ?? null) as {
     indoorMapId?: string;
     branding?: { primaryColor?: string; name?: string; logo?: string };
+    defaultLocale?: unknown;
   } | null;
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene?.defaultLocale),
+  );
+  if (!map.isPublished)
+    return <NotPublishedPlaceholder name={map.title} locale={locale} />;
   const indoorMapId = scene?.indoorMapId;
   const accentColor =
     scene?.branding?.primaryColor &&
@@ -76,5 +79,10 @@ export default async function CampusMapPage({
     );
   }
 
-  return <PublicViewerClient mapId={token} />;
+  return (
+    <PublicViewerClient
+      mapId={token}
+      defaultLocale={pickDefaultLocale(scene?.defaultLocale)}
+    />
+  );
 }

--- a/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
@@ -3,7 +3,11 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ChevronLeft, MapPin } from "lucide-react";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickLocalized } from "@/app/lib/i18n-core";
+import {
+  detectLocale,
+  pickDefaultLocale,
+  pickLocalized,
+} from "@/app/lib/i18n-core";
 import {
   formatNewsDate,
   getNewsPost,
@@ -71,14 +75,19 @@ export default async function NewsDetailPage({
 }) {
   const { token, id } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
-
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
   const post = await getNewsPost(id);
   if (!post || post.projectId !== map.id) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
 

--- a/apps/campus/app/(public)/campus/[token]/news/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
-import { detectLocale, pickText } from "@/app/lib/i18n-core";
+import { detectLocale, pickDefaultLocale, pickText } from "@/app/lib/i18n-core";
 import { listNewsForProject } from "@/lib/news";
 import { readPosts } from "@/lib/posts";
 import { SegmentedTabs } from "@/lib/consumer/SegmentedTabs";
@@ -57,12 +57,18 @@ export default async function NewsPage({
 }) {
   const { token } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
 
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
 import { readHomePage } from "@/lib/home-page";
-import { detectLocale, pickLocalized, pickText } from "@/app/lib/i18n-core";
+import {
+  detectLocale,
+  pickDefaultLocale,
+  pickLocalized,
+  pickText,
+} from "@/app/lib/i18n-core";
 import { readPosts } from "@/lib/posts";
 import { listNewsForProject, type NewsPost } from "@/lib/news";
 import {
@@ -85,14 +90,21 @@ export default async function CampusHomePage({
 }) {
   const { token } = await params;
   const sp = await searchParams;
-  const locale = detectLocale(typeof sp.lang === "string" ? sp.lang : null);
 
   const map = await getPublicCampusByToken(token);
   if (!map) notFound();
+  const scene = (map.sceneData ?? {}) as {
+    branding?: CampusBranding;
+    defaultLocale?: unknown;
+  };
+  // URL wins; tenant default applies only when the visitor hasn't
+  // picked. The campus Settings screen writes `defaultLocale`.
+  const locale = detectLocale(
+    typeof sp.lang === "string" ? sp.lang : null,
+    pickDefaultLocale(scene.defaultLocale),
+  );
   if (!map.isPublished)
     return <NotPublishedPlaceholder name={map.title} locale={locale} />;
-
-  const scene = (map.sceneData ?? {}) as { branding?: CampusBranding };
   const branding = scene.branding ?? {};
   const campusName = branding.name || map.title;
   const accentColor = isValidHex(branding.primaryColor)

--- a/apps/campus/app/lib/i18n-core.ts
+++ b/apps/campus/app/lib/i18n-core.ts
@@ -257,14 +257,37 @@ const MESSAGES = {
 export type MessageKey = keyof typeof MESSAGES.en;
 
 /**
- * URL-only locale detection. Browser-side preferences (localStorage,
- * navigator.language) are intentionally NOT consulted here — they make
- * the SSR pass disagree with the first client render and trigger React
- * hydration warnings.
+ * Locale detection — URL parameter wins, then the campus's stored
+ * default (typically read from `sceneData.defaultLocale`), then the
+ * platform fallback. Browser-side preferences (localStorage,
+ * navigator.language) are intentionally NOT consulted: they'd make
+ * the SSR pass disagree with the first client render and trigger
+ * React hydration warnings.
+ *
+ * Two precedence rules deliberately:
+ *   1. `?lang=` always wins, because the visitor explicitly chose.
+ *   2. The campus default applies only when the URL is silent — a
+ *      Greek-defaulting campus still shows English the moment a
+ *      visitor clicks the EN toggle.
  */
-export function detectLocale(urlParam?: string | null): Locale {
+export function detectLocale(
+  urlParam?: string | null,
+  fallback?: Locale | null,
+): Locale {
   if (urlParam === "el" || urlParam === "en") return urlParam;
+  if (fallback === "el" || fallback === "en") return fallback;
   return DEFAULT_LOCALE;
+}
+
+/**
+ * Narrow an unknown value (typically `sceneData.defaultLocale` read
+ * from the JSON blob) to a `Locale`, returning `null` when the value
+ * isn't a supported language. Use the result directly as the second
+ * argument to {@link detectLocale}.
+ */
+export function pickDefaultLocale(value: unknown): Locale | null {
+  if (value === "el" || value === "en") return value;
+  return null;
 }
 
 /** Message lookup with {placeholder} substitution. */


### PR DESCRIPTION
## Summary
Closes the follow-up queued in `USER-PATH §A13` from #199 — the Settings screen has been saving `sceneData.defaultLocale`, but every public route was still picking up the platform default for visitors arriving without `?lang=`. Now the rector's choice actually shows.

## What's in
- **`detectLocale(urlParam, fallback?)`** — second argument added. URL still wins, so a visitor clicking the EN/EL toggle isn't overridden by a Greek-defaulting campus.
- **`pickDefaultLocale(unknown): Locale | null`** — narrows the JSON blob field to a `Locale` safely, so each call site can pass `scene.defaultLocale` without an unchecked cast.
- **10 server pages** updated to the same pattern: fetch the campus first, then resolve locale with the scene fallback. Touched: home, news (list + detail), events (list + detail), clubs (list + detail), dining, map, klio.
- **`PublicViewerClient`** (the Mapbox-fallback client component) takes a new optional `defaultLocale` prop so the map page can hand the server-resolved value down.

## What this isn't
No behaviour change for campuses that haven't set a default — `DEFAULT_LOCALE = "en"` remains the final fallback. The whole change is invisible until a rector opens Settings → picks Ελληνικά.

## Test plan
- [ ] `pnpm build` clean (verified locally; all 10 routes still compile).
- [ ] Campus with `sceneData.defaultLocale: "el"`, visited at `/campus/<token>` with no `?lang=` → renders in Greek.
- [ ] Same campus visited at `/campus/<token>?lang=en` → URL wins, renders in English.
- [ ] Campus that hasn't set a default → renders in English as before.
- [ ] Spot-check every consumer surface: /, /news, /events, /clubs, /dining, /map, /klio, plus a news/event/club detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)