### PR TITLE
feat(campus): Broadcast model + history list on Reach

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -113,7 +113,7 @@
 | 2 | Copy the public URL | ✅ | `/reach` |
 | 3 | Download an SVG QR code (sized for print) | ✅ | `/reach` (#192) |
 | 4 | Send a push broadcast with deep-link target | ✅ | `/reach` → `POST /api/maps/[mapId]/notify` |
-| 5 | Broadcast history with delivered / opened / CTR | ❌ | Placeholder card. Needs a `Broadcast` model |
+| 5 | Broadcast history with delivered / attempted counts | ✅ | `Broadcast` model + `GET /api/maps/<mapId>/broadcasts`. Open-rate / CTR still TBD — needs a service-worker click hook |
 
 ### A11. Day-to-day operations — dashboard glance
 
@@ -257,7 +257,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 | S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up — shipped |
 | M | Med | "Open now" structured hours for dining | A7.6 |
 | L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — feed shipped synthesised from `updatedAt`; richer trail TBD |
-| M | Med | Broadcast model + history with CTR on `/reach` | A10.5 |
+| M | Med | Broadcast model + history with CTR on `/reach` | A10.5 — history shipped; CTR (service-worker click hook) still queued |
 | S | Med | Org-level "New organisation" form | A2.2 |
 | S | Med | Org-level "Enable Campus app" toggle | A2.4 |
 | M | Low | Klio: tool toggles, persona sliders, suggestion chip editor | A9.3–5 |

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/CampusReachPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/CampusReachPageClient.tsx
@@ -41,8 +41,28 @@ interface PushStats {
   subscribers: number;
 }
 
+interface BroadcastHistoryItem {
+  id: string;
+  title: string;
+  body: string;
+  targetPath: string | null;
+  attempted: number;
+  delivered: number;
+  pruned: number;
+  sentAt: string;
+  senderName: string | null;
+}
+
+interface BroadcastsResponse {
+  items: BroadcastHistoryItem[];
+}
+
 const mapFetcher = (url: string): Promise<MapResponse> =>
   fetch(url).then((r) => r.json());
+
+const broadcastsFetcher = (
+  url: string,
+): Promise<BroadcastsResponse> => fetch(url).then((r) => r.json());
 
 const pushFetcher = (url: string): Promise<PushStats> =>
   fetch(url).then((r) => r.json());
@@ -92,6 +112,11 @@ export default function CampusReachPageClient({
     `/api/maps/${mapId}/push-stats`,
     pushFetcher,
     { refreshInterval: 30_000 },
+  );
+  const { data: broadcasts } = useSWR<BroadcastsResponse>(
+    `/api/maps/${mapId}/broadcasts`,
+    broadcastsFetcher,
+    { revalidateOnFocus: true },
   );
 
   const [target, setTarget] = useState<(typeof DEEPLINK_TARGETS)[number]["key"]>(
@@ -212,7 +237,10 @@ export default function CampusReachPageClient({
       setBody("");
       // Subscriber count may have shrunk if any endpoints were
       // pruned — refresh so the rector sees the live number.
-      await globalMutate(`/api/maps/${mapId}/push-stats`);
+      await Promise.all([
+        globalMutate(`/api/maps/${mapId}/push-stats`),
+        globalMutate(`/api/maps/${mapId}/broadcasts`),
+      ]);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Couldn't send");
     } finally {
@@ -351,7 +379,7 @@ export default function CampusReachPageClient({
             </div>
           </Panel>
 
-          {/* ─ History placeholder ───────────────────────────────── */}
+          {/* ─ History ────────────────────────────────────────────── */}
           <Panel className="rounded-2xl p-6">
             <div className="mb-4 flex items-start gap-3">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
@@ -362,13 +390,13 @@ export default function CampusReachPageClient({
                   Broadcast history
                 </h2>
                 <p className="mt-0.5 text-xs text-text-tertiary">
-                  Past broadcasts and their delivered / CTR counts.
+                  Past broadcasts with delivered / attempted counts.
+                  Open-rate tracking lands once the service worker
+                  reports back-clicks.
                 </p>
               </div>
             </div>
-            <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
-              History lands once we persist broadcasts to a model.
-            </div>
+            <BroadcastHistoryList items={broadcasts?.items ?? null} />
           </Panel>
         </div>
 
@@ -459,4 +487,126 @@ export default function CampusReachPageClient({
       </div>
     </div>
   );
+}
+
+/**
+ * Broadcast history rows — one per past send, newest first. Three
+ * states: cold (null, render skeleton), empty (zero broadcasts ever),
+ * populated. Delivery-rate pill highlights when a send underperformed
+ * — anything below 80% is amber, below 50% is red — so a sudden drop
+ * is obvious without parsing the raw counts.
+ */
+function BroadcastHistoryList({
+  items,
+}: {
+  items: BroadcastHistoryItem[] | null;
+}) {
+  if (items === null) {
+    return (
+      <ul className="space-y-2">
+        {[0, 1, 2].map((i) => (
+          <li
+            key={i}
+            className="h-16 animate-pulse rounded-xl bg-surface-2/60"
+          />
+        ))}
+      </ul>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+        No broadcasts yet. The next one you send will show up here.
+      </div>
+    );
+  }
+  return (
+    <ul className="space-y-2">
+      {items.map((b) => (
+        <BroadcastHistoryRow key={b.id} item={b} />
+      ))}
+    </ul>
+  );
+}
+
+function BroadcastHistoryRow({ item }: { item: BroadcastHistoryItem }) {
+  const rate =
+    item.attempted > 0
+      ? Math.round((item.delivered / item.attempted) * 100)
+      : null;
+  const ratePill =
+    rate === null
+      ? "bg-text-tertiary/10 text-text-tertiary"
+      : rate >= 80
+        ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+        : rate >= 50
+          ? "bg-amber-500/10 text-amber-700 dark:text-amber-300"
+          : "bg-red-500/10 text-red-700 dark:text-red-300";
+
+  return (
+    <li className="rounded-xl border border-line-soft bg-surface-2/30 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-text-primary">
+            {item.title}
+          </p>
+          <p className="mt-0.5 line-clamp-2 text-xs text-text-tertiary">
+            {item.body}
+          </p>
+        </div>
+        <span
+          className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-1 text-[11px] font-medium ${ratePill}`}
+        >
+          {item.delivered.toLocaleString()} / {item.attempted.toLocaleString()}
+          {rate !== null ? <> &middot; {rate}%</> : null}
+        </span>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-text-tertiary">
+        <time dateTime={item.sentAt}>{relative(item.sentAt)}</time>
+        {item.targetPath ? (
+          <>
+            <span aria-hidden>&middot;</span>
+            <span>
+              <span className="text-text-secondary">target</span>{" "}
+              <code className="font-mono">{item.targetPath}</code>
+            </span>
+          </>
+        ) : null}
+        {item.pruned > 0 ? (
+          <>
+            <span aria-hidden>&middot;</span>
+            <span>{item.pruned} pruned</span>
+          </>
+        ) : null}
+        {item.senderName ? (
+          <>
+            <span aria-hidden>&middot;</span>
+            <span>by {item.senderName}</span>
+          </>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/** Compact "Nm / Nh / Nd" relative time. Falls back to a localised
+ *  date for anything older than a month. Mirrors the dashboard
+ *  changes feed so the two surfaces read the same. */
+function relative(iso: string): string {
+  const ageMs = Date.now() - new Date(iso).getTime();
+  if (ageMs < 60_000) return "just now";
+  if (ageMs < 60 * 60_000) return `${Math.floor(ageMs / 60_000)}m`;
+  if (ageMs < 24 * 60 * 60_000) {
+    return `${Math.floor(ageMs / (60 * 60_000))}h`;
+  }
+  if (ageMs < 7 * 24 * 60 * 60_000) {
+    return `${Math.floor(ageMs / (24 * 60 * 60_000))}d`;
+  }
+  if (ageMs < 30 * 24 * 60 * 60_000) {
+    return `${Math.floor(ageMs / (7 * 24 * 60 * 60_000))}w`;
+  }
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/apps/campus/app/api/maps/[mapId]/broadcasts/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/broadcasts/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { requireCampusAccess } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * `GET /api/maps/[mapId]/broadcasts` — the Reach screen's history
+ * list. Most-recent first, capped at 25 so we don't ship the full
+ * archive on every poll. Read-gated.
+ */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  try {
+    const rows = await prisma.broadcast.findMany({
+      where: { projectId: mapId },
+      orderBy: { createdAt: "desc" },
+      take: 25,
+      select: {
+        id: true,
+        title: true,
+        body: true,
+        targetPath: true,
+        attempted: true,
+        delivered: true,
+        pruned: true,
+        createdAt: true,
+        sender: { select: { name: true, email: true } },
+      },
+    });
+    return NextResponse.json({
+      items: rows.map((b) => ({
+        id: b.id,
+        title: b.title,
+        body: b.body,
+        targetPath: b.targetPath,
+        attempted: b.attempted,
+        delivered: b.delivered,
+        pruned: b.pruned,
+        sentAt: b.createdAt.toISOString(),
+        senderName:
+          b.sender?.name ?? b.sender?.email?.split("@")[0] ?? null,
+      })),
+    });
+  } catch (err) {
+    console.error("[broadcasts]", err);
+    return NextResponse.json({ items: [] }, { status: 200 });
+  }
+}

--- a/apps/campus/app/api/maps/[mapId]/notify/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/notify/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { requireCampusAccess } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
 import { pushEnabled, sendPushToProject } from "@/lib/push";
 
 type Params = Promise<{ mapId: string }>;
@@ -11,8 +13,13 @@ type Params = Promise<{ mapId: string }>;
  *   { title: string, body: string, url?: string, icon?: string }
  *
  * Returns counts: `{ attempted, delivered, pruned }`. Subscriptions
- * that respond 404 / 410 are pruned in-line — anything else is logged
- * and the row stays in case it was transient.
+ * that respond 404 / 410 are pruned in-line — anything else is
+ * logged and the row stays in case it was transient.
+ *
+ * On success we also persist a `Broadcast` row so the Reach screen
+ * can render history. We store the *campus-relative* path (e.g.
+ * `/events`) rather than the absolute URL so deep-links survive a
+ * change to the public URL scheme.
  */
 export async function POST(req: Request, { params }: { params: Params }) {
   const { mapId } = await params;
@@ -51,6 +58,29 @@ export async function POST(req: Request, { params }: { params: Params }) {
       url,
       icon,
     });
+
+    // Persist a history row. We deliberately *don't* fail the send
+    // when the DB write fails — the notification already reached the
+    // devices, missing history is recoverable.
+    const session = await auth();
+    await prisma.broadcast
+      .create({
+        data: {
+          projectId: mapId,
+          title,
+          body: message,
+          targetPath: extractCampusRelativePath(url, mapId),
+          senderId:
+            (session?.user?.id as string | undefined) ?? null,
+          attempted: result.attempted,
+          delivered: result.delivered,
+          pruned: result.pruned,
+        },
+      })
+      .catch((err) => {
+        console.error("[notify] history insert failed", err);
+      });
+
     return NextResponse.json({ ok: true, result });
   } catch (err) {
     console.error("[notify]", err);
@@ -59,4 +89,33 @@ export async function POST(req: Request, { params }: { params: Params }) {
       { status: 500 },
     );
   }
+}
+
+/**
+ * The Reach composer sends an absolute-or-campus-prefixed URL like
+ * `/campus/<mapId>/events`. We store the campus-relative tail so
+ * future history rows stay valid if the public URL scheme moves
+ * (e.g. custom domains). Returns `null` when the URL doesn't look
+ * like a campus link — there's nothing safe to deep-link to from
+ * the history list in that case.
+ */
+function extractCampusRelativePath(
+  url: string | undefined,
+  mapId: string,
+): string | null {
+  if (!url) return null;
+  // Accept either an absolute URL or a path. We only care about the
+  // pathname for the relative tail.
+  let path = url;
+  try {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      path = new URL(url).pathname;
+    }
+  } catch {
+    return null;
+  }
+  const prefix = `/campus/${mapId}`;
+  if (!path.startsWith(prefix)) return null;
+  const tail = path.slice(prefix.length);
+  return tail || "/";
 }

--- a/packages/prisma/migrations/20260603120000_add_broadcast/migration.sql
+++ b/packages/prisma/migrations/20260603120000_add_broadcast/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "Broadcast" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "targetPath" TEXT,
+    "senderId" TEXT,
+    "attempted" INTEGER NOT NULL DEFAULT 0,
+    "delivered" INTEGER NOT NULL DEFAULT 0,
+    "pruned" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Broadcast_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Broadcast_projectId_createdAt_idx" ON "Broadcast"("projectId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Broadcast" ADD CONSTRAINT "Broadcast_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Broadcast" ADD CONSTRAINT "Broadcast_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   organizationMembers     OrganizationMember[]
   organizationInvitesSent OrganizationInvite[] @relation("InvitesSent") // Invitations sent by this user
   activities              Activity[] // Activities performed by this user (as actor)
+  broadcastsSent          Broadcast[]          @relation("BroadcastsSent") // Push broadcasts triggered by this user
 }
 
 model VerificationToken {
@@ -182,6 +183,8 @@ model Project {
   diningLocations DiningLocation[]
   // Anonymous push-notification subscribers — see lib/push.ts.
   pushSubscriptions PushSubscription[]
+  // Per-campus push broadcast history — see lib/broadcasts.ts.
+  broadcasts        Broadcast[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -586,6 +589,38 @@ model DiningLocation {
 }
 
 /// Anonymous web-push subscription. No PII — just the endpoint URL +
+/// One row per push broadcast the rector sends from the Reach screen.
+/// Stores enough context to render the history feed (title/body/target
+/// + counts) without keeping the literal device endpoint list around.
+/// `senderId` is nullable so deleting a user doesn't orphan or lose
+/// historic broadcasts they triggered.
+model Broadcast {
+  id         String   @id @default(cuid())
+  projectId  String
+  /// Notification title shown on the device.
+  title      String
+  /// Notification body shown on the device.
+  body       String
+  /// Path relative to the campus root, e.g. "/events". Stored without
+  /// the `/campus/<mapId>` prefix so deep-links don't break if the
+  /// consumer URL scheme changes.
+  targetPath String?
+  /// The user that triggered the broadcast.
+  senderId   String?
+  /// How many subscriptions we attempted to deliver to.
+  attempted  Int      @default(0)
+  /// How many succeeded (non-failure responses).
+  delivered  Int      @default(0)
+  /// How many subscriptions were pruned (404/410) during this send.
+  pruned     Int      @default(0)
+  createdAt  DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  sender  User?   @relation("BroadcastsSent", fields: [senderId], references: [id], onDelete: SetNull)
+
+  @@index([projectId, createdAt])
+}
+
 /// the two keys the Push API hands the browser, scoped to a Project.
 /// Per Project so notifications go to the right campus's visitors.
 model PushSubscription {


### PR DESCRIPTION
## Summary
Replaces the placeholder card on Reach with a real broadcast history feed, persisted to a new `Broadcast` model. Each Send now inserts a row capturing the title, body, deep-link target, who triggered it, and the attempted / delivered / pruned counters returned by `sendPushToProject`.

## Schema
New `Broadcast` model: `id`, `projectId`, `title`, `body`, `targetPath` (campus-relative — stripped of the `/campus/<mapId>` prefix so deep-links survive a URL scheme change), nullable `senderId` (deleting a user shouldn't lose history), `attempted` / `delivered` / `pruned` counters, `createdAt`. Composite index on `(projectId, createdAt)` so the history feed paginates without a scan.

Migration `20260603120000_add_broadcast` follows the existing hand-written-SQL pattern.

## Flow
- `POST /api/maps/[mapId]/notify` → sends as before → inserts a `Broadcast` row with the result counts. DB write failures don't break the send; the notification already reached devices.
- `GET /api/maps/[mapId]/broadcasts` → read-gated, most-recent 25. Degrades to `[]` on error so the panel stays mounted with its empty state.
- Reach client: history panel renders skeleton / empty / populated states. Delivery-rate pill goes amber below 80% and red below 50% so a degraded send is obvious at a glance. SWR revalidates on focus and after every Send.

## What's deferred
- **Open-rate / CTR** — needs a service-worker `notificationclick` hook that POSTs back to a counter endpoint. Its own arc; queued in `USER-PATH §A10.5`.

## Test plan
- [ ] Apply the migration (`pnpm db:migrate` on preview) — confirms the `Broadcast` table exists with the right columns and FKs.
- [ ] Send a broadcast from Reach → toast confirms `N / M`, history panel gains a row at the top within a beat (SWR revalidates after Send).
- [ ] Delivery-rate pill: a 1/1 send is green; a forced underperformer (subscriber count > devices online) shows amber or red.
- [ ] `targetPath` column: `/events` for an events deep-link; `/` for the home target; `null` when the URL doesn't look like a campus link.
- [ ] Send broadcast → delete the sending user → row remains; the byline drops to anonymous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)