### PR TITLE
feat(campus): per-campus role overrides

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -132,8 +132,8 @@ Campus authors **don't** edit a 3D scene in the Klorad app any more — MappedIn
 |---|---|---|---|
 | 1 | List members, change role, remove | ✅ | `/org/[orgId]/settings/members` |
 | 2 | Send invite email | ✅ (env-gated) | Sends via Resend when configured, otherwise hands the owner the link (see A1.4) |
-| 3 | See "who can edit this campus" from the campus IA | ✅ | Campus-tier `/members` screen — read-only roll, separates editors from viewers, deep-link to the org-tier screen for management |
-| 4 | Per-campus role overrides (some campuses for some members) | ❌ | Role is still org-wide today; the campus-tier screen acknowledges this |
+| 3 | See "who can edit this campus" from the campus IA | ✅ | Campus-tier `/members` screen groups by effective role on this campus, not by org role |
+| 4 | Per-campus role overrides (promote, demote, or block one member for one campus) | ✅ | `ProjectMember` row supersedes `OrganizationMember.role` for that campus. NULL role = explicit block. Owners are immune to overrides. The campus-tier `/members` screen edits these inline |
 
 ### A13. Organisation tier
 
@@ -251,7 +251,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 ### Post-MVP, useful
 | S | U | Item | Pointer |
 |---|---|---|---|
