### PR TITLE
feat(campus): Klio knobs — tool toggles, persona sliders, chip editor

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -101,9 +101,9 @@
 |---|---|---|---|
 | 1 | Use the platform's Anthropic key (zero config) | ✅ | Server falls back to `ANTHROPIC_API_KEY` env var |
 | 2 | Bring your own key per-campus, encrypted at rest | ✅ | `/klio` → `AiKeyPanel` (AES-256-GCM via `lib/secrets.ts`) |
-| 3 | Toggle individual tools (search, wayfinding, etc.) | ❌ | All tools on or none |
-| 4 | Persona sliders (formal ↔ casual; verbose ↔ concise) | ❌ | Single fixed persona |
-| 5 | Suggestion-chip editor (custom starter prompts on the chat screen) | ❌ | Hardcoded chips |
+| 3 | Toggle individual tools (search, wayfinding, etc.) | ✅ | Per-tool kill switches on `/klio`. Disabled tools also drop their instructions from the system prompt so Claude won't pretend it has them |
+| 4 | Persona sliders (formal ↔ casual; verbose ↔ concise) | ✅ | Two 1-5 sliders + free-text additional instructions, appended to the system prompt |
+| 5 | Suggestion-chip editor (custom starter prompts on the chat screen) | ✅ | Bilingual (EN required, EL optional with EN fallback), up to eight. Empty list keeps the platform defaults |
 
 ### A10. Publish + share
 
@@ -260,7 +260,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 | M | Med | Broadcast model + history with CTR on `/reach` | A10.5 — history + CTR shipped |
 | S | Med | Org-level "New organisation" form | A2.2 |
 | S | Med | Org-level "Enable Campus app" toggle | A2.4 |
-| M | Low | Klio: tool toggles, persona sliders, suggestion chip editor | A9.3–5 |
+| M | Low | Klio: tool toggles, persona sliders, suggestion chip editor | A9.3–5 — shipped |
 | L | Med | Virtual tour authoring + playback | B4.4 |
 | M | Med | Workbench: room.reshape, floor-plan.reposition, floor-plan.replace-image | A8.3–5 |
 | M | Med | Saved routes authoring UI | A8.7 |

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/CampusKlioPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/klio/CampusKlioPageClient.tsx
@@ -1,98 +1,555 @@
 "use client";
 
-import { MessageSquare, Sliders, Wrench } from "lucide-react";
-import { Panel } from "@klorad/design-system";
+import { useEffect, useMemo, useState } from "react";
+import useSWR, { mutate as globalMutate } from "swr";
+import { toast } from "react-toastify";
+import {
+  MessageSquare,
+  Plus,
+  RotateCcw,
+  Sliders,
+  Trash2,
+  Wrench,
+} from "lucide-react";
+import {
+  Button,
+  Field,
+  Input,
+  Panel,
+  Textarea,
+} from "@klorad/design-system";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
 import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 import { AiKeyPanel } from "@/app/(dashboard)/org/[orgId]/maps/[mapId]/tabs/AiKeyPanel";
+import { ASSISTANT_TOOL_NAMES, type AssistantToolName } from "@/lib/assistant/tools";
+import {
+  DEFAULT_KLIO_CONFIG,
+  DEFAULT_PERSONA,
+  defaultTools,
+  parseKlioConfig,
+  type KlioChip,
+  type KlioConfig,
+  type KlioPersona,
+} from "@/lib/klio-config";
 
 interface Props {
   orgId: string;
   mapId: string;
 }
 
