### PR TITLE
feat(campus): structured dining hours + real "Open now" badge

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -79,7 +79,7 @@
 | 3 | Events ICS feed sync (paste a Google Calendar feed URL) | ✅ | `IcsFeedsManager` + `/api/maps/[mapId]/sync-ics` |
 | 4 | Clubs authoring (initials, avatar colour, member count, meets cadence) | ✅ | `/clubs` |
 | 5 | Dining authoring (hours as free text, cuisine, menu URL) | ✅ | `/dining` |
-| 6 | Structured "open now" hours (parse hoursText into a weekly schema) | ❌ | Today the public page can't tell a student whether dining is open right now |
+| 6 | Structured "open now" hours on a weekly schema | ✅ | `DiningLocation.hours` (JSON shifts). `hoursText` survives as a free-text caveat for one-off notes ("Closed for finals") |
 | 7 | Bulk-edit / re-order / tagging | ❌ | One-at-a-time only |
 | 8 | Drafts vs. published per content item | ❌ | Everything is live the moment it's saved |
 
@@ -170,7 +170,7 @@
 | 4 | News rail (DB + legacy sceneData posts) | ✅ | |
 | 5 | Events rail (DB + ICS-merged) | ✅ | |
 | 6 | Clubs "most active" rail | ✅ | |
-| 7 | Dining "now open" rail | ⚠️ | "Open now" is a heuristic on free-text hours; structured hours not yet (A7.6) |
+| 7 | Dining "now open" rail | ✅ | Real "Open now" / "Opens HH:mm" status driven by structured `hours` JSON on `DiningLocation`. Past-midnight kitchens close at 25:00+ |
 
 ### B2. Install as a PWA & receive push
 
@@ -255,7 +255,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 | M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 — read-only view shipped; per-campus *overrides* are the bigger arc still queued |
 | M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 — shipped |
 | S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up — shipped |
-| M | Med | "Open now" structured hours for dining | A7.6 |
+| M | Med | "Open now" structured hours for dining | A7.6 — shipped |
 | L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — feed shipped synthesised from `updatedAt`; richer trail TBD |
 | M | Med | Broadcast model + history with CTR on `/reach` | A10.5 — history + CTR shipped |
 | S | Med | Org-level "New organisation" form | A2.2 |

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -9,12 +9,149 @@ import {
   Field,
   Input,
   Panel,
+  Select,
   Textarea,
 } from "@klorad/design-system";
 import { uploadFile } from "@klorad/storage/client";
 import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
 import { type DiningLocation } from "@/lib/dining-db";
+import { type HoursShift, type Weekday } from "@/lib/dining-hours";
 import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