-| M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 — read-only view shipped; per-campus *overrides* are the bigger arc still queued |
+| M | Med | Campus-tier "Members" screen (per-campus access) | A12.3 — shipped (with overrides) |
 | M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 — shipped |
 | S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up — shipped |
 | M | Med | "Open now" structured hours for dining | A7.6 — shipped |

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/members/CampusMembersPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/members/CampusMembersPageClient.tsx
@@ -1,9 +1,19 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import useSWR from "swr";
-import { ArrowRight, Crown, Eye, Pencil, Users } from "lucide-react";
-import { Panel } from "@klorad/design-system";
+import useSWR, { mutate as globalMutate } from "swr";
+import { toast } from "react-toastify";
+import {
+  ArrowRight,
+  Ban,
+  Crown,
+  Eye,
+  Pencil,
+  RotateCcw,
+  Users,
+} from "lucide-react";
+import { Panel, Select } from "@klorad/design-system";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
 
 interface Props {
@@ -12,11 +22,15 @@ interface Props {
 }
 
 type Role = "owner" | "admin" | "member" | "publicViewer";
+type Override = Role | "blocked" | null;
+type EffectiveRole = Role | "blocked";
 
 interface Member {
   id: string;
   userId: string;
   role: Role;
+  override: Override;
+  effectiveRole: EffectiveRole;
   user: {
     id: string;
     name?: string | null;
@@ -33,43 +47,87 @@ const fetcher = (url: string): Promise<MembersResponse> =>
   fetch(url).then((r) => r.json());
 
 /**
- * Campus-tier Members — read-only roll of everyone in the
- * organisation who can edit this campus. Per-campus role overrides
- * are deferred (see USER-PATH §A12.3); today everyone with the right
- * org role automatically gets access to every campus, so this view
- * mirrors the org-tier list.
+ * Campus-tier Members — every org member shown alongside their
+ * **effective** role on this campus. The role picker lets owners +
+ * admins override the org-level role for this specific campus, or
+ * block someone entirely.
  *
- * We keep the screen because the IA is clearer with it than without:
- * a rector standing on a campus dashboard shouldn't have to know
- * that "members" live one level up. The "Manage members" CTA hands
- * them off to the org-tier screen where the actual mutations happen.
+ * The IA layering:
+ *   - Org members are added / removed at `/org/<orgId>/settings/members`
+ *     (still the place for invites).
+ *   - Per-campus role overrides live here. They supersede the org
+ *     role for this campus only.
  *
- * Filtered to roles that can read or write — `publicViewer` accounts
- * (auth-required-but-read-only campuses, USER-PATH §A13.2) are
- * counted separately so the list stays focused on the working team.
+ * Owners are immune to overrides — the picker is read-only on the
+ * owner row.
  */
 export default function CampusMembersPageClient({ orgId, mapId }: Props) {
   const { data, isLoading } = useSWR<MembersResponse>(
-    `/api/organizations/${orgId}/members`,
+    `/api/maps/${mapId}/members`,
     fetcher,
   );
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
 
   const all = data?.members ?? [];
-  const editors = all.filter((m) => m.role !== "publicViewer");
-  const viewers = all.filter((m) => m.role === "publicViewer");
+  // Group by effective role so the screen reads as "who can do what
+  // on this campus" rather than "who is what at the org tier".
+  const active = all.filter((m) => m.effectiveRole !== "publicViewer" && m.effectiveRole !== "blocked");
+  const viewers = all.filter((m) => m.effectiveRole === "publicViewer");
+  const blocked = all.filter((m) => m.effectiveRole === "blocked");
+
+  const applyOverride = async (member: Member, next: Override) => {
+    if (busyUserId) return;
+    setBusyUserId(member.userId);
+    try {
+      if (next === null) {
+        // "Inherit from organisation" → clear the override row.
+        const res = await fetch(
+          `/api/maps/${mapId}/members/${member.userId}`,
+          { method: "DELETE" },
+        );
+        if (!res.ok) throw new Error("Failed");
+        toast.success("Reverted to organisation role");
+      } else {
+        const body =
+          next === "blocked" ? { role: null } : { role: next };
+        const res = await fetch(
+          `/api/maps/${mapId}/members/${member.userId}`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          },
+        );
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error ?? "Failed");
+        }
+        toast.success(
+          next === "blocked"
+            ? "Blocked from this campus"
+            : "Override saved",
+        );
+      }
+      await globalMutate(`/api/maps/${mapId}/members`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't update");
+    } finally {
+      setBusyUserId(null);
+    }
+  };
 
   return (
     <div className="mx-auto w-full max-w-[920px] px-6 py-8 md:px-10">
       <PageHeader
         eyebrow="Manage"
         title="Members"
-        subtitle="Who can edit or view this campus. Manage roles and invites from the organisation settings."
+        subtitle="Who can edit or view this campus. Overrides on this screen apply only to this campus; the org-tier role is the fallback."
         actions={
           <Link
             href={`/org/${orgId}/settings/members`}
             className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
           >
-            Manage members
+            Invite to organisation
             <ArrowRight size={14} strokeWidth={1.75} aria-hidden />
           </Link>
         }
@@ -82,12 +140,19 @@ export default function CampusMembersPageClient({ orgId, mapId }: Props) {
           </div>
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-text-primary">
-              Roles are organisation-wide
+              How overrides work
             </h2>
             <p className="mt-0.5 text-xs text-text-tertiary">
-              Anyone with an editor role on the organisation can author
-              every campus inside it. Per-campus role overrides are on
-              the roadmap.
+              The role you pick here applies only to this campus. Pick{" "}
+              <span className="font-medium text-text-primary">
+                Inherit
+              </span>{" "}
+              to fall back to the organisation role, or{" "}
+              <span className="font-medium text-text-primary">
+                Block
+              </span>{" "}
+              to lock the member out of this campus entirely. Owners
+              always retain access.
             </p>
           </div>
         </div>
@@ -96,10 +161,10 @@ export default function CampusMembersPageClient({ orgId, mapId }: Props) {
       <Panel className="rounded-2xl p-6">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-sm font-semibold text-text-primary">
-            Editors
+            Active on this campus
           </h2>
           <span className="text-xs text-text-tertiary">
-            {editors.length} {editors.length === 1 ? "person" : "people"}
+            {active.length} {active.length === 1 ? "person" : "people"}
           </span>
         </div>
 
@@ -112,12 +177,17 @@ export default function CampusMembersPageClient({ orgId, mapId }: Props) {
               />
             ))}
           </ul>
-        ) : editors.length === 0 ? (
+        ) : active.length === 0 ? (
           <EmptyState />
         ) : (
-          <ul className="space-y-1.5">
-            {editors.map((m) => (
-              <MemberRow key={m.id} member={m} />
+          <ul className="space-y-2">
+            {active.map((m) => (
+              <MemberRow
+                key={m.id}
+                member={m}
+                busy={busyUserId === m.userId}
+                onApply={(next) => void applyOverride(m, next)}
+              />
             ))}
           </ul>
         )}
@@ -134,24 +204,55 @@ export default function CampusMembersPageClient({ orgId, mapId }: Props) {
               {viewers.length === 1 ? "person" : "people"}
             </span>
           </div>
-          <ul className="space-y-1.5">
+          <ul className="space-y-2">
             {viewers.map((m) => (
-              <MemberRow key={m.id} member={m} />
+              <MemberRow
+                key={m.id}
+                member={m}
+                busy={busyUserId === m.userId}
+                onApply={(next) => void applyOverride(m, next)}
+              />
             ))}
           </ul>
         </Panel>
       ) : null}
 
-      {/* mapId is referenced so the file's "scoped to this campus"
-          contract is type-checked even though the screen currently
-          fetches org-level data; per-campus member assignment is the
-          follow-up that uses it. */}
-      <div className="hidden" data-map-id={mapId} />
+      {blocked.length > 0 ? (
+        <Panel className="mt-6 rounded-2xl p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-text-primary">
+              Blocked from this campus
+            </h2>
+            <span className="text-xs text-text-tertiary">
+              {blocked.length}{" "}
+              {blocked.length === 1 ? "person" : "people"}
+            </span>
+          </div>
+          <ul className="space-y-2">
+            {blocked.map((m) => (
+              <MemberRow
+                key={m.id}
+                member={m}
+                busy={busyUserId === m.userId}
+                onApply={(next) => void applyOverride(m, next)}
+              />
+            ))}
+          </ul>
+        </Panel>
+      ) : null}
     </div>
   );
 }
 
-function MemberRow({ member }: { member: Member }) {
+function MemberRow({
+  member,
+  busy,
+  onApply,
+}: {
+  member: Member;
+  busy: boolean;
+  onApply: (next: Override) => void;
+}) {
   const name =
     member.user.name?.trim() ||
     member.user.email?.split("@")[0] ||
@@ -162,8 +263,20 @@ function MemberRow({ member }: { member: Member }) {
     .map((s) => s[0]?.toUpperCase() ?? "")
     .join("");
 
+  const isOwner = member.role === "owner";
+  // The picker's value: "inherit" when no override, the role name
+  // otherwise, "blocked" for the null-role row.
+  const pickerValue: "inherit" | Role | "blocked" =
+    member.override === null ? "inherit" : member.override;
+
+  const handleChange = (value: string) => {
+    if (value === "inherit") onApply(null);
+    else if (value === "blocked") onApply("blocked");
+    else onApply(value as Role);
+  };
+
   return (
-    <li className="flex items-center gap-3 rounded-xl border border-line-soft bg-surface-2/30 p-3">
+    <li className="flex flex-wrap items-center gap-3 rounded-xl border border-line-soft bg-surface-2/30 p-3">
       <span
         aria-hidden
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-soft text-xs font-semibold text-accent"
@@ -187,13 +300,56 @@ function MemberRow({ member }: { member: Member }) {
           {member.user.email}
         </p>
       </div>
-      <RoleBadge role={member.role} />
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        <EffectiveBadge effective={member.effectiveRole} />
+        {isOwner ? (
+          <span className="text-[11px] text-text-tertiary">
+            Owner — always full access
+          </span>
+        ) : (
+          <>
+            <Select
+              value={pickerValue}
+              disabled={busy}
+              onChange={(e) => handleChange(e.target.value)}
+              className="w-[170px]"
+            >
+              <option value="inherit">
+                Inherit ({readableRole(member.role)})
+              </option>
+              <option value="admin">Override → Admin</option>
+              <option value="member">Override → Editor</option>
+              <option value="publicViewer">Override → Viewer</option>
+              <option value="blocked">Block</option>
+            </Select>
+            {member.override !== null ? (
+              <button
+                type="button"
+                onClick={() => onApply(null)}
+                disabled={busy}
+                aria-label="Revert to organisation role"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-text-primary disabled:opacity-40"
+              >
+                <RotateCcw size={14} strokeWidth={1.75} aria-hidden />
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
     </li>
   );
 }
 
-function RoleBadge({ role }: { role: Role }) {
-  const meta = ROLE_META[role];
+function EffectiveBadge({ effective }: { effective: EffectiveRole }) {
+  if (effective === "blocked") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-red-500/10 px-2.5 py-1 text-[11px] font-medium text-red-700 dark:text-red-300">
+        <Ban size={11} strokeWidth={1.75} aria-hidden />
+        Blocked
+      </span>
+    );
+  }
+  const meta = ROLE_META[effective];
   const Icon = meta.icon;
   return (
     <span
@@ -231,11 +387,15 @@ const ROLE_META: Record<
   },
 };
 
+function readableRole(role: Role): string {
+  return ROLE_META[role].label;
+}
+
 function EmptyState() {
   return (
     <div className="flex flex-col items-center gap-2 py-10 text-center">
       <p className="text-sm font-medium text-text-primary">
-        No editors yet
+        No active members
       </p>
       <p className="max-w-xs text-xs text-text-tertiary">
         Invite teammates from the organisation settings — they&rsquo;ll

--- a/apps/campus/app/api/maps/[mapId]/members/[userId]/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/members/[userId]/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+import type { OrganizationRole } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+
+type Params = Promise<{ mapId: string; userId: string }>;
+
+/** Roles the override accepts as the `role` field, in addition to
+ *  `null` (block). The whitelist matches the OrganizationRole enum
+ *  exactly so a typo in the request body doesn't silently elevate. */
+const ALLOWED_ROLES: OrganizationRole[] = [
+  "owner",
+  "admin",
+  "member",
+  "publicViewer",
+];
+
+/**
+ * `PUT /api/maps/[mapId]/members/[userId]` — upsert a per-campus
+ * override. Body:
+ *   `{ role: "owner" | "admin" | "member" | "publicViewer" | null }`
+ *
+ * `role: null` is the explicit block — the user keeps their org
+ * membership but can't reach this campus. Owners are exempt; an
+ * override on the org owner is rejected with 400 because the authz
+ * helper ignores it anyway and we'd rather not store a confusing
+ * row.
+ *
+ * Manage-gated: only org owners + admins can mutate overrides.
+ */
+export async function PUT(req: Request, { params }: { params: Params }) {
+  const { mapId, userId } = await params;
+  const denied = await requireCampusAccess(mapId, "manage");
+  if (denied) return denied;
+
+  let body: { role?: unknown } = {};
+  try {
+    body = (await req.json()) as { role?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const role = body.role;
+  if (
+    role !== null &&
+    (typeof role !== "string" ||
+      !ALLOWED_ROLES.includes(role as OrganizationRole))
+  ) {
+    return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+  }
+
+  // Block targeting the org owner — overrides on owners would be
+  // confusingly inert (the authz helper short-circuits before
+  // looking at overrides for owners). Reject loudly instead.
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+  const orgMember = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: project.organizationId,
+        userId,
+      },
+    },
+  });
+  if (!orgMember) {
+    return NextResponse.json(
+      { error: "Target user is not an organization member" },
+      { status: 404 },
+    );
+  }
+  if (orgMember.role === "owner") {
+    return NextResponse.json(
+      { error: "Owners can't have per-campus overrides" },
+      { status: 400 },
+    );
+  }
+
+  await prisma.projectMember.upsert({
+    where: { projectId_userId: { projectId: mapId, userId } },
+    create: {
+      projectId: mapId,
+      userId,
+      role: role as OrganizationRole | null,
+    },
+    update: { role: role as OrganizationRole | null },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+/**
+ * `DELETE /api/maps/[mapId]/members/[userId]` — drop the override.
+ * The user reverts to their org-level role for this campus.
+ * Manage-gated.
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+) {
+  const { mapId, userId } = await params;
+  const denied = await requireCampusAccess(mapId, "manage");
+  if (denied) return denied;
+
+  await prisma.projectMember
+    .delete({
+      where: { projectId_userId: { projectId: mapId, userId } },
+    })
+    .catch(() => undefined);
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/app/api/maps/[mapId]/members/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/members/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+
+type Params = Promise<{ mapId: string }>;
+
+/**
+ * `GET /api/maps/[mapId]/members` — campus-tier members list.
+ *
+ * Returns every org member alongside their *effective* role on this
+ * campus: the org-level role unless a `ProjectMember` override is
+ * set. Owners are always shown as owners regardless of any
+ * override row (blocks are ignored for owners).
+ *
+ * The shape mirrors what the campus-tier `/members` screen needs:
+ *
+ *   {
+ *     members: [{
+ *       id, userId, role,            // raw org membership row
+ *       override: "owner" | "admin" | "member" | "publicViewer" | "blocked" | null,
+ *       effectiveRole: OrganizationRole | "blocked",
+ *       user: { id, name, email, image }
+ *     }]
+ *   }
+ *
+ * Read-gated. We surface this rather than the org-tier list because
+ * the campus screen is allowed to be seen by every org member, but
+ * only owners + admins can mutate overrides — see PUT/DELETE below.
+ */
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ members: [] }, { status: 404 });
+  }
+
+  const [orgMembers, overrides] = await Promise.all([
+    prisma.organizationMember.findMany({
+      where: { organizationId: project.organizationId },
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, image: true },
+        },
+      },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+    }),
+    prisma.projectMember.findMany({
+      where: { projectId: mapId },
+      select: { userId: true, role: true },
+    }),
+  ]);
+
+  const overrideByUser = new Map(
+    overrides.map((o) => [o.userId, o.role] as const),
+  );
+
+  const members = orgMembers.map((m) => {
+    const hasOverride = overrideByUser.has(m.userId);
+    const overrideRole = overrideByUser.get(m.userId) ?? null;
+    // Owners ignore blocks; nothing else changes for them.
+    const isOwner = m.role === "owner";
+    const override = !hasOverride
+      ? null
+      : overrideRole === null
+        ? ("blocked" as const)
+        : overrideRole;
+    const effectiveRole =
+      isOwner || !hasOverride
+        ? m.role
+        : overrideRole === null
+          ? ("blocked" as const)
+          : overrideRole;
+    return {
+      id: m.id,
+      userId: m.userId,
+      role: m.role,
+      override,
+      effectiveRole,
+      user: m.user,
+    };
+  });
+
+  return NextResponse.json({ members });
+}

--- a/apps/campus/lib/authz.ts
+++ b/apps/campus/lib/authz.ts
@@ -6,13 +6,26 @@ import { prisma } from "@/lib/prisma";
 /**
  * Campus authorization.
  *
- * Access is derived from `OrganizationMember.role`:
+ * Access is layered: per-campus override (when present) wins over
+ * org-level role. The override model lives on `ProjectMember`:
+ *   - row with `role` = some role → use that role instead of the
+ *     user's org role for this campus
+ *   - row with `role` = NULL → explicit block (denied even if the
+ *     org role would otherwise allow access)
+ *   - no row → fall through to `OrganizationMember.role`
+ *
+ * Owners are exempt from per-campus blocks — they own the org and
+ * by extension every campus inside it. The campus-tier Members UI
+ * disables the override controls for owners to make this explicit.
+ *
+ * Role tiers:
  *   - read   — any member of the organization
  *   - write  — owner / admin / member (editors); not `publicViewer`
  *   - manage — owner / admin only (destructive / org-level actions)
  *
- * The `require*` helpers return a `NextResponse` to send back when the
- * caller is denied, or `null` when access is granted. Usage in a route:
+ * The `require*` helpers return a `NextResponse` to send back when
+ * the caller is denied, or `null` when access is granted. Usage in
+ * a route:
  *
  *   const denied = await requireCampusAccess(mapId, "write");
  *   if (denied) return denied;
@@ -29,8 +42,8 @@ function roleAllows(role: OrganizationRole, mode: AccessMode): boolean {
 }
 
 /**
- * Require the caller to be a member of `orgId` with rights for `mode`.
- * Returns the denial response, or `null` if allowed.
+ * Require the caller to be a member of `orgId` with rights for
+ * `mode`. Returns the denial response, or `null` if allowed.
  */
 export async function requireOrgAccess(
   orgId: string,
@@ -61,13 +74,33 @@ export async function requireOrgAccess(
 }
 
 /**
- * Require `mode` rights on the campus's organization. Resolves the
- * campus → its organization, then defers to {@link requireOrgAccess}.
+ * Require `mode` rights on a campus. Resolves to the campus's org,
+ * checks the caller is a member, then layers any
+ * `ProjectMember` override on top:
+ *
+ *   override role  | org role  | effective
+ *   -------------- | --------- | -----------------------------
+ *   (no row)       | owner     | owner
+ *   (no row)       | member    | member
+ *   admin          | member    | admin (override promotes)
+ *   member         | admin     | member (override demotes)
+ *   NULL (block)   | member    | blocked
+ *   NULL (block)   | owner     | owner (owners bypass blocks)
  */
 export async function requireCampusAccess(
   mapId: string,
   mode: AccessMode,
 ): Promise<NextResponse | null> {
+  const session = await auth();
+  const userId = session?.user?.id as string | undefined;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // One round-trip for the project + org membership + override.
+  // Override is keyed by (projectId, userId); orgMember by
+  // (organizationId, userId). We don't have either id yet, so the
+  // project read comes first, then a parallel read of the other two.
   const project = await prisma.project.findUnique({
     where: { id: mapId },
     select: { organizationId: true },
@@ -75,5 +108,59 @@ export async function requireCampusAccess(
   if (!project) {
     return NextResponse.json({ error: "Campus not found" }, { status: 404 });
   }
-  return requireOrgAccess(project.organizationId, mode);
+
+  const [orgMember, override] = await Promise.all([
+    prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: project.organizationId,
+          userId,
+        },
+      },
+    }),
+    prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId: mapId, userId } },
+    }),
+  ]);
+
+  if (!orgMember) {
+    return NextResponse.json(
+      { error: "You are not a member of this organization" },
+      { status: 403 },
+    );
+  }
+
+  // Owners are immune to per-campus blocks — they own the org and
+  // can always reach into every campus.
+  if (orgMember.role === "owner") {
+    return roleAllows("owner", mode)
+      ? null
+      : NextResponse.json(
+          { error: "You don't have permission to do that" },
+          { status: 403 },
+        );
+  }
+
+  if (override) {
+    if (override.role === null) {
+      // Explicit block.
+      return NextResponse.json(
+        { error: "You don't have access to this campus" },
+        { status: 403 },
+      );
+    }
+    return roleAllows(override.role, mode)
+      ? null
+      : NextResponse.json(
+          { error: "You don't have permission to do that" },
+          { status: 403 },
+        );
+  }
+
+  return roleAllows(orgMember.role, mode)
+    ? null
+    : NextResponse.json(
+        { error: "You don't have permission to do that" },
+        { status: 403 },
+      );
 }