+interface MapResponse {
+  id: string;
+  sceneData?: Record<string, unknown>;
+}
+
+const mapFetcher = (url: string): Promise<MapResponse> =>
+  fetch(url).then((r) => r.json());
+
+const TOOL_LABELS: Record<AssistantToolName, { title: string; hint: string }> =
+  {
+    search_places: {
+      title: "Search places",
+      hint: "Find buildings and rooms by free-text query.",
+    },
+    query_news: {
+      title: "Query news",
+      hint: "Pull recent news posts and cite them.",
+    },
+    query_events: {
+      title: "Query events",
+      hint: "List upcoming events filtered by anchor or time window.",
+    },
+    query_clubs: {
+      title: "Query clubs",
+      hint: "List the most active student clubs.",
+    },
+    query_dining: {
+      title: "Query dining",
+      hint: "Read the dining list — names, hours, cuisines.",
+    },
+    focus: {
+      title: "Focus on a space",
+      hint: "Pan the MappedIn viewer to a single building or room.",
+    },
+    route: {
+      title: "Compute routes",
+      hint: "Draw a from-X-to-Y route, including accessible variants.",
+    },
+    cite: {
+      title: "Cite sources",
+      hint: "Surface tappable cards for news/events/clubs/dining mentioned.",
+    },
+  };
+
 /**
- * Klio — the AI campus assistant settings screen. Phase 4a ships the
- * BYOK Anthropic key card (real, wired to `/ai-settings`) plus
- * placeholder cards for the three knobs that need a backend before
- * they can land: tools the assistant can call, persona sliders,
- * suggestion chips. Those move to "Coming next" so the rail row
- * resolves to something honest instead of dead UI.
+ * Klio — the AI campus assistant settings screen. Wired to
+ * `sceneData.klio`:
+ *   - tools: per-tool kill switches
+ *   - persona: formality + verbosity sliders + free-text notes
+ *   - chips: bilingual suggestion-prompt overrides for the chat
+ *     empty state
+ *
+ * The BYOK API key panel lives next to these but speaks to a
+ * different endpoint (`/api/maps/<mapId>/ai-settings`) — keys are
+ * encrypted at rest and never round-trip through `sceneData`.
  */
 export default function CampusKlioPageClient({
   orgId: _orgId,
   mapId,
 }: Props) {
+  const { data: server } = useSWR<MapResponse>(
+    `/api/maps/${mapId}`,
+    mapFetcher,
+  );
+
+  const [config, setConfig] = useState<KlioConfig>(DEFAULT_KLIO_CONFIG);
+  const [hydrated, setHydrated] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (hydrated || !server) return;
+    setConfig(parseKlioConfig(server.sceneData?.klio));
+    setHydrated(true);
+  }, [hydrated, server]);
+
+  const savedConfig = useMemo(
+    () => parseKlioConfig(server?.sceneData?.klio),
+    [server],
+  );
+  const dirty = useMemo(
+    () => hydrated && !configsEqual(config, savedConfig),
+    [hydrated, config, savedConfig],
+  );
+
+  const handleSave = async () => {
+    if (!server || !dirty || saving) return;
+    setSaving(true);
+    try {
+      const nextScene = { ...(server.sceneData ?? {}), klio: config };
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneData: nextScene }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      await globalMutate(`/api/maps/${mapId}`);
+      toast.success("Klio settings saved");
+    } catch {
+      toast.error("Couldn't save Klio settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const setTool = (name: AssistantToolName, enabled: boolean) => {
+    setConfig((c) => ({
+      ...c,
+      tools: { ...c.tools, [name]: enabled },
+    }));
+  };
+
+  const setPersona = (patch: Partial<KlioPersona>) => {
+    setConfig((c) => ({ ...c, persona: { ...c.persona, ...patch } }));
+  };
+
+  const setChips = (chips: KlioChip[]) => {
+    setConfig((c) => ({ ...c, chips }));
+  };
+
   return (
     <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
       <PageHeader
         eyebrow="Public surface"
         title="Klio"
-        subtitle="The AI campus assistant, powered by Claude. BYOK Anthropic key, choose its tools and seed the prompts students see first."
-        actions={<OpenPublicAction href={`/campus/${mapId}/klio`} />}
+        subtitle="The AI campus assistant, powered by Claude. BYOK Anthropic key, choose its tools, shape its tone, and seed the prompts students see first."
+        actions={
+          <>
+            <OpenPublicAction href={`/campus/${mapId}/klio`} />
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!dirty || saving}
+            >
+              {saving ? "Saving…" : "Save changes"}
+            </Button>
+          </>
+        }
       />
 
       <div className="space-y-6">
         <AiKeyPanel mapId={mapId} />
 
+        {/* ─ Tools ─────────────────────────────────────────────── */}
         <Panel className="rounded-2xl p-6">
           <div className="mb-4 flex items-start gap-3">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
               <Wrench size={16} strokeWidth={1.75} aria-hidden />
             </div>
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <h2 className="text-sm font-semibold text-text-primary">
                 Tools Klio can call
               </h2>
               <p className="mt-0.5 text-xs text-text-tertiary">
-                Search news, lookup buildings, give directions, fetch events,
-                list clubs — toggle each on or off.
+                Each tool is exposed to the model only when toggled on.
+                Disabling a tool also drops the related instructions
+                from the system prompt so Claude won&rsquo;t pretend it
+                has them.
               </p>
             </div>
+            <button
+              type="button"
+              onClick={() =>
+                setConfig((c) => ({ ...c, tools: defaultTools() }))
+              }
+              className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-text-tertiary underline-offset-2 hover:text-text-primary hover:underline"
+            >
+              <RotateCcw size={11} strokeWidth={1.75} aria-hidden />
+              Reset
+            </button>
           </div>
-          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
-            All tools on by default. Per-tool toggles land next.
-          </div>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {ASSISTANT_TOOL_NAMES.map((name) => {
+              const meta = TOOL_LABELS[name];
+              const enabled = config.tools[name] !== false;
+              return (
+                <li
+                  key={name}
+                  className="flex items-start gap-3 rounded-xl border border-line-soft bg-surface-2/30 p-3"
+                >
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={enabled}
+                    aria-label={meta.title}
+                    onClick={() => setTool(name, !enabled)}
+                    className={`relative mt-0.5 inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+                      enabled ? "bg-accent" : "bg-surface-2"
+                    }`}
+                  >
+                    <span
+                      aria-hidden
+                      className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform ${
+                        enabled ? "translate-x-4" : "translate-x-1"
+                      }`}
+                    />
+                  </button>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-text-primary">
+                      {meta.title}
+                    </div>
+                    <div className="mt-0.5 text-xs text-text-tertiary">
+                      {meta.hint}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
         </Panel>
 
+        {/* ─ Persona ───────────────────────────────────────────── */}
         <Panel className="rounded-2xl p-6">
           <div className="mb-4 flex items-start gap-3">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
               <Sliders size={16} strokeWidth={1.75} aria-hidden />
             </div>
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <h2 className="text-sm font-semibold text-text-primary">
                 Persona &amp; tone
               </h2>
               <p className="mt-0.5 text-xs text-text-tertiary">
-                Formal ↔ casual, English-first ↔ Greek-first, disclosure copy.
+                Shape how Klio speaks. Defaults sit in the middle of
+                each slider so the assistant works fine even when this
+                screen is untouched.
               </p>
             </div>
+            <button
+              type="button"
+              onClick={() => setPersona(DEFAULT_PERSONA)}
+              className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-text-tertiary underline-offset-2 hover:text-text-primary hover:underline"
+            >
+              <RotateCcw size={11} strokeWidth={1.75} aria-hidden />
+              Reset
+            </button>
           </div>
-          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
-            Sliders + tone copy land alongside the tool toggles.
+          <div className="space-y-5">
+            <PersonaSlider
+              label="Formality"
+              hint="Strict + formal · Relaxed + friendly"
+              leftLabel="Formal"
+              rightLabel="Casual"
+              value={config.persona.formality}
+              onChange={(v) => setPersona({ formality: v })}
+            />
+            <PersonaSlider
+              label="Verbosity"
+              hint="Terse answers · Detailed explanations"
+              leftLabel="Concise"
+              rightLabel="Verbose"
+              value={config.persona.verbosity}
+              onChange={(v) => setPersona({ verbosity: v })}
+            />
+            <Field
+              label="Additional instructions (optional)"
+              hint={`${1000 - config.persona.notes.length} characters left. Appended verbatim to the system prompt.`}
+            >
+              <Textarea
+                value={config.persona.notes}
+                onChange={(e) =>
+                  setPersona({ notes: e.target.value.slice(0, 1000) })
+                }
+                placeholder="Always remind students about open office hours on Wednesdays."
+                rows={3}
+                maxLength={1000}
+              />
+            </Field>
           </div>
         </Panel>
 
+        {/* ─ Suggestion chips ──────────────────────────────────── */}
         <Panel className="rounded-2xl p-6">
           <div className="mb-4 flex items-start gap-3">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
               <MessageSquare size={16} strokeWidth={1.75} aria-hidden />
             </div>
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <h2 className="text-sm font-semibold text-text-primary">
                 Suggestion chips
               </h2>
               <p className="mt-0.5 text-xs text-text-tertiary">
-                EL + EN prompts students see in the empty Klio state.
+                Empty-state prompts on the Klio chat. Leave blank to
+                use the platform&rsquo;s defaults. EN is required; EL
+                falls back to EN on Greek-locale visitors when blank.
+                Max eight chips.
               </p>
             </div>
+            <button
+              type="button"
+              onClick={() => setChips([])}
+              disabled={config.chips.length === 0}
+              className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-text-tertiary underline-offset-2 hover:text-text-primary hover:underline disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RotateCcw size={11} strokeWidth={1.75} aria-hidden />
+              Use defaults
+            </button>
           </div>
-          <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
-            Editable chip list lands next.
-          </div>
+          <ChipsEditor value={config.chips} onChange={setChips} />
         </Panel>
       </div>
     </div>
   );
+}
+
+/* ──────────────────────────────────────────────────────────────── */
+
+function PersonaSlider({
+  label,
+  hint,
+  leftLabel,
+  rightLabel,
+  value,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  leftLabel: string;
+  rightLabel: string;
+  value: number;
+  onChange: (next: number) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <span className="text-xs font-medium uppercase tracking-[0.14em] text-text-tertiary">
+          {label}
+        </span>
+        <span className="text-[11px] text-text-tertiary">{hint}</span>
+      </div>
+      <input
+        type="range"
+        min={1}
+        max={5}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-accent"
+        aria-label={label}
+      />
+      <div className="mt-1 flex justify-between text-[11px] text-text-tertiary">
+        <span>{leftLabel}</span>
+        <span>{rightLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+function ChipsEditor({
+  value,
+  onChange,
+}: {
+  value: KlioChip[];
+  onChange: (next: KlioChip[]) => void;
+}) {
+  const addChip = () => {
+    if (value.length >= 8) return;
+    onChange([
+      ...value,
+      { en: { label: "", prompt: "" } },
+    ]);
+  };
+
+  const update = (idx: number, patch: Partial<KlioChip>) => {
+    const copy = [...value];
+    copy[idx] = { ...copy[idx], ...patch };
+    onChange(copy);
+  };
+
+  const updateLocale = (
+    idx: number,
+    lang: "en" | "el",
+    patch: { label?: string; prompt?: string },
+  ) => {
+    const copy = [...value];
+    const existing = copy[idx][lang] ?? { label: "", prompt: "" };
+    copy[idx] = { ...copy[idx], [lang]: { ...existing, ...patch } };
+    onChange(copy);
+  };
+
+  const remove = (idx: number) => {
+    const copy = [...value];
+    copy.splice(idx, 1);
+    onChange(copy);
+  };
+
+  if (value.length === 0) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+          No custom chips. Platform defaults will show on the chat
+          screen.
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={addChip}
+        >
+          <Plus size={12} strokeWidth={1.75} aria-hidden />
+          Add chip
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-3">
+        {value.map((chip, idx) => (
+          <li
+            key={idx}
+            className="space-y-2 rounded-xl border border-line-soft bg-surface-2/30 p-3"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+                Chip {idx + 1}
+              </span>
+              <button
+                type="button"
+                onClick={() => remove(idx)}
+                aria-label="Remove chip"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-500"
+              >
+                <Trash2 size={12} strokeWidth={1.75} aria-hidden />
+              </button>
+            </div>
+            <ChipLocaleFields
+              lang="en"
+              label="English"
+              labelValue={chip.en.label}
+              promptValue={chip.en.prompt}
+              onChange={(patch) => updateLocale(idx, "en", patch)}
+            />
+            <ChipLocaleFields
+              lang="el"
+              label="Greek (optional)"
+              labelValue={chip.el?.label ?? ""}
+              promptValue={chip.el?.prompt ?? ""}
+              onChange={(patch) => {
+                if (
+                  !patch.label?.trim() &&
+                  !patch.prompt?.trim() &&
+                  (chip.el?.label ?? "").trim().length <= 1 &&
+                  (chip.el?.prompt ?? "").trim().length <= 1
+                ) {
+                  // Drop the EL key entirely when both fields are
+                  // empty after this keystroke — keeps the saved
+                  // shape clean.
+                  const { el: _drop, ...rest } = chip;
+                  void _drop;
+                  update(idx, rest);
+                  return;
+                }
+                updateLocale(idx, "el", patch);
+              }}
+            />
+          </li>
+        ))}
+      </ul>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        onClick={addChip}
+        disabled={value.length >= 8}
+      >
+        <Plus size={12} strokeWidth={1.75} aria-hidden />
+        Add chip
+      </Button>
+    </div>
+  );
+}
+
+function ChipLocaleFields({
+  lang,
+  label,
+  labelValue,
+  promptValue,
+  onChange,
+}: {
+  lang: "en" | "el";
+  label: string;
+  labelValue: string;
+  promptValue: string;
+  onChange: (patch: { label?: string; prompt?: string }) => void;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-[160px_minmax(0,1fr)]">
+      <Field label={`Label · ${label}`}>
+        <Input
+          value={labelValue}
+          onChange={(e) => onChange({ label: e.target.value })}
+          placeholder={lang === "en" ? "Where's the gym?" : "Πού είναι το γυμναστήριο;"}
+          maxLength={60}
+        />
+      </Field>
+      <Field label="Prompt sent to Klio">
+        <Input
+          value={promptValue}
+          onChange={(e) => onChange({ prompt: e.target.value })}
+          placeholder={
+            lang === "en"
+              ? "Where's the gym?"
+              : "Πού είναι το γυμναστήριο και τι ωράριο έχει;"
+          }
+          maxLength={240}
+        />
+      </Field>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────── */
+
+function configsEqual(a: KlioConfig, b: KlioConfig): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/apps/campus/app/(public)/campus/[token]/klio/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/klio/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { getPublicCampusByToken } from "@/lib/public-campus";
 import { detectLocale, pickDefaultLocale } from "@/app/lib/i18n-core";
 import { KlioPanel } from "@/lib/consumer/KlioPanel";
+import { parseKlioConfig } from "@/lib/klio-config";
 import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
 
 type Params = Promise<{ token: string }>;
@@ -55,7 +56,9 @@ export default async function KlioPage({
   const scene = (map.sceneData ?? {}) as {
     branding?: CampusBranding;
     defaultLocale?: unknown;
+    klio?: unknown;
   };
+  const klio = parseKlioConfig(scene.klio);
   const locale = detectLocale(
     typeof sp.lang === "string" ? sp.lang : null,
     pickDefaultLocale(scene.defaultLocale),
@@ -78,6 +81,7 @@ export default async function KlioPage({
         mapId={map.id}
         campusName={campusName}
         locale={locale}
+        chipOverrides={klio.chips}
         mapHref={`/campus/${token}/map${lang}`}
       />
     </main>

--- a/apps/campus/app/api/assistant/route.ts
+++ b/apps/campus/app/api/assistant/route.ts
@@ -5,10 +5,16 @@ import {
   executeTool,
   type AssistantAction,
   type AssistantSpace,
+  type AssistantToolName,
   type ToolContext,
 } from "@/lib/assistant/tools";
 import { checkRateLimit, clientIp } from "@/lib/assistant/rate-limit";
 import { loadAssistantSpacesForProject } from "@/lib/assistant/spaces-loader";
+import {
+  parseKlioConfig,
+  personaPromptFragment,
+  type KlioConfig,
+} from "@/lib/klio-config";
 import { prisma } from "@/lib/prisma";
 import { decryptSecret, secretsEnabled } from "@/lib/secrets";
 
@@ -36,6 +42,27 @@ async function resolveAnthropicKey(
     }
   }
   return process.env.ANTHROPIC_API_KEY ?? undefined;
+}
+
+/**
+ * Read `sceneData.klio` and narrow it to a `KlioConfig`. Errors fall
+ * through to the default config so a flaky DB doesn't kill the chat
+ * — defaults are safe (every tool enabled, neutral persona).
+ */
+async function loadKlioConfig(mapId: string): Promise<KlioConfig> {
+  try {
+    const project = await prisma.project.findUnique({
+      where: { id: mapId },
+      select: { sceneData: true },
+    });
+    const scene = (project?.sceneData ?? null) as
+      | { klio?: unknown }
+      | null;
+    return parseKlioConfig(scene?.klio);
+  } catch (err) {
+    console.error("[assistant] klio config lookup failed", err);
+    return parseKlioConfig(null);
+  }
 }
 
 interface AssistantTurn {
@@ -70,38 +97,115 @@ const MODEL = "claude-haiku-4-5-20251001";
 const MAX_TOOL_ITERATIONS = 5;
 const MAX_TOKENS = 1024;
 
-function systemPrompt(campusName: string, locale: string): string {
-  return [
+function systemPrompt(
+  campusName: string,
+  locale: string,
+  klio: KlioConfig,
+): string {
+  // Build the active-tools list so we can both name them in the
+  // prompt and skip instructions for disabled ones — Claude follows
+  // a shorter prompt more reliably than one that says "do X" then
+  // hides the X tool from the registry.
+  const t = klio.tools;
+  const activeQueryTools = [
+    t.query_news && "news",
+    t.query_events && "events",
+    t.query_clubs && "clubs",
+    t.query_dining && "dining",
+  ].filter(Boolean) as string[];
+
+  const lines: string[] = [
     `You are the friendly assistant for the ${campusName} campus app.`,
     "",
-    "You help students find news, events, clubs, dining, and rooms on campus.",
+    "You help students find " +
+      (activeQueryTools.length > 0
+        ? `${activeQueryTools.join(", ")}, and rooms on campus.`
+        : "rooms on campus."),
     "Be concise — answers fit in 2-3 short sentences whenever possible.",
     "Always prefer tool calls over guessing. If a tool returns nothing,",
     "say so plainly. Cite places, events, and clubs by name.",
     "",
-    "When the user mentions a place (gym, library, room 201), call",
-    "`search_places` first. If the map context is available (spaces > 0),",
-    "you can also call `focus` (to point at a single space) or `route`",
-    "(for 'from X to Y' style questions). Mark a route `accessible: true`",
-    "when the user mentions wheelchair, step-free, accessibility, αναπηρ,",
-    "or προσβάσιμ.",
-    "",
-    "If the user asks about news, events, clubs, or dining, call the",
-    "matching `query_*` tool. Filter by anchor when the user names a",
-    "building. Don't list more than ~5 results unless asked.",
-    "",
-    "**Always cite your sources.** When you mention a specific club,",
-    "event, news post, or dining venue you fetched, call `cite(kind,",
-    "id, name)` so the student gets a tappable card linking to it in",
-    "the app. One `cite` per mention; up to 4 per response. Don't",
-    "cite something you didn't fetch. For spaces, pass the human-",
-    "readable name to `focus` / `route` (`toName`, `fromName`) so the",
-    "directions card reads 'Library' instead of an id.",
+  ];
+
+  if (t.search_places) {
+    lines.push(
+      "When the user mentions a place (gym, library, room 201), call",
+      "`search_places` first.",
+    );
+  }
+  if (t.focus || t.route) {
+    const both = t.focus && t.route;
+    const onlyFocus = t.focus && !t.route;
+    const onlyRoute = !t.focus && t.route;
+    lines.push(
+      `If the map context is available (spaces > 0), you can ${
+        both
+          ? "call `focus` (to point at a single space) or `route` (for 'from X to Y' style questions)"
+          : onlyFocus
+            ? "call `focus` to point at a single space"
+            : onlyRoute
+              ? "call `route` for 'from X to Y' style questions"
+              : ""
+      }.`,
+    );
+    if (t.route) {
+      lines.push(
+        "Mark a route `accessible: true` when the user mentions wheelchair, step-free, accessibility, αναπηρ, or προσβάσιμ.",
+      );
+    }
+    lines.push("");
+  }
+
+  if (activeQueryTools.length > 0) {
+    lines.push(
+      `If the user asks about ${activeQueryTools.join(", ")}, call the`,
+      "matching `query_*` tool. Filter by anchor when the user names a",
+      "building. Don't list more than ~5 results unless asked.",
+      "",
+    );
+  }
+
+  if (t.cite) {
+    lines.push(
+      "**Always cite your sources.** When you mention a specific club,",
+      "event, news post, or dining venue you fetched, call `cite(kind,",
+      "id, name)` so the student gets a tappable card linking to it in",
+      "the app. One `cite` per mention; up to 4 per response. Don't",
+      "cite something you didn't fetch.",
+    );
+  }
+  if (t.focus || t.route) {
+    lines.push(
+      "For spaces, pass the human-readable name to `focus` / `route`",
+      "(`toName`, `fromName`) so the directions card reads 'Library'",
+      "instead of an id.",
+    );
+  }
+
+  lines.push(
     "",
     locale === "el"
       ? "Απαντήστε στα ελληνικά όταν ο χρήστης γράφει στα ελληνικά."
       : "Reply in the language of the user's question.",
-  ].join("\n");
+  );
+
+  const persona = personaPromptFragment(klio.persona);
+  if (persona) {
+    lines.push("", persona);
+  }
+
+  return lines.join("\n");
+}
+
+/** Filter the static tool registry down to whatever the rector has
+ *  left enabled. We never mutate `ASSISTANT_TOOLS` — Anthropic's
+ *  Tool type is shared by reference across requests, and a concurrent
+ *  splice would scramble other tenants. */
+function activeToolsFor(klio: KlioConfig) {
+  return ASSISTANT_TOOLS.filter((tool) => {
+    const name = tool.name as AssistantToolName;
+    return klio.tools[name] !== false;
+  });
 }
 
 /**
@@ -179,6 +283,7 @@ async function runClaude(
   client: Anthropic,
   body: RequestBody,
   ctx: ToolContext,
+  klio: KlioConfig,
 ): Promise<AssistantReply> {
   const messages: Anthropic.Messages.MessageParam[] = [
     ...(body.history ?? []).map((turn) => ({
@@ -188,12 +293,19 @@ async function runClaude(
     { role: "user", content: body.message },
   ];
 
+  const tools = activeToolsFor(klio);
+  const system = systemPrompt(
+    body.campusName ?? "the",
+    body.locale ?? "en",
+    klio,
+  );
+
   for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
     const response = await client.messages.create({
       model: MODEL,
       max_tokens: MAX_TOKENS,
-      system: systemPrompt(body.campusName ?? "the", body.locale ?? "en"),
-      tools: ASSISTANT_TOOLS as unknown as Anthropic.Messages.Tool[],
+      system,
+      tools: tools as unknown as Anthropic.Messages.Tool[],
       messages,
     });
 
@@ -292,8 +404,13 @@ export async function POST(req: Request) {
       : await loadAssistantSpacesForProject(body.mapId);
   // Per-campus BYOK first, platform key second. Each chat turn does
   // one extra Project read by id (cuid lookup, fast); per-tenant key
-  // means usage + cost scope to the right buyer.
-  const apiKey = await resolveAnthropicKey(body.mapId);
+  // means usage + cost scope to the right buyer. We also pull the
+  // Klio config from sceneData so the rector's tool / persona /
+  // notes settings take effect on every turn.
+  const [apiKey, klio] = await Promise.all([
+    resolveAnthropicKey(body.mapId),
+    loadKlioConfig(body.mapId),
+  ]);
 
   // No key → keep the basic regex parser alive. The chat input is
   // still visible everywhere; without a key it only handles the
@@ -310,7 +427,7 @@ export async function POST(req: Request) {
 
   try {
     const client = new Anthropic({ apiKey });
-    const reply = await runClaude(client, body, ctx);
+    const reply = await runClaude(client, body, ctx, klio);
     return NextResponse.json(reply);
   } catch (err) {
     console.error("[/api/assistant] Claude call failed", err);

--- a/apps/campus/lib/assistant/tools.ts
+++ b/apps/campus/lib/assistant/tools.ts
@@ -73,6 +73,23 @@ export interface ToolContext {
  * spaces are available — without spaces, those tools return an
  * empty list / a "not available" note and Claude routes around them.
  */
+/** Names of every tool exposed by the assistant. Kept as a tuple so
+ *  `AssistantToolName` is a strict union and `lib/klio-config.ts`'s
+ *  parse functions can iterate it. Keep this list in sync with
+ *  `ASSISTANT_TOOLS` below. */
+export const ASSISTANT_TOOL_NAMES = [
+  "search_places",
+  "query_news",
+  "query_events",
+  "query_clubs",
+  "query_dining",
+  "focus",
+  "route",
+  "cite",
+] as const;
+
+export type AssistantToolName = (typeof ASSISTANT_TOOL_NAMES)[number];
+
 export const ASSISTANT_TOOLS = [
   {
     name: "search_places",

--- a/apps/campus/lib/consumer/KlioPanel.tsx
+++ b/apps/campus/lib/consumer/KlioPanel.tsx
@@ -19,6 +19,12 @@ export interface KlioPanelProps {
   campusName: string;
   /** UI locale — drives all visible strings + the assistant locale param. */
   locale: "en" | "el";
+  /** Rector-defined suggestion chips. Empty array = use the platform
+   *  defaults. Resolved server-side from `sceneData.klio.chips`. */
+  chipOverrides?: Array<{
+    en: { label: string; prompt: string };
+    el?: { label: string; prompt: string };
+  }>;
   /**
    * Deprecated — `KlioSourceCards` builds map URLs from `mapId` + locale
    * directly. Kept on the props for one release so the existing call
@@ -85,8 +91,23 @@ const COPY = {
  * Empty state mirrors the mockup: hero ("Hi, I'm Klio"), four
  * suggested-prompt pills, a chat thread, an input + send button.
  */
-export function KlioPanel({ mapId, campusName, locale }: KlioPanelProps) {
+export function KlioPanel({
+  mapId,
+  campusName,
+  locale,
+  chipOverrides,
+}: KlioPanelProps) {
   const copy = COPY[locale];
+  // Pick the rector's chips when set; otherwise fall through to the
+  // platform defaults. Locale fallback: EL falls back to EN within a
+  // single chip — same behaviour as `pickLocalized` for news titles.
+  const suggestions: Suggestion[] =
+    chipOverrides && chipOverrides.length > 0
+      ? chipOverrides.map((c) => {
+          const loc = locale === "el" ? c.el ?? c.en : c.en;
+          return { label: loc.label, prompt: loc.prompt };
+        })
+      : copy.suggestions;
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
@@ -166,7 +187,7 @@ export function KlioPanel({ mapId, campusName, locale }: KlioPanelProps) {
           </p>
 
           <ul className="mt-6 space-y-2.5">
-            {copy.suggestions.map((s) => (
+            {suggestions.map((s) => (
               <li key={s.label}>
                 <button
                   type="button"

--- a/apps/campus/lib/klio-config.ts
+++ b/apps/campus/lib/klio-config.ts
@@ -1,0 +1,177 @@
+/**
+ * Per-campus Klio (AI assistant) configuration.
+ *
+ * Persisted under `Project.sceneData.klio`. Everything optional —
+ * the assistant ships with sane defaults and the rector only fills
+ * in what they want to override. Lives outside the assistant route
+ * itself so the public chat (`KlioPanel`) and the admin authoring
+ * screen (`/klio`) share the same parse + defaults code.
+ *
+ * Pure + isomorphic — no Prisma, no React. Safe to import from
+ * server routes, client components, and `server-only` modules.
+ */
+
+import { ASSISTANT_TOOL_NAMES, type AssistantToolName } from "@/lib/assistant/tools";
+
+/** Persona dimensions, both 1..5 scales. */
+export interface KlioPersona {
+  /** 1 = strict + formal · 5 = relaxed + casual. */
+  formality: number;
+  /** 1 = terse, 1-sentence answers · 5 = verbose, walk-through replies. */
+  verbosity: number;
+  /** Free-text additional instructions appended to the system prompt
+   *  — e.g. "Always remind students about open office hours." */
+  notes: string;
+}
+
+/** One suggestion chip — the empty-state "starter prompts" on Klio
+ *  chat. Stored bilingual; the public surface picks the right
+ *  language at render time and falls back to EN if EL is missing. */
+export interface KlioChip {
+  en: { label: string; prompt: string };
+  el?: { label: string; prompt: string };
+}
+
+export interface KlioConfig {
+  /** Per-tool kill switches. `false` disables; anything else means
+   *  on. Stored as a sparse map so adding a new tool defaults to on. */
+  tools: Record<AssistantToolName, boolean>;
+  persona: KlioPersona;
+  /** Empty array = use the built-in `DEFAULT_CHIPS` defined in the
+   *  KlioPanel; non-empty overrides them. The split exists so a
+   *  rector who deletes all chips still sees the platform defaults
+   *  instead of an empty grid, which would make the chat look
+   *  broken on first visit. */
+  chips: KlioChip[];
+}
+
+export const DEFAULT_PERSONA: KlioPersona = {
+  formality: 3,
+  verbosity: 2,
+  notes: "",
+};
+
+/** Returns a `tools` map with every known tool enabled. Source of
+ *  truth for the admin UI's reset button and the parser's fallback
+ *  when a row has never been saved. */
+export function defaultTools(): Record<AssistantToolName, boolean> {
+  const out = {} as Record<AssistantToolName, boolean>;
+  for (const name of ASSISTANT_TOOL_NAMES) {
+    out[name] = true;
+  }
+  return out;
+}
+
+export const DEFAULT_KLIO_CONFIG: KlioConfig = {
+  tools: defaultTools(),
+  persona: DEFAULT_PERSONA,
+  chips: [],
+};
+
+const FORMALITY_CLAMP = clampRange(1, 5);
+const VERBOSITY_CLAMP = clampRange(1, 5);
+
+/** Validate + narrow whatever the JSON column hands us into a
+ *  `KlioConfig`. Anything malformed is silently filled with the
+ *  default; the assistant should keep answering even if a rector
+ *  pasted nonsense into the DB through Prisma Studio. */
+export function parseKlioConfig(value: unknown): KlioConfig {
+  if (!value || typeof value !== "object") return DEFAULT_KLIO_CONFIG;
+  const raw = value as Record<string, unknown>;
+  return {
+    tools: parseTools(raw.tools),
+    persona: parsePersona(raw.persona),
+    chips: parseChips(raw.chips),
+  };
+}
+
+function parseTools(value: unknown): Record<AssistantToolName, boolean> {
+  const out = defaultTools();
+  if (!value || typeof value !== "object") return out;
+  const raw = value as Record<string, unknown>;
+  for (const name of ASSISTANT_TOOL_NAMES) {
+    if (raw[name] === false) out[name] = false;
+  }
+  return out;
+}
+
+function parsePersona(value: unknown): KlioPersona {
+  if (!value || typeof value !== "object") return DEFAULT_PERSONA;
+  const raw = value as Record<string, unknown>;
+  return {
+    formality:
+      typeof raw.formality === "number"
+        ? FORMALITY_CLAMP(raw.formality)
+        : DEFAULT_PERSONA.formality,
+    verbosity:
+      typeof raw.verbosity === "number"
+        ? VERBOSITY_CLAMP(raw.verbosity)
+        : DEFAULT_PERSONA.verbosity,
+    notes:
+      typeof raw.notes === "string" ? raw.notes.slice(0, 1000) : "",
+  };
+}
+
+function parseChips(value: unknown): KlioChip[] {
+  if (!Array.isArray(value)) return [];
+  const out: KlioChip[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const en = parseChipLocale(e.en);
+    if (!en) continue;
+    const el = parseChipLocale(e.el);
+    out.push(el ? { en, el } : { en });
+  }
+  return out.slice(0, 8);
+}
+
+function parseChipLocale(
+  value: unknown,
+): { label: string; prompt: string } | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const label = typeof raw.label === "string" ? raw.label.trim() : "";
+  const prompt = typeof raw.prompt === "string" ? raw.prompt.trim() : "";
+  if (!label || !prompt) return null;
+  return { label: label.slice(0, 60), prompt: prompt.slice(0, 240) };
+}
+
+function clampRange(min: number, max: number) {
+  return (n: number) => {
+    if (!Number.isFinite(n)) return Math.round((min + max) / 2);
+    return Math.min(max, Math.max(min, Math.round(n)));
+  };
+}
+
+/**
+ * Persona dimensions translated into a system-prompt fragment. The
+ * fragment is appended (no token-budget reason to drop it) to the
+ * base prompt — Claude is happy folding behavioural tweaks in even
+ * when they're terse.
+ */
+export function personaPromptFragment(persona: KlioPersona): string {
+  const lines: string[] = [];
+  if (persona.formality <= 2) {
+    lines.push(
+      "Use a formal, advisory tone — the way a department secretary writes.",
+    );
+  } else if (persona.formality >= 4) {
+    lines.push(
+      "Use a relaxed, friendly tone — the way a senior student would.",
+    );
+  }
+  if (persona.verbosity <= 2) {
+    lines.push(
+      "Be very concise. One sentence is usually enough; never more than two.",
+    );
+  } else if (persona.verbosity >= 4) {
+    lines.push(
+      "It's fine to explain. Walk through the answer in 3-4 sentences, add helpful context.",
+    );
+  }
+  if (persona.notes.trim()) {
+    lines.push(`Additional campus instructions: ${persona.notes.trim()}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
Fills the three placeholder panels on `/klio` with real editors and threads the saved config through to both the assistant route and the public chat. No schema migration — everything lives under a new `sceneData.klio` namespace, parsed + defaulted in one place.

## What's in
- **`lib/klio-config.ts`** — pure parsers + defaults for `tools`, `persona`, `chips`. A stale row from before this PR still yields a working assistant because every slot has a default.
- **`lib/assistant/tools.ts`** — exports `ASSISTANT_TOOL_NAMES` as a tuple so the parser and the UI iterate the canonical list without drift.
- **`/api/assistant/route.ts`** — loads klio config in parallel with the API key, filters the static `ASSISTANT_TOOLS` array to the enabled subset, and conditionally generates each section of the system prompt based on the toggles (disabling a tool also drops its instructions, so Claude won't pretend it has them). Persona dimensions append a short "use this tone" fragment.
- **`KlioPanel`** — new optional `chipOverrides` prop with EL→EN per-chip fallback. Falls back to platform defaults when the array is empty.
- **`CampusKlioPageClient`** — completely rewritten. AiKeyPanel stays on top, then three real editors:
  1. **Tools**: 8 switches, per-tool hint copy, Reset button.
  2. **Persona**: 1-5 sliders for formality + verbosity, free-text notes capped at 1000 chars.
  3. **Chips**: row-per-chip editor (EN required, EL optional), up to 8 chips. Empty list explicitly returns to platform defaults.
  Save merges `sceneData.klio` and PATCHes the existing `/api/maps/[mapId]` route.
- **Public `/klio` page** reads `sceneData.klio` server-side and passes `chips` to `KlioPanel` as `chipOverrides`. No new client fetch.

## Bundle cost
- `/org/.../klio` 8 kB → was 0 kB (was placeholders).
- `/campus/.../klio` unchanged at 5 kB.

## Test plan
- [ ] `pnpm build` clean (verified).
- [ ] Open `/klio` admin: form hydrates from `sceneData.klio` if present, else from defaults.
- [ ] Disable `query_dining` → save → ask Klio "what's for lunch?" → assistant says it can't read dining instead of hallucinating.
- [ ] Slide formality to 5 + verbosity to 5 → save → ask any question → reply uses casual, multi-sentence tone.
- [ ] Add a custom chip with EN only → save → visit public `/klio` in both EN and EL → chip shows EN label in both locales.
- [ ] Add chip with both EN + EL → save → visit `/klio?lang=el` → EL label renders.
- [ ] Remove all chips with "Use defaults" → public `/klio` shows the platform's four defaults again.
- [ ] `sceneData.klio` not set (fresh campus) → `/klio` admin shows defaults, public chat works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)