+
+const WEEKDAY_LABELS: Record<Weekday, string> = {
+  0: "Sun",
+  1: "Mon",
+  2: "Tue",
+  3: "Wed",
+  4: "Thu",
+  5: "Fri",
+  6: "Sat",
+};
+
+/**
+ * Hours editor — row per shift, add/remove rows, pick the weekday
+ * and type open + close (`HH:mm`). Native `<input type="time">` gives
+ * us free validation and a sane keyboard / dial UI on every browser;
+ * we don't try to be clever about preventing overlapping shifts,
+ * since "lunch + dinner" overlap is actually legitimate.
+ */
+function HoursEditor({
+  value,
+  onChange,
+}: {
+  value: HoursShift[];
+  onChange: (next: HoursShift[]) => void;
+}) {
+  const sorted = [...value].sort(
+    (a, b) => a.day - b.day || a.open.localeCompare(b.open),
+  );
+
+  const addRow = () => {
+    // Default to "Mon 09:00 - 17:00" if no existing rows, otherwise
+    // clone the day of the last row so the rector can quickly add a
+    // second shift (Mon lunch, Mon dinner).
+    const last = sorted[sorted.length - 1];
+    const next: HoursShift = {
+      day: last ? last.day : 1,
+      open: "09:00",
+      close: "17:00",
+    };
+    onChange([...value, next]);
+  };
+
+  const update = (idx: number, patch: Partial<HoursShift>) => {
+    const copy = [...value];
+    copy[idx] = { ...copy[idx], ...patch };
+    onChange(copy);
+  };
+
+  const remove = (idx: number) => {
+    const copy = [...value];
+    copy.splice(idx, 1);
+    onChange(copy);
+  };
+
+  if (sorted.length === 0) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-4 text-xs text-text-tertiary">
+          No structured hours yet. The public site will fall back to the
+          caveat below.
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={addRow}
+        >
+          <Plus size={12} strokeWidth={1.75} aria-hidden />
+          Add shift
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-2">
+        {value.map((shift, idx) => (
+          <li
+            key={idx}
+            className="flex flex-wrap items-center gap-2 rounded-xl border border-line-soft bg-surface-2/30 p-2"
+          >
+            <Select
+              value={String(shift.day)}
+              onChange={(e) =>
+                update(idx, { day: Number(e.target.value) as Weekday })
+              }
+              className="w-[88px]"
+            >
+              {([0, 1, 2, 3, 4, 5, 6] as Weekday[]).map((d) => (
+                <option key={d} value={d}>
+                  {WEEKDAY_LABELS[d]}
+                </option>
+              ))}
+            </Select>
+            <input
+              type="time"
+              value={shift.open}
+              onChange={(e) => update(idx, { open: e.target.value })}
+              className="h-9 w-[96px] rounded-md border border-line-strong bg-surface-1 px-2 text-sm text-text-primary outline-none focus:border-accent"
+              aria-label="Opens at"
+            />
+            <span aria-hidden className="text-xs text-text-tertiary">
+              &mdash;
+            </span>
+            <input
+              type="time"
+              value={shift.close}
+              onChange={(e) => update(idx, { close: e.target.value })}
+              className="h-9 w-[96px] rounded-md border border-line-strong bg-surface-1 px-2 text-sm text-text-primary outline-none focus:border-accent"
+              aria-label="Closes at"
+            />
+            <button
+              type="button"
+              onClick={() => remove(idx)}
+              aria-label="Remove shift"
+              className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-500"
+            >
+              <Trash2 size={14} strokeWidth={1.75} aria-hidden />
+            </button>
+          </li>
+        ))}
+      </ul>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        onClick={addRow}
+      >
+        <Plus size={12} strokeWidth={1.75} aria-hidden />
+        Add shift
+      </Button>
+    </div>
+  );
+}
 
 interface Props {
   mapId: string;
@@ -43,6 +180,7 @@ export function DiningAdminClient({
   const [description, setDescription] = useState("");
   const [descriptionEl, setDescriptionEl] = useState("");
   const [hoursText, setHoursText] = useState("");
+  const [hours, setHours] = useState<HoursShift[]>([]);
   const [cuisine, setCuisine] = useState("");
   const [menuUrl, setMenuUrl] = useState("");
   const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
@@ -70,6 +208,7 @@ export function DiningAdminClient({
     setDescription("");
     setDescriptionEl("");
     setHoursText("");
+    setHours([]);
     setCuisine("");
     setMenuUrl("");
     setAnchor(EMPTY_ANCHOR);
@@ -83,6 +222,7 @@ export function DiningAdminClient({
     setDescription(location.description);
     setDescriptionEl(location.descriptionEl ?? "");
     setHoursText(location.hoursText ?? "");
+    setHours(location.hours);
     setCuisine(location.cuisine ?? "");
     setMenuUrl(location.menuUrl ?? "");
     setAnchor(
@@ -120,6 +260,7 @@ export function DiningAdminClient({
           description: description.trim(),
           descriptionEl: descriptionEl.trim() || "",
           hoursText: hoursText.trim() || undefined,
+          hours,
           cuisine: cuisine.trim() || undefined,
           menuUrl: menuUrl.trim() || undefined,
           imageUrl,
@@ -291,11 +432,21 @@ export function DiningAdminClient({
             />
           </Field>
 
-          <Field label="Hours (free text)">
+          <Field
+            label="Hours"
+            hint="Add a shift per opening — split shifts (lunch + dinner) are separate rows on the same day. Used to compute the live Open now badge."
+          >
+            <HoursEditor value={hours} onChange={setHours} />
+          </Field>
+
+          <Field
+            label="Hours caveat (free text, optional)"
+            hint="Shows alongside the structured hours. Use for one-off notes: 'Closed for finals week', 'Patio seasonal'."
+          >
             <Input
               value={hoursText}
               onChange={(e) => setHoursText(e.target.value)}
-              placeholder="Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed"
+              placeholder="Closed for finals week"
             />
           </Field>
 

--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/events-db";
 import { listTopClubsForProject, type Club } from "@/lib/clubs-db";
 import { listDiningForProject, type DiningLocation } from "@/lib/dining-db";
+import { openNowStatus } from "@/lib/dining-hours";
 import { readEventFeeds, type CampusEvent } from "@/lib/events";
 import { fetchCampusEvents } from "@/lib/events-server";
 import { mergeEvents } from "@/lib/events-merge";
@@ -219,13 +220,19 @@ export default async function CampusHomePage({
   }));
 
   // Dining rows for the "Dining now" rail — name + status pair.
-  // `hoursText` is the only status copy we have today; "open now"
-  // semantics arrive when an hours parser ships.
-  const dining: ConsumerDining[] = dbDining.map((d) => ({
-    id: d.id,
-    name: pickLocalized(d.name, d.nameEl, locale),
-    status: d.hoursText ?? d.cuisine ?? "",
-  }));
+  // Structured `hours` (when set) drives a real "Open now" / "Opens
+  // 17:00" status; otherwise we fall back to the free-text caveat or
+  // the cuisine label.
+  const now = new Date();
+  const dining: ConsumerDining[] = dbDining.map((d) => {
+    const status = openNowStatus(d.hours, now);
+    const statusCopy = locale === "el" ? status.labelEl : status.label;
+    return {
+      id: d.id,
+      name: pickLocalized(d.name, d.nameEl, locale),
+      status: statusCopy || d.hoursText || d.cuisine || "",
+    };
+  });
 
   // Merge DB events + ICS-feed events into one list — soonest first,
   // dupes (same title + minute) collapsed. `eventPostToConsumer` and

--- a/apps/campus/app/api/dining/[id]/route.ts
+++ b/apps/campus/app/api/dining/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
+import { parseHours } from "@/lib/dining-hours";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
@@ -88,6 +89,13 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
       typeof body.hoursText === "string" && body.hoursText.length > 0
         ? body.hoursText
         : null;
+  }
+  if (body.hours !== undefined) {
+    const parsed = parseHours(body.hours);
+    data.hours =
+      parsed.length > 0
+        ? (parsed as unknown as Prisma.InputJsonValue)
+        : Prisma.JsonNull;
   }
   if (body.cuisine !== undefined) {
     data.cuisine =

--- a/apps/campus/app/api/maps/[mapId]/dining/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/dining/route.ts
@@ -3,8 +3,19 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
 import { listDiningForProject, type DiningAnchor } from "@/lib/dining-db";
+import { parseHours } from "@/lib/dining-hours";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
+
+/** Normalise the incoming `hours` payload to the JSON shape we
+ *  store. Empty / missing returns `null` so the column truly says
+ *  "no structured hours" instead of an empty array — the renderer
+ *  treats those the same, but `null` is what the rest of the schema
+ *  uses for unset values. */
+function parseHoursForDb(value: unknown): Prisma.InputJsonValue | null {
+  const parsed = parseHours(value);
+  return parsed.length > 0 ? (parsed as unknown as Prisma.InputJsonValue) : null;
+}
 
 type Params = Promise<{ mapId: string }>;
 
@@ -82,6 +93,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
         typeof body.hoursText === "string" && body.hoursText.trim().length > 0
           ? body.hoursText.trim()
           : null,
+      hours: parseHoursForDb(body.hours),
       cuisine:
         typeof body.cuisine === "string" && body.cuisine.trim().length > 0
           ? body.cuisine.trim()

--- a/apps/campus/lib/consumer/DiningListClient.tsx
+++ b/apps/campus/lib/consumer/DiningListClient.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import { Clock, ExternalLink, MapPin } from "lucide-react";
 import { pickLocalized, type Locale } from "@/app/lib/i18n-core";
 import type { DiningLocation } from "@/lib/dining-db";
+import {
+  formatWeeklyHours,
+  openNowStatus,
+} from "@/lib/dining-hours";
 import { useCampusDining } from "@/lib/swr/useCampusDining";
 import { DiningListSkeleton } from "./DiningListSkeleton";
 
@@ -27,6 +32,11 @@ export function DiningListClient({
   emptyCopy,
 }: Props) {
   const { dining, isLoading } = useCampusDining(token, initialLocations);
+  // Resolve "open now" once per render. The minute resolution is
+  // enough — the client never re-renders fast enough for clock-skew
+  // to matter, and re-running every minute would trigger SWR-revalidate
+  // churn for no useful UX gain.
+  const now = useMemo(() => new Date(), [dining]);
 
   if (isLoading && dining.length === 0) {
     return <DiningListSkeleton rows={4} />;
@@ -50,6 +60,10 @@ export function DiningListClient({
           l.descriptionEl,
           locale,
         );
+        const status = openNowStatus(l.hours, now);
+        const statusCopy =
+          locale === "el" ? status.labelEl : status.label;
+        const weekly = formatWeeklyHours(l.hours, locale);
         return (
           <article
             key={l.id}
@@ -73,14 +87,33 @@ export function DiningListClient({
               />
             )}
             <div className="flex flex-1 flex-col gap-3 p-5">
-              <div>
-                <h2 className="text-lg font-medium text-[var(--brand-text)]">
-                  {name}
-                </h2>
-                {l.cuisine ? (
-                  <p className="mt-0.5 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
-                    {l.cuisine}
-                  </p>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <h2 className="text-lg font-medium text-[var(--brand-text)]">
+                    {name}
+                  </h2>
+                  {l.cuisine ? (
+                    <p className="mt-0.5 text-xs uppercase tracking-wide text-[var(--brand-text-muted)]">
+                      {l.cuisine}
+                    </p>
+                  ) : null}
+                </div>
+                {statusCopy ? (
+                  <span
+                    className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium ${
+                      status.open
+                        ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                        : "bg-[var(--brand-line)] text-[var(--brand-text-muted)]"
+                    }`}
+                  >
+                    <span
+                      aria-hidden
+                      className={`h-1.5 w-1.5 rounded-full ${
+                        status.open ? "bg-emerald-500" : "bg-[var(--brand-text-muted)]"
+                      }`}
+                    />
+                    {statusCopy}
+                  </span>
                 ) : null}
               </div>
 
@@ -88,9 +121,19 @@ export function DiningListClient({
                 {description}
               </p>
 
-              {l.hoursText ? (
+              {weekly ? (
+                <p className="inline-flex items-start gap-1.5 text-xs text-[var(--brand-text-muted)]">
+                  <Clock size={14} strokeWidth={1.75} aria-hidden />
+                  <span>{weekly}</span>
+                </p>
+              ) : l.hoursText ? (
                 <p className="inline-flex items-center gap-1.5 text-xs text-[var(--brand-text-muted)]">
-                  <Clock size={14} strokeWidth={1.75} />
+                  <Clock size={14} strokeWidth={1.75} aria-hidden />
+                  {l.hoursText}
+                </p>
+              ) : null}
+              {weekly && l.hoursText ? (
+                <p className="-mt-1 text-[11px] text-[var(--brand-text-muted)]">
                   {l.hoursText}
                 </p>
               ) : null}

--- a/apps/campus/lib/dining-db.ts
+++ b/apps/campus/lib/dining-db.ts
@@ -8,6 +8,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import type { DiningLocation as PrismaDining } from "@prisma/client";
+import { parseHours, type WeeklyHours } from "@/lib/dining-hours";
 
 export interface DiningAnchor {
   kind: "building" | "room";
@@ -25,6 +26,10 @@ export interface DiningLocation {
   /** Greek translation, optional. */
   descriptionEl: string | null;
   hoursText: string | null;
+  /** Structured weekly schedule — drives "Open now" copy on the
+   *  public surface. Empty array when the location hasn't set
+   *  structured hours yet. */
+  hours: WeeklyHours;
   cuisine: string | null;
   menuUrl: string | null;
   imageUrl: string | null;
@@ -51,6 +56,7 @@ function fromPrisma(row: PrismaDining): DiningLocation {
     description: row.description,
     descriptionEl: row.descriptionEl,
     hoursText: row.hoursText,
+    hours: parseHours(row.hours),
     cuisine: row.cuisine,
     menuUrl: row.menuUrl,
     imageUrl: row.imageUrl,

--- a/apps/campus/lib/dining-hours.ts
+++ b/apps/campus/lib/dining-hours.ts
@@ -1,0 +1,220 @@
+/**
+ * Structured weekly hours for `DiningLocation`.
+ *
+ * Stored as a JSON array on `DiningLocation.hours`. Each row is one
+ * shift on one day (Sun=0..Sat=6); a kitchen with split shifts has
+ * multiple rows for the same day. Close times after midnight wrap
+ * past `24:00` by passing e.g. `26:30` — much easier to reason about
+ * than spilling the row into the next day.
+ *
+ * Pure functions here: no Prisma, no React. Imported from both the
+ * dashboard authoring screen and the public list.
+ */
+
+/** Sunday = 0 through Saturday = 6 — matches `Date#getDay`. */
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** One open / close pair on one day, both in `HH:mm` 24-hour. The
+ *  close can be 24:00 or later to model past-midnight kitchens. */
+export interface HoursShift {
+  day: Weekday;
+  open: string;
+  close: string;
+}
+
+export type WeeklyHours = HoursShift[];
+
+const WEEKDAY_NAMES_EN: Record<Weekday, string> = {
+  0: "Sun",
+  1: "Mon",
+  2: "Tue",
+  3: "Wed",
+  4: "Thu",
+  5: "Fri",
+  6: "Sat",
+};
+
+const WEEKDAY_NAMES_EL: Record<Weekday, string> = {
+  0: "Κυρ",
+  1: "Δευ",
+  2: "Τρι",
+  3: "Τετ",
+  4: "Πεμ",
+  5: "Παρ",
+  6: "Σαβ",
+};
+
+const TIME_RE = /^\d{2}:\d{2}$/;
+
+/** Narrow an unknown JSON blob (Prisma returns `JsonValue`) to a
+ *  validated `WeeklyHours`. Anything malformed is silently filtered;
+ *  a partly-broken row is better than a 500. */
+export function parseHours(value: unknown): WeeklyHours {
+  if (!Array.isArray(value)) return [];
+  const out: WeeklyHours = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const day = e.day;
+    const open = e.open;
+    const close = e.close;
+    if (
+      typeof day !== "number" ||
+      !Number.isInteger(day) ||
+      day < 0 ||
+      day > 6 ||
+      typeof open !== "string" ||
+      typeof close !== "string" ||
+      !TIME_RE.test(open) ||
+      !TIME_RE.test(close)
+    ) {
+      continue;
+    }
+    out.push({ day: day as Weekday, open, close });
+  }
+  out.sort((a, b) => a.day - b.day || a.open.localeCompare(b.open));
+  return out;
+}
+
+function minutes(hhmm: string): number {
+  const [h, m] = hhmm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/**
+ * Is the dining location currently open? `now` defaults to the
+ * server's wall clock; the public page calls this server-side so the
+ * cached SSR answer matches the user's first paint.
+ *
+ * Past-midnight shifts close > 24:00) extend into the next day's
+ * minute math automatically. A 02:00 close on Friday is matched at
+ * 01:30 Saturday by the previous day's Fri/Sat shift.
+ */
+export function isOpenAt(hours: WeeklyHours, now: Date): boolean {
+  if (hours.length === 0) return false;
+  const day = now.getDay();
+  const nowMins = now.getHours() * 60 + now.getMinutes();
+
+  for (const h of hours) {
+    if (h.day === day) {
+      if (nowMins >= minutes(h.open) && nowMins < minutes(h.close)) {
+        return true;
+      }
+    }
+    // Past-midnight catch: a shift opened on the prior day with close
+    // > 24:00 spills into today.
+    const prevDay = (day + 6) % 7;
+    if (h.day === prevDay && minutes(h.close) > 24 * 60) {
+      const spilloverMins = minutes(h.close) - 24 * 60;
+      if (nowMins < spilloverMins) return true;
+    }
+  }
+  return false;
+}
+
+/** Same shape as `isOpenAt` but returns the next opening as `HH:mm`
+ *  on the same day, or `null` if the place won't open again today.
+ *  Used by the public surface to render "Opens at 17:00" copy. */
+export function nextOpeningToday(
+  hours: WeeklyHours,
+  now: Date,
+): string | null {
+  if (hours.length === 0) return null;
+  const day = now.getDay();
+  const nowMins = now.getHours() * 60 + now.getMinutes();
+  const todays = hours
+    .filter((h) => h.day === day)
+    .filter((h) => minutes(h.open) > nowMins)
+    .sort((a, b) => minutes(a.open) - minutes(b.open));
+  return todays[0]?.open ?? null;
+}
+
+/** Friendly "Mon-Fri 7:00-22:00 · Sat 9:00-15:00" string, derived
+ *  from `WeeklyHours`. Used both as the campus-list card subtitle
+ *  and the bilingual fallback when `hoursText` isn't set. */
+export function formatWeeklyHours(
+  hours: WeeklyHours,
+  locale: "en" | "el" = "en",
+): string {
+  if (hours.length === 0) return "";
+  const names = locale === "el" ? WEEKDAY_NAMES_EL : WEEKDAY_NAMES_EN;
+  const byDay = new Map<Weekday, string[]>();
+  for (const h of hours) {
+    const list = byDay.get(h.day) ?? [];
+    list.push(`${h.open}-${h.close}`);
+    byDay.set(h.day, list);
+  }
+  // Group consecutive days that share the exact same range list.
+  const days = Array.from({ length: 7 }, (_, i) => i as Weekday).filter(
+    (d) => byDay.has(d),
+  );
+  const segments: string[] = [];
+  let i = 0;
+  while (i < days.length) {
+    const start = days[i];
+    const ranges = byDay.get(start)!.join(",");
+    let end = start;
+    while (
+      i + 1 < days.length &&
+      days[i + 1] === end + 1 &&
+      byDay.get(days[i + 1])!.join(",") === ranges
+    ) {
+      end = days[i + 1];
+      i++;
+    }
+    const label =
+      start === end ? names[start] : `${names[start]}-${names[end]}`;
+    segments.push(`${label} ${byDay.get(start)!.join(", ")}`);
+    i++;
+  }
+  const sep = locale === "el" ? " · " : " · ";
+  return segments.join(sep);
+}
+
+export interface OpenNowStatus {
+  /** True when the location is currently open. */
+  open: boolean;
+  /** Short label suitable for a pill: "Open now" / "Closed" /
+   *  "Opens at 17:00". Empty when there are no structured hours. */
+  label: string;
+  /** Localised body copy: same as `label` but in Greek when asked. */
+  labelEl: string;
+}
+
+const STATUS_COPY = {
+  open: { en: "Open now", el: "Ανοιχτά τώρα" },
+  closed: { en: "Closed", el: "Κλειστά" },
+  opensAt: { en: "Opens", el: "Ανοίγει" },
+} as const;
+
+/** One-shot status summary — used by every surface that needs to
+ *  show "is it open?" plus follow-up copy. */
+export function openNowStatus(
+  value: unknown,
+  now: Date,
+): OpenNowStatus {
+  const hours = parseHours(value);
+  if (hours.length === 0) {
+    return { open: false, label: "", labelEl: "" };
+  }
+  if (isOpenAt(hours, now)) {
+    return {
+      open: true,
+      label: STATUS_COPY.open.en,
+      labelEl: STATUS_COPY.open.el,
+    };
+  }
+  const next = nextOpeningToday(hours, now);
+  if (next) {
+    return {
+      open: false,
+      label: `${STATUS_COPY.opensAt.en} ${next}`,
+      labelEl: `${STATUS_COPY.opensAt.el} ${next}`,
+    };
+  }
+  return {
+    open: false,
+    label: STATUS_COPY.closed.en,
+    labelEl: STATUS_COPY.closed.el,
+  };
+}

--- a/apps/campus/lib/sample-seed.ts
+++ b/apps/campus/lib/sample-seed.ts
@@ -74,10 +74,30 @@ interface SeedDining {
   nameEl?: string;
   description: string;
   descriptionEl?: string;
+  /** Free-text caveat shown alongside the structured hours. */
   hoursText: string;
+  /** Structured hours — drives the "Open now" badge on the public
+   *  surface. See `lib/dining-hours.ts` for the shape. */
+  hours: Array<{ day: number; open: string; close: string }>;
   cuisine: string;
   menuUrl?: string;
   anchors: SeedAnchor[];
+}
+
+/** Helper for the seed — give it a `[start, end]` range of weekdays
+ *  (e.g. `[1, 5]` for Mon-Fri) plus an open/close pair, get an array
+ *  of one shift per day in that range. */
+function shiftRange(
+  start: number,
+  end: number,
+  open: string,
+  close: string,
+): Array<{ day: number; open: string; close: string }> {
+  const out: Array<{ day: number; open: string; close: string }> = [];
+  for (let d = start; d <= end; d++) {
+    out.push({ day: d, open, close });
+  }
+  return out;
 }
 
 const NEWS: SeedNews[] = [
@@ -337,7 +357,11 @@ const DINING: SeedDining[] = [
       "Quick-service cafe with sandwiches, bowls, espresso, and a long patio. Bring a laptop, stay all afternoon.",
     descriptionEl:
       "Γρήγορη εξυπηρέτηση με σάντουιτς, μπολ, espresso και μεγάλη βεράντα. Φέρτε τον φορητό σας, μείνετε όλο το απόγευμα.",
-    hoursText: "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed",
+    hoursText: "",
+    hours: [
+      ...shiftRange(1, 5, "07:00", "22:00"),
+      { day: 6, open: "09:00", close: "15:00" },
+    ],
     cuisine: "Sandwiches, salads, coffee",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
@@ -345,7 +369,8 @@ const DINING: SeedDining[] = [
     name: "Marketplace",
     description:
       "All-day food court — pizza, ramen, burrito bar, and a salad bar. Multiple stations, one card swipe.",
-    hoursText: "Mon-Sun 7am-9pm",
+    hoursText: "",
+    hours: shiftRange(0, 6, "07:00", "21:00"),
     cuisine: "International, fast-casual",
     anchors: [
       { kind: "building", refId: "", refName: "1901 Marketplace Building" },
@@ -355,7 +380,12 @@ const DINING: SeedDining[] = [
     name: "Mott juice bar",
     description:
       "Smoothies, açai bowls, cold-pressed juices. Inside the athletics centre, drop in after a workout.",
-    hoursText: "Mon-Fri 6am-8pm · Sat-Sun 8am-4pm",
+    hoursText: "",
+    hours: [
+      ...shiftRange(1, 5, "06:00", "20:00"),
+      { day: 6, open: "08:00", close: "16:00" },
+      { day: 0, open: "08:00", close: "16:00" },
+    ],
     cuisine: "Smoothies, bowls",
     anchors: [
       { kind: "building", refId: "", refName: "Mott Athletics Center" },
@@ -365,7 +395,10 @@ const DINING: SeedDining[] = [
     name: "Quad pizza",
     description:
       "Sourdough pizza by the slice, salads, and dessert. Late-night window opens at 9 pm.",
-    hoursText: "Mon-Sun 11am-1am",
+    // 25:00 = 01:00 the next day — see lib/dining-hours.ts for the
+    // past-midnight encoding.
+    hoursText: "Late-night window opens at 9 pm",
+    hours: shiftRange(0, 6, "11:00", "25:00"),
     cuisine: "Pizza, salads",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
@@ -376,7 +409,12 @@ const DINING: SeedDining[] = [
       "Quiet espresso bar tucked inside Engineering South. Strict no-microwave policy; pastries from the campus bakery.",
     descriptionEl:
       "Ήσυχο espresso bar μέσα στο Engineering South. Αυστηρή απαγόρευση φούρνου μικροκυμάτων· γλυκά από τον φούρνο της πανεπιστημιούπολης.",
-    hoursText: "Mon-Fri 8am-11pm · Sat-Sun 10am-8pm",
+    hoursText: "",
+    hours: [
+      ...shiftRange(1, 5, "08:00", "23:00"),
+      { day: 6, open: "10:00", close: "20:00" },
+      { day: 0, open: "10:00", close: "20:00" },
+    ],
     cuisine: "Coffee, pastries",
     anchors: [
       { kind: "building", refId: "", refName: "Engineering South Building" },
@@ -456,7 +494,8 @@ export async function seedSampleCampus(
     nameEl: d.nameEl ?? null,
     description: d.description,
     descriptionEl: d.descriptionEl ?? null,
-    hoursText: d.hoursText,
+    hoursText: d.hoursText || null,
+    hours: d.hours as unknown as Prisma.InputJsonValue,
     cuisine: d.cuisine,
     menuUrl: d.menuUrl ?? null,
     anchors: d.anchors as unknown as Prisma.InputJsonValue,

--- a/packages/prisma/migrations/20260603140000_dining_structured_hours/migration.sql
+++ b/packages/prisma/migrations/20260603140000_dining_structured_hours/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "DiningLocation"
+  ADD COLUMN "hours" JSONB;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -569,9 +569,17 @@ model DiningLocation {
   description     String   @db.Text
   /// Greek translation of `description`, optional.
   descriptionEl   String?  @db.Text
-  /// Free text — "Mon-Fri 7am-10pm · Sat 9am-3pm · Sun closed".
-  /// Structured day/time ranges + "open now" badge are a follow-up.
+  /// Free-text caveat shown alongside the structured hours below —
+  /// e.g. "Closed for finals week" or "Patio seasonal". When the
+  /// structured `hours` is null we still display this as the
+  /// fallback status copy on the public surface.
   hoursText       String?
+  /// Structured weekly schedule. Array of
+  /// `{ day: 0-6 (Sun..Sat), open: "HH:mm", close: "HH:mm" }`
+  /// shifts. Multiple entries per day model split shifts (lunch +
+  /// dinner). Drives the "Open now" badge on the public dining list
+  /// — see `lib/dining-hours.ts`.
+  hours           Json?
   /// Free text — "Pizza, Salads, Coffee".
   cuisine         String?
   /// External link to the menu (PDF, Google Doc, restaurant site).


### PR DESCRIPTION
## Summary
Replaces the free-text hours field with a structured weekly schedule on `DiningLocation`. The public dining list now shows a real **Open now** / **Opens 17:00** / **Closed** badge driven by the actual hours, instead of just echoing whatever the rector typed.

## Schema
`DiningLocation.hours: Json?` — array of `{ day: 0-6 (Sun..Sat), open: "HH:mm", close: "HH:mm" }` shifts. Multiple rows per day model split shifts (lunch + dinner). Close past `24:00` (e.g. `25:00` = 01:00 next day) encodes late-night kitchens without spilling into the next day's row.

`hoursText` stays as a free-text caveat for one-off notes ("Closed for finals week") — the public surface shows both when set, structured hours first.

Migration `20260603140000_dining_structured_hours` adds the JSONB column. Additive only.

## What's in
- **`lib/dining-hours.ts`** — pure parsers + helpers (`parseHours`, `isOpenAt`, `nextOpeningToday`, `formatWeeklyHours`, and a one-shot `openNowStatus` that returns the badge label in EN + EL).
- **Public dining list** — gains a coloured pill (emerald when open, muted otherwise) and a derived weekly-hours line. Home Dining rail uses the same status copy.
- **Admin** — `DiningAdminClient` gets a row-per-shift `HoursEditor` (weekday `Select` + native `<input type="time">` × 2 + remove). Free-text field repositioned as "Hours caveat" with copy that makes it clear this is a supplement to the structured hours.
- **Sample seed** — every dining row now has structured hours. Quad Pizza keeps its 11:00-25:00 late-night window as the past-midnight example.

## Caveats
- "Open now" is computed at SSR-render time on the home page and at client-mount time on the dining list. The dining list doesn't ticker-revalidate every minute; the SWR cache plus focus revalidation handles long sessions, and a heuristic that close to real-time wasn't worth a per-minute re-render of the grid.
- No timezone handling — assumes the server clock and the campus clock are the same. Multi-tenant timezone is an arc of its own.

## Test plan
- [ ] Apply migration on preview → `DiningLocation` gains the `hours` JSONB column.
- [ ] Open `/dining` admin: existing rows render with an empty hours editor, the old free-text moves to the new "Hours caveat" field.
- [ ] Add a shift (Mon 09:00 – 17:00), save → public list shows "Open now" between those times today, "Opens 09:00" before, "Closed" after.
- [ ] Add a second shift on the same day (lunch + dinner pattern) → both render correctly.
- [ ] Late-night example: `close = "25:00"` (1 AM) → at 00:30 the next day, the row reads "Open now".
- [ ] Empty hours + free-text caveat set → public list falls back to the caveat (existing behaviour preserved).
- [ ] Re-run sample seed → 5 dining rows land with structured hours; "Open now" badges appear immediately at the right times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)