--- a/packages/prisma/migrations/20260603150000_add_project_member/migration.sql
+++ b/packages/prisma/migrations/20260603150000_add_project_member/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "ProjectMember" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "OrganizationRole",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProjectMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectMember_projectId_userId_key" ON "ProjectMember"("projectId", "userId");
+
+-- CreateIndex
+CREATE INDEX "ProjectMember_userId_idx" ON "ProjectMember"("userId");
+
+-- AddForeignKey
+ALTER TABLE "ProjectMember" ADD CONSTRAINT "ProjectMember_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectMember" ADD CONSTRAINT "ProjectMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -56,6 +56,7 @@ model User {
   organizationInvitesSent OrganizationInvite[] @relation("InvitesSent") // Invitations sent by this user
   activities              Activity[] // Activities performed by this user (as actor)
   broadcastsSent          Broadcast[]          @relation("BroadcastsSent") // Push broadcasts triggered by this user
+  projectRoleOverrides    ProjectMember[] // Per-project role overrides (per-campus access scoping)
 }
 
 model VerificationToken {
@@ -185,6 +186,9 @@ model Project {
   pushSubscriptions PushSubscription[]
   // Per-campus push broadcast history — see lib/broadcasts.ts.
   broadcasts        Broadcast[]
+  // Per-campus role overrides — when set, supersede the user's
+  // organization role for this specific campus. See lib/authz.ts.
+  memberOverrides   ProjectMember[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -597,6 +601,30 @@ model DiningLocation {
 }
 
 /// Anonymous web-push subscription. No PII — just the endpoint URL +
+/// Per-campus role override for an organization member. When present,
+/// supersedes the user's `OrganizationMember.role` for this specific
+/// project. `role` is nullable on purpose: NULL means "explicitly
+/// blocked from this campus" — the only way to keep an org-level
+/// editor out of one campus without removing them from the org
+/// entirely. Owners always retain access; the authz helper short-
+/// circuits before consulting overrides for them.
+model ProjectMember {
+  id        String            @id @default(cuid())
+  projectId String
+  userId    String
+  /// NULL = explicit block. Otherwise overrides `OrganizationMember.role`
+  /// for this campus.
+  role      OrganizationRole?
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, userId])
+  @@index([userId])
+}
+
 /// One row per push broadcast the rector sends from the Reach screen.
 /// Stores enough context to render the history feed (title/body/target
 /// + counts) without keeping the literal device endpoint list around.


### PR DESCRIPTION
## Summary
Closes the gap the campus-tier `/members` screen has been honest about since #199: **"Maria is an editor on the Thermi campus but blocked from Kavala"** is finally expressible. A new `ProjectMember` row supersedes the user's `OrganizationMember.role` for one campus at a time.

## Schema
`ProjectMember { id, projectId, userId, role: nullable OrganizationRole, createdAt, updatedAt }`. Unique on `(projectId, userId)`, indexed on `userId`.

`role` is nullable on purpose: `NULL` = **explicit block** — the only way to keep an org-level editor out of one campus without removing them from the org entirely.

Migration `20260603150000_add_project_member` adds the table additively; no backfill.

## Authz semantics (truth table)
| Override row | Org role | Effective |
|---|---|---|
| (no row) | owner | owner |
| (no row) | member | member |
| admin | member | admin (promote) |
| member | admin | member (demote) |
| NULL (block) | member | blocked |
| NULL (block) | owner | owner (owners bypass blocks) |

Owners always retain access. The campus-tier UI marks the picker disabled on owner rows.

## What's in
- **`lib/authz.ts → requireCampusAccess`** rewritten as a three-layer resolver: project → org-membership → optional override. Owners short-circuit before the override check.
- **`GET /api/maps/[mapId]/members`** — returns every org member with their `override` + `effectiveRole` computed server-side, so the client never recomputes the precedence rules.
- **`PUT /api/maps/[mapId]/members/[userId]`** — upsert the override. `{ role: null }` blocks; any `OrganizationRole` overrides. Rejects overrides targeting the org owner with 400.
- **`DELETE /api/maps/[mapId]/members/[userId]`** — drop the override, revert to org role.
- Both writes are **manage-gated** (owner / admin only).
- **`CampusMembersPageClient` rewritten as an editor**: three sections by effective role (Active / Viewers / Blocked), each row carries an effective-role badge + a Select (Inherit / Override → Admin/Editor/Viewer / Block) + a "revert" button when an override exists.

## Test plan
- [ ] Apply migration on preview → `ProjectMember` table exists with the right shape.
- [ ] Two campuses + a member. Owner promotes the member to Admin on campus A → member now sees admin-only routes (the Reach broadcast composer Save button etc.) on campus A but not campus B.
- [ ] Owner blocks the member from campus B → member's API calls to `/api/maps/<B>/news` return 403; the campus loads nothing from the dashboard.
- [ ] Owner removes the block → member's access reverts.
- [ ] The owner's row shows "Owner — always full access" and the picker is disabled.
- [ ] Trying to PUT an override on the owner via API → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)