### PR TITLE
feat(campus): real audit log backing "What Changed"

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -123,7 +123,7 @@ Campus authors **don't** edit a 3D scene in the Klorad app any more — MappedIn
 | 3 | Stat: Push subscribers | ⚠️ → ✅ | Wired in **this** PR using existing `/push-stats` |
 | 4 | Stat: POIs across N buildings | ✅ | From `campus-health` |
 | 5 | Stat: Accessibility % | ✅ | From `campus-health` |
-| 6 | What Changed feed (audit timeline) | ✅ | Synthesised from satellite `updatedAt` columns (news / events / clubs / dining / campus settings) + a rolled-up subscriber tally — no audit-log schema needed. `GET /api/maps/<mapId>/changes` |
+| 6 | What Changed feed (audit timeline) | ✅ | Backed by the `Activity` table — every write through `/api/...` drops an attributed row via `lib/audit.ts`. Subscribers stay synthesised (push subs are anonymous, no audit row makes sense) |
 | 7 | Jump-back tiles to recent CRUD | ✅ | `JumpBackInTiles` |
 
 ### A12. Manage organisation members
@@ -255,7 +255,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 | M | Med | Campus-tier "Settings" screen (publish + danger zone) | A13.2 — shipped |
 | S | Med | Wire `sceneData.defaultLocale` from Settings through the 10 public routes that today fall back to platform default | A13 follow-up — shipped |
 | M | Med | "Open now" structured hours for dining | A7.6 — shipped |
-| L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — feed shipped synthesised from `updatedAt`; richer trail TBD |
+| L | Med | Real audit log (per-write trail with actor + diff) | A11.6 — actor + entity-typed action shipped; richer field-level diffs TBD |
 | M | Med | Broadcast model + history with CTR on `/reach` | A10.5 — history + CTR shipped |
 | S | Med | Org-level "New organisation" form | A2.2 |
 | S | Med | Org-level "Enable Campus app" toggle | A2.4 |

--- a/apps/campus/app/(dashboard)/components/WhatChangedCard.tsx
+++ b/apps/campus/app/(dashboard)/components/WhatChangedCard.tsx
@@ -4,8 +4,10 @@ import {
   Bell,
   Calendar,
   History,
+  Megaphone,
   Newspaper,
   Palette,
+  Shield,
   Users,
   Utensils,
 } from "lucide-react";
@@ -99,6 +101,12 @@ function ChangeRow({ item }: { item: CampusChange }) {
         </div>
         <div className="mt-0.5 flex items-center gap-2 text-[11px] text-text-tertiary">
           <time dateTime={item.at}>{relative(item.at)}</time>
+          {item.actor ? (
+            <>
+              <span aria-hidden>·</span>
+              <span>by {item.actor}</span>
+            </>
+          ) : null}
           {item.detail ? (
             <>
               <span aria-hidden>·</span>
@@ -141,14 +149,20 @@ const ICONS: Record<ChangeKind, typeof Newspaper> = {
   club: Users,
   dining: Utensils,
   campus: Palette,
+  broadcast: Megaphone,
+  member: Shield,
   subscribers: Bell,
 };
 
 /** Verb phrase used as the row's eyebrow. Kept short — the entity's
- *  own title carries the specifics. */
+ *  own title carries the specifics. Audit-derived rows often pre-
+ *  render the verb inside `title` already (e.g. "Published Foo"), so
+ *  this is the eyebrow that contextualises the entity bucket. */
 function verbFor(item: CampusChange): string {
   if (item.kind === "subscribers") return "Subscribers";
   if (item.kind === "campus") return item.isNew ? "Created" : "Updated";
+  if (item.kind === "broadcast") return "Broadcast";
+  if (item.kind === "member") return "Members";
   const verb = item.isNew ? "New" : "Updated";
   const noun = {
     news: "news",
@@ -156,6 +170,8 @@ function verbFor(item: CampusChange): string {
     club: "club",
     dining: "dining",
     campus: "",
+    broadcast: "",
+    member: "",
     subscribers: "",
   }[item.kind];
   return `${verb} ${noun}`;

--- a/apps/campus/app/api/clubs/[id]/route.ts
+++ b/apps/campus/app/api/clubs/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma, type ClubColor } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
@@ -119,8 +121,20 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
   }
 
-  await prisma.club.update({ where: { id }, data });
+  const updated = await prisma.club.update({ where: { id }, data });
   revalidateTag(publicCampusTag(existing.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: existing.organizationId,
+    projectId: existing.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "CLUB",
+    entityId: id,
+    action: "UPDATED",
+    message: `Club "${updated.name}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }
 
@@ -128,7 +142,11 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;
   const club = await prisma.club.findUnique({
     where: { id },
-    select: { organizationId: true, projectId: true },
+    select: {
+      organizationId: true,
+      projectId: true,
+      name: true,
+    },
   });
   if (!club) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -137,5 +155,17 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   if (denied) return denied;
   await prisma.club.delete({ where: { id } });
   revalidateTag(publicCampusTag(club.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: club.organizationId,
+    projectId: club.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "CLUB",
+    entityId: id,
+    action: "DELETED",
+    message: `Club "${club.name}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }

--- a/apps/campus/app/api/dining/[id]/route.ts
+++ b/apps/campus/app/api/dining/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { parseHours } from "@/lib/dining-hours";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
@@ -119,8 +121,20 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
   }
 
-  await prisma.diningLocation.update({ where: { id }, data });
+  const updated = await prisma.diningLocation.update({ where: { id }, data });
   revalidateTag(publicCampusTag(existing.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: existing.organizationId,
+    projectId: existing.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "DINING_LOCATION",
+    entityId: id,
+    action: "UPDATED",
+    message: `Dining "${updated.name}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }
 
@@ -128,7 +142,11 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;
   const location = await prisma.diningLocation.findUnique({
     where: { id },
-    select: { organizationId: true, projectId: true },
+    select: {
+      organizationId: true,
+      projectId: true,
+      name: true,
+    },
   });
   if (!location) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -137,5 +155,17 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   if (denied) return denied;
   await prisma.diningLocation.delete({ where: { id } });
   revalidateTag(publicCampusTag(location.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: location.organizationId,
+    projectId: location.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "DINING_LOCATION",
+    entityId: id,
+    action: "DELETED",
+    message: `Dining "${location.name}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }

--- a/apps/campus/app/api/events/[id]/route.ts
+++ b/apps/campus/app/api/events/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma, type EventBanner, type EventIcon } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
@@ -142,8 +144,20 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
   }
 
-  await prisma.eventPost.update({ where: { id }, data });
+  const updated = await prisma.eventPost.update({ where: { id }, data });
   revalidateTag(publicCampusTag(existing.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: existing.organizationId,
+    projectId: existing.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "EVENT_POST",
+    entityId: id,
+    action: "UPDATED",
+    message: `Event "${updated.title}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }
 
@@ -151,7 +165,11 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;
   const event = await prisma.eventPost.findUnique({
     where: { id },
-    select: { organizationId: true, projectId: true },
+    select: {
+      organizationId: true,
+      projectId: true,
+      title: true,
+    },
   });
   if (!event) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -160,5 +178,17 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   if (denied) return denied;
   await prisma.eventPost.delete({ where: { id } });
   revalidateTag(publicCampusTag(event.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: event.organizationId,
+    projectId: event.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "EVENT_POST",
+    entityId: id,
+    action: "DELETED",
+    message: `Event "${event.title}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }

--- a/apps/campus/app/api/maps/[mapId]/clubs/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/clubs/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma, type ClubColor } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import {
   deriveInitials,
   listClubsForAdmin,
@@ -125,5 +127,17 @@ export async function POST(req: Request, { params }: { params: Params }) {
   });
 
   revalidateTag(publicCampusTag(mapId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: project.organizationId,
+    projectId: mapId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "CLUB",
+    entityId: created.id,
+    action: "CREATED",
+    message: `Club "${name}"`,
+  });
+
   return NextResponse.json({ id: created.id });
 }

--- a/apps/campus/app/api/maps/[mapId]/dining/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/dining/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { listDiningForProject, type DiningAnchor } from "@/lib/dining-db";
 import { parseHours } from "@/lib/dining-hours";
 import { revalidateTag } from "next/cache";
@@ -111,5 +113,17 @@ export async function POST(req: Request, { params }: { params: Params }) {
   });
 
   revalidateTag(publicCampusTag(mapId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: project.organizationId,
+    projectId: mapId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "DINING_LOCATION",
+    entityId: created.id,
+    action: "CREATED",
+    message: `Dining "${name}"`,
+  });
+
   return NextResponse.json({ id: created.id });
 }

--- a/apps/campus/app/api/maps/[mapId]/events/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/events/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma, type EventBanner, type EventIcon } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import {
   listEventsForAdmin,
   type EventAnchor,
@@ -146,5 +148,18 @@ export async function POST(req: Request, { params }: { params: Params }) {
   });
 
   revalidateTag(publicCampusTag(mapId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: project.organizationId,
+    projectId: mapId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "EVENT_POST",
+    entityId: created.id,
+    action: "CREATED",
+    message: `Event "${title}"`,
+    metadata: { startsAt: startsAt.toISOString() },
+  });
+
   return NextResponse.json({ id: created.id });
 }

--- a/apps/campus/app/api/maps/[mapId]/members/[userId]/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/members/[userId]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import type { OrganizationRole } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 
 type Params = Promise<{ mapId: string; userId: string }>;
 
@@ -79,7 +81,7 @@ export async function PUT(req: Request, { params }: { params: Params }) {
     );
   }
 
-  await prisma.projectMember.upsert({
+  const upserted = await prisma.projectMember.upsert({
     where: { projectId_userId: { projectId: mapId, userId } },
     create: {
       projectId: mapId,
@@ -87,9 +89,41 @@ export async function PUT(req: Request, { params }: { params: Params }) {
       role: role as OrganizationRole | null,
     },
     update: { role: role as OrganizationRole | null },
+    include: {
+      user: { select: { name: true, email: true } },
+    },
+  });
+
+  const session = await auth();
+  const targetName =
+    upserted.user.name?.trim() ||
+    upserted.user.email?.split("@")[0] ||
+    "a member";
+  await recordAudit({
+    organizationId: project.organizationId,
+    projectId: mapId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "PROJECT_MEMBER",
+    entityId: upserted.id,
+    action: role === null ? "REMOVED" : "UPDATED",
+    message:
+      role === null
+        ? `Blocked ${targetName} from this campus`
+        : `Set ${targetName}'s role to ${humanRole(role as OrganizationRole)}`,
+    metadata: { targetUserId: userId, role: role as string | null },
   });
 
   return NextResponse.json({ ok: true });
+}
+
+const ROLE_LABEL: Record<OrganizationRole, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Editor",
+  publicViewer: "Viewer",
+};
+function humanRole(role: OrganizationRole): string {
+  return ROLE_LABEL[role];
 }
 
 /**
@@ -105,11 +139,44 @@ export async function DELETE(
   const denied = await requireCampusAccess(mapId, "manage");
   if (denied) return denied;
 
+  const existing = await prisma.projectMember
+    .findUnique({
+      where: { projectId_userId: { projectId: mapId, userId } },
+      include: {
+        user: { select: { name: true, email: true } },
+      },
+    })
+    .catch(() => null);
+
   await prisma.projectMember
     .delete({
       where: { projectId_userId: { projectId: mapId, userId } },
     })
     .catch(() => undefined);
+
+  if (existing) {
+    const project = await prisma.project.findUnique({
+      where: { id: mapId },
+      select: { organizationId: true },
+    });
+    if (project) {
+      const session = await auth();
+      const targetName =
+        existing.user.name?.trim() ||
+        existing.user.email?.split("@")[0] ||
+        "a member";
+      await recordAudit({
+        organizationId: project.organizationId,
+        projectId: mapId,
+        actorId: (session?.user?.id as string | undefined) ?? null,
+        entityType: "PROJECT_MEMBER",
+        entityId: existing.id,
+        action: "REMOVED",
+        message: `Reverted ${targetName} to organisation role`,
+        metadata: { targetUserId: userId },
+      });
+    }
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/campus/app/api/maps/[mapId]/news/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/news/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import {
   listNewsForAdmin,
   type NewsAnchor,
@@ -129,6 +130,17 @@ export async function POST(req: Request, { params }: { params: Params }) {
   // Public surface caches per token — bust this campus's tag so the
   // new post shows up immediately without waiting for the 60 s TTL.
   revalidateTag(publicCampusTag(mapId));
+
+  await recordAudit({
+    organizationId: project.organizationId,
+    projectId: mapId,
+    actorId: session.user.id as string,
+    entityType: "NEWS_POST",
+    entityId: created.id,
+    action: "CREATED",
+    message: `News post "${title}"`,
+    metadata: { category, title },
+  });
 
   return NextResponse.json({ id: created.id });
 }

--- a/apps/campus/app/api/maps/[mapId]/notify/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/notify/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { randomBytes } from "node:crypto";
 import { auth } from "@/auth";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { pushEnabled, sendPushToProject } from "@/lib/push";
 
@@ -95,6 +96,30 @@ export async function POST(req: Request, { params }: { params: Params }) {
       .catch((err) => {
         console.error("[notify] count update failed", err);
       });
+
+    // Audit row: piggybacks on the project lookup the authz helper
+    // already did. We do an extra `findUnique` to get the org id —
+    // tiny cost vs. accurate attribution on the "What Changed" feed.
+    const project = await prisma.project.findUnique({
+      where: { id: mapId },
+      select: { organizationId: true },
+    });
+    if (project) {
+      await recordAudit({
+        organizationId: project.organizationId,
+        projectId: mapId,
+        actorId: (session?.user?.id as string | undefined) ?? null,
+        entityType: "BROADCAST",
+        entityId: broadcast.id,
+        action: "CREATED",
+        message: `Broadcast "${title}" — sent to ${result.delivered} of ${result.attempted}`,
+        metadata: {
+          attempted: result.attempted,
+          delivered: result.delivered,
+          pruned: result.pruned,
+        },
+      });
+    }
 
     return NextResponse.json({ ok: true, result });
   } catch (err) {

--- a/apps/campus/app/api/maps/[mapId]/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess, requireOrgAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { publicCampusTag } from "@/lib/public-campus";
 
 export async function GET(
@@ -20,6 +22,7 @@ export async function GET(
       createdAt: true,
       thumbnail: true,
       isPublished: true,
+      isPublic: true,
       organizationId: true,
     },
   });
@@ -45,20 +48,44 @@ export async function PATCH(
   const denied = await requireCampusAccess(mapId, "write");
   if (denied) return denied;
 
-  const body = await req.json() as {
+  const body = (await req.json()) as {
     name?: string;
     sceneData?: unknown;
     thumbnail?: string | null;
     isPublished?: boolean;
+    isPublic?: boolean;
   };
+
+  // Snapshot the prior state so the audit row can attribute what
+  // moved. Cheap (single PK lookup); the savings come from giving
+  // the dashboard "What Changed" feed real semantics ("Published"
+  // vs "Card image updated") instead of one generic "Updated".
+  const prior = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: {
+      organizationId: true,
+      title: true,
+      isPublished: true,
+      isPublic: true,
+      thumbnail: true,
+    },
+  });
+  if (!prior) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
 
   const map = await prisma.project.update({
     where: { id: mapId },
     data: {
       ...(body.name !== undefined && { title: body.name }),
-      ...(body.sceneData !== undefined && { sceneData: body.sceneData as object }),
+      ...(body.sceneData !== undefined && {
+        sceneData: body.sceneData as object,
+      }),
       ...(body.thumbnail !== undefined && { thumbnail: body.thumbnail }),
-      ...(body.isPublished !== undefined && { isPublished: body.isPublished }),
+      ...(body.isPublished !== undefined && {
+        isPublished: body.isPublished,
+      }),
+      ...(body.isPublic !== undefined && { isPublic: body.isPublic }),
     },
     select: {
       id: true,
@@ -66,6 +93,7 @@ export async function PATCH(
       updatedAt: true,
       thumbnail: true,
       isPublished: true,
+      isPublic: true,
     },
   });
 
@@ -73,6 +101,69 @@ export async function PATCH(
   // this campus's entry so an owner's save shows up promptly (and one
   // tenant's edits don't thrash every other campus's cache).
   revalidateTag(publicCampusTag(mapId));
+
+  // Decide the right audit row. Publish state is the loudest signal
+  // — call it out explicitly. Otherwise infer the dominant change
+  // and fall back to "Settings updated".
+  const session = await auth();
+  const actorId = (session?.user?.id as string | undefined) ?? null;
+  const auditCommon = {
+    organizationId: prior.organizationId,
+    projectId: mapId,
+    actorId,
+    entityType: "PROJECT" as const,
+    entityId: mapId,
+  };
+  if (
+    body.isPublished !== undefined &&
+    body.isPublished !== prior.isPublished
+  ) {
+    if (body.isPublished) {
+      await recordAudit({
+        ...auditCommon,
+        action: "PUBLISHED",
+        message: `Published ${map.title}`,
+      });
+    } else {
+      await recordAudit({
+        ...auditCommon,
+        action: "UPDATED",
+        message: `Unpublished ${map.title}`,
+      });
+    }
+  } else if (body.name !== undefined && body.name !== prior.title) {
+    await recordAudit({
+      ...auditCommon,
+      action: "RENAMED",
+      message: `Renamed campus to "${map.title}"`,
+    });
+  } else if (
+    body.thumbnail !== undefined &&
+    body.thumbnail !== prior.thumbnail
+  ) {
+    await recordAudit({
+      ...auditCommon,
+      action: "UPDATED",
+      message: "Card image updated",
+    });
+  } else if (
+    body.isPublic !== undefined &&
+    body.isPublic !== prior.isPublic
+  ) {
+    await recordAudit({
+      ...auditCommon,
+      action: "UPDATED",
+      message: body.isPublic
+        ? "Campus is now public"
+        : "Campus now requires sign-in",
+    });
+  } else if (body.sceneData !== undefined) {
+    await recordAudit({
+      ...auditCommon,
+      action: "UPDATED",
+      message: "Settings updated",
+    });
+  }
 
   return NextResponse.json({ ...map, name: map.title });
 }
@@ -87,11 +178,29 @@ export async function DELETE(
   const denied = await requireCampusAccess(mapId, "manage");
   if (denied) return denied;
 
+  const prior = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true, title: true },
+  });
+
   await prisma.project.delete({ where: { id: mapId } });
 
   // Without this the public cache would keep serving the deleted
   // campus for up to 60s.
   revalidateTag(publicCampusTag(mapId));
+
+  if (prior) {
+    const session = await auth();
+    await recordAudit({
+      organizationId: prior.organizationId,
+      projectId: mapId,
+      actorId: (session?.user?.id as string | undefined) ?? null,
+      entityType: "PROJECT",
+      entityId: mapId,
+      action: "DELETED",
+      message: `Deleted campus "${prior.title}"`,
+    });
+  }
 
   return new NextResponse(null, { status: 204 });
 }

--- a/apps/campus/app/api/maps/[mapId]/seed-sample/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/seed-sample/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import {
   projectHasContent,
   seedSampleCampus,
@@ -45,6 +47,19 @@ export async function POST(_req: Request, { params }: { params: Params }) {
   try {
     const counts = await seedSampleCampus(mapId, project.organizationId);
     revalidateTag(publicCampusTag(mapId));
+
+    const session = await auth();
+    await recordAudit({
+      organizationId: project.organizationId,
+      projectId: mapId,
+      actorId: (session?.user?.id as string | undefined) ?? null,
+      entityType: "PROJECT",
+      entityId: mapId,
+      action: "ADDED",
+      message: `Seeded sample content (${counts.news} news, ${counts.events} events, ${counts.clubs} clubs, ${counts.dining} dining)`,
+      metadata: counts,
+    });
+
     return NextResponse.json({ ok: true, counts });
   } catch (err) {
     console.error("[seed-sample] failed", err);

--- a/apps/campus/app/api/news/[id]/route.ts
+++ b/apps/campus/app/api/news/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { Prisma, type NewsCategory } from "@prisma/client";
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 
@@ -118,8 +120,20 @@ export async function PATCH(req: Request, { params }: { params: Params }) {
     data.anchors = parseAnchors(body.anchors) as unknown as Prisma.InputJsonValue;
   }
 
-  await prisma.newsPost.update({ where: { id }, data });
+  const updated = await prisma.newsPost.update({ where: { id }, data });
   revalidateTag(publicCampusTag(existing.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: existing.organizationId,
+    projectId: existing.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "NEWS_POST",
+    entityId: id,
+    action: "UPDATED",
+    message: `News post "${updated.title}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }
 
@@ -128,7 +142,11 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
   const { id } = await params;
   const post = await prisma.newsPost.findUnique({
     where: { id },
-    select: { organizationId: true, projectId: true },
+    select: {
+      organizationId: true,
+      projectId: true,
+      title: true,
+    },
   });
   if (!post) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -138,5 +156,17 @@ export async function DELETE(_req: Request, { params }: { params: Params }) {
 
   await prisma.newsPost.delete({ where: { id } });
   revalidateTag(publicCampusTag(post.projectId));
+
+  const session = await auth();
+  await recordAudit({
+    organizationId: post.organizationId,
+    projectId: post.projectId,
+    actorId: (session?.user?.id as string | undefined) ?? null,
+    entityType: "NEWS_POST",
+    entityId: id,
+    action: "DELETED",
+    message: `News post "${post.title}"`,
+  });
+
   return NextResponse.json({ ok: true });
 }

--- a/apps/campus/lib/audit.ts
+++ b/apps/campus/lib/audit.ts
@@ -1,0 +1,72 @@
+import "server-only";
+import type {
+  ActivityActionType,
+  ActivityEntityType,
+  Prisma,
+} from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Audit-log writer for Campus.
+ *
+ * Every write that survives in the DB should drop a row here so the
+ * dashboard's "What Changed" feed can show attribution. Best-effort
+ * by design: an audit-write failure is logged and swallowed so the
+ * caller's primary write never gets rolled back over missing
+ * history.
+ *
+ * The `Activity` model is platform-shared (see `packages/prisma`),
+ * so we expose a thin campus-flavoured wrapper instead of letting
+ * every route hand-roll the field names.
+ */
+export interface AuditInput {
+  /** Owning organisation — always known via the project. */
+  organizationId: string;
+  /** Campus / project id. `null` is allowed by the model but every
+   *  campus write has one, so we keep it required here. */
+  projectId: string;
+  /** The signed-in user that triggered the write. Pass `null` when
+   *  the actor is a system job (e.g. ICS sync) — the row is dropped
+   *  silently rather than committed without an actor. */
+  actorId: string | null;
+  entityType: ActivityEntityType;
+  entityId: string;
+  action: ActivityActionType;
+  /** Pre-rendered one-liner used as the feed row body. Keep human-
+   *  readable; the feed shows it verbatim. */
+  message?: string;
+  /** Optional bookkeeping — anchors, counts, diff hints. */
+  metadata?: Prisma.InputJsonValue;
+}
+
+/**
+ * Drop an audit row. Returns nothing — the caller never branches on
+ * the result. Errors are caught and console-logged because a missing
+ * row is a worse story than a broken endpoint.
+ */
+export async function recordAudit(input: AuditInput): Promise<void> {
+  // No actor → no row. System-driven writes (sync jobs) keep happening
+  // but we don't want to pollute the feed with unattributable noise
+  // until we have a proper SYSTEM actor pattern.
+  if (!input.actorId) return;
+  try {
+    await prisma.activity.create({
+      data: {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        actorId: input.actorId,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        action: input.action,
+        message: input.message,
+        metadata: input.metadata,
+      },
+    });
+  } catch (err) {
+    console.error("[audit] insert failed", {
+      entityType: input.entityType,
+      action: input.action,
+      err,
+    });
+  }
+}

--- a/apps/campus/lib/changes.ts
+++ b/apps/campus/lib/changes.ts
@@ -1,4 +1,8 @@
 import "server-only";
+import type {
+  ActivityActionType,
+  ActivityEntityType,
+} from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
 export type ChangeKind =
@@ -7,57 +11,51 @@ export type ChangeKind =
   | "club"
   | "dining"
   | "campus"
+  | "broadcast"
+  | "member"
   | "subscribers";
 
 export interface CampusChange {
-  /** Stable identifier — composed `<kind>:<rowId>` so React keys never clash. */
+  /** Stable identifier — `Activity.id` for real audit rows,
+   *  `subscribers:<mapId>:7d` for the rolled-up subscriber tally. */
   id: string;
   kind: ChangeKind;
-  /** Human-readable label, e.g. `"Exam schedule"` or `"Branding updated"`. */
+  /** Human-readable label. Audit rows pre-render this on write so
+   *  the dashboard can show it verbatim (no second lookup). */
   title: string;
   /** Optional deep-link into the dashboard. */
   href?: string;
-  /** Optional one-line context, e.g. `"3 new"` or `"posted by Maria"`. */
+  /** Optional secondary context — e.g. `"3 new"` or `"by Maria"`. */
   detail?: string;
-  /** True for creations (createdAt ≈ updatedAt), false for updates. */
+  /** True for creations rather than updates. */
   isNew: boolean;
-  /** ISO timestamp — the change's `updatedAt`. */
+  /** ISO timestamp. */
   at: string;
+  /** Display name of the actor (when known). */
+  actor?: string;
 }
 
-/** How many rows to read per satellite model before merging. The merged
- *  list is capped at `limit`; over-reading per model keeps the merge
- *  fair when one model has a sustained edit burst. */
-const PER_MODEL_LIMIT = 10;
-/** "Created" vs "updated" — Prisma stamps `createdAt` and `updatedAt`
- *  in the same write, but they can drift by a few ms. Treat the gap
- *  as a creation. */
-const CREATION_GAP_MS = 5_000;
-/** Activity window — anything older than this drops out of the feed
- *  even if there's slack in the per-model cap. */
-const WINDOW_DAYS = 30;
-
 interface BuildOpts {
-  /** Project / campus id. */
   mapId: string;
-  /** Org id — used to scope the org-tier hrefs. */
   orgId: string;
   /** How many changes to return after merging. */
   limit?: number;
 }
 
+/** Activity window — anything older than this drops off the feed. */
+const WINDOW_DAYS = 30;
+
 /**
- * "What changed" feed for a campus dashboard.
+ * "What changed" feed for the campus dashboard, backed by the
+ * `Activity` table. Each write through Campus's API endpoints
+ * leaves a row (see `lib/audit.ts`); this function reads them back
+ * and shapes them for the UI.
  *
- * We don't have a dedicated audit-log model — every write would need
- * to be re-routed through one — so this builds the feed from the
- * `updatedAt` columns we already maintain on news / events / clubs /
- * dining + the project itself. Good enough to answer "what did the
- * team do this week?" without a schema change; we can swap in a real
- * `Activity` reader later without touching the UI (just this file).
- *
- * Subscriber growth is rolled up into a single entry so a one-tab
- * burst of installs doesn't drown the rest of the feed.
+ * Subscriber growth is still synthesised — push subscriptions are
+ * anonymous, so we roll them up into a single 7-day tally rather
+ * than write one Activity row per device. Same intent as the
+ * earlier `updatedAt`-based feed; just narrower scope now that real
+ * audit rows carry every other entity.
  */
 export async function readCampusChanges({
   mapId,
@@ -67,123 +65,55 @@ export async function readCampusChanges({
   const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
   const dashBase = `/org/${orgId}/maps/${mapId}`;
 
-  const [project, news, events, clubs, dining, recentSubs] =
-    await Promise.all([
-      prisma.project.findUnique({
-        where: { id: mapId },
-        select: {
-          id: true,
-          title: true,
-          updatedAt: true,
-          createdAt: true,
-          isPublished: true,
+  const [rows, recentSubs] = await Promise.all([
+    prisma.activity
+      .findMany({
+        where: { projectId: mapId, createdAt: { gte: since } },
+        orderBy: { createdAt: "desc" },
+        take: limit * 2,
+        include: {
+          actor: { select: { name: true, email: true } },
         },
-      }),
-      prisma.newsPost
-        .findMany({
-          where: { projectId: mapId, updatedAt: { gte: since } },
-          orderBy: { updatedAt: "desc" },
-          take: PER_MODEL_LIMIT,
-          select: {
-            id: true,
-            title: true,
-            updatedAt: true,
-            createdAt: true,
+      })
+      .catch(() => []),
+    prisma.pushSubscription
+      .count({
+        where: {
+          projectId: mapId,
+          createdAt: {
+            gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
           },
-        })
-        .catch(() => []),
-      prisma.eventPost
-        .findMany({
-          where: { projectId: mapId, updatedAt: { gte: since } },
-          orderBy: { updatedAt: "desc" },
-          take: PER_MODEL_LIMIT,
-          select: {
-            id: true,
-            title: true,
-            updatedAt: true,
-            createdAt: true,
-          },
-        })
-        .catch(() => []),
-      prisma.club
-        .findMany({
-          where: { projectId: mapId, updatedAt: { gte: since } },
-          orderBy: { updatedAt: "desc" },
-          take: PER_MODEL_LIMIT,
-          select: {
-            id: true,
-            name: true,
-            updatedAt: true,
-            createdAt: true,
-          },
-        })
-        .catch(() => []),
-      prisma.diningLocation
-        .findMany({
-          where: { projectId: mapId, updatedAt: { gte: since } },
-          orderBy: { updatedAt: "desc" },
-          take: PER_MODEL_LIMIT,
-          select: {
-            id: true,
-            name: true,
-            updatedAt: true,
-            createdAt: true,
-          },
-        })
-        .catch(() => []),
-      prisma.pushSubscription
-        .count({
-          where: {
-            projectId: mapId,
-            createdAt: {
-              gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-            },
-          },
-        })
-        .catch(() => 0),
-    ]);
+        },
+      })
+      .catch(() => 0),
+  ]);
 
   const items: CampusChange[] = [];
 
-  for (const row of news) {
-    items.push(makeRow("news", row.id, row.title, row.createdAt, row.updatedAt, `${dashBase}/news`));
-  }
-  for (const row of events) {
-    items.push(makeRow("event", row.id, row.title, row.createdAt, row.updatedAt, `${dashBase}/events`));
-  }
-  for (const row of clubs) {
-    items.push(makeRow("club", row.id, row.name, row.createdAt, row.updatedAt, `${dashBase}/clubs`));
-  }
-  for (const row of dining) {
-    items.push(makeRow("dining", row.id, row.name, row.createdAt, row.updatedAt, `${dashBase}/dining`));
-  }
-
-  // Project-level change: branding / publish state / scene edits.
-  // We can't tell what specifically moved without an audit log, so
-  // we label it as either "Branding & settings updated" or "Campus
-  // published" — the latter only if isPublished is true and updatedAt
-  // is fresh.
-  if (project && project.updatedAt >= since) {
-    const projectIsNew =
-      project.updatedAt.getTime() - project.createdAt.getTime() <
-      CREATION_GAP_MS;
+  for (const row of rows) {
+    const kind = mapKind(row.entityType);
+    if (!kind) continue;
     items.push({
-      id: `campus:${project.id}:${project.updatedAt.getTime()}`,
-      kind: "campus",
-      title: projectIsNew
-        ? "Campus created"
-        : project.isPublished
-          ? "Campus settings updated"
-          : "Draft settings updated",
-      href: `${dashBase}/identity`,
-      isNew: projectIsNew,
-      at: project.updatedAt.toISOString(),
+      id: row.id,
+      kind,
+      title:
+        row.message ??
+        // Fallback when older rows have no pre-rendered message —
+        // synthesise something serviceable so the feed doesn't show
+        // a blank row.
+        `${humanAction(row.action)} ${humanEntity(row.entityType)}`,
+      href: hrefFor(kind, dashBase),
+      isNew: isCreation(row.action),
+      at: row.createdAt.toISOString(),
+      actor:
+        row.actor?.name?.trim() ||
+        row.actor?.email?.split("@")[0] ||
+        undefined,
     });
   }
 
-  // Push subscribers rolled up into one entry. The endpoint is the
-  // dashboard's Reach screen — clicking through gives the live total
-  // and the broadcast composer in one place.
+  // Subscribers: anonymous, no Activity rows — keep the rolled-up
+  // tally so a burst of installs still surfaces in the feed.
   if (recentSubs > 0) {
     items.push({
       id: `subscribers:${mapId}:7d`,
@@ -195,34 +125,104 @@ export async function readCampusChanges({
       detail: "last 7 days",
       href: `${dashBase}/reach`,
       isNew: true,
-      // Timestamp at "now" so this floats to the top when activity is
-      // otherwise thin — feels right because the count IS current,
-      // not a single past event.
       at: new Date().toISOString(),
     });
   }
 
-  // Newest first, capped.
   items.sort((a, b) => b.at.localeCompare(a.at));
   return items.slice(0, limit);
 }
 
-function makeRow(
-  kind: ChangeKind,
-  id: string,
-  title: string,
-  createdAt: Date,
-  updatedAt: Date,
-  href: string,
-): CampusChange {
-  const isNew =
-    updatedAt.getTime() - createdAt.getTime() < CREATION_GAP_MS;
-  return {
-    id: `${kind}:${id}`,
-    kind,
-    title,
-    href,
-    isNew,
-    at: updatedAt.toISOString(),
-  };
+function isCreation(action: ActivityActionType): boolean {
+  return action === "CREATED" || action === "ADDED" || action === "PUBLISHED";
+}
+
+/** Map an `ActivityEntityType` to the dashboard's `ChangeKind`. The
+ *  enum carries lots of platform values (sensors, cesium assets etc.)
+ *  that the campus dashboard doesn't render — those return null and
+ *  get filtered. */
+function mapKind(value: ActivityEntityType): ChangeKind | null {
+  switch (value) {
+    case "NEWS_POST":
+      return "news";
+    case "EVENT_POST":
+      return "event";
+    case "CLUB":
+      return "club";
+    case "DINING_LOCATION":
+      return "dining";
+    case "BROADCAST":
+      return "broadcast";
+    case "PROJECT_MEMBER":
+      return "member";
+    case "PROJECT":
+      return "campus";
+    default:
+      return null;
+  }
+}
+
+function hrefFor(kind: ChangeKind, base: string): string {
+  switch (kind) {
+    case "news":
+      return `${base}/news`;
+    case "event":
+      return `${base}/events`;
+    case "club":
+      return `${base}/clubs`;
+    case "dining":
+      return `${base}/dining`;
+    case "campus":
+      return `${base}/identity`;
+    case "broadcast":
+      return `${base}/reach`;
+    case "member":
+      return `${base}/members`;
+    case "subscribers":
+      return `${base}/reach`;
+  }
+}
+
+function humanAction(action: ActivityActionType): string {
+  switch (action) {
+    case "CREATED":
+      return "Created";
+    case "UPDATED":
+      return "Updated";
+    case "DELETED":
+      return "Deleted";
+    case "RENAMED":
+      return "Renamed";
+    case "PUBLISHED":
+      return "Published";
+    case "ARCHIVED":
+      return "Archived";
+    case "ADDED":
+      return "Added";
+    case "REMOVED":
+      return "Removed";
+    case "SYNCED":
+      return "Synced";
+  }
+}
+
+function humanEntity(value: ActivityEntityType): string {
+  switch (value) {
+    case "NEWS_POST":
+      return "news post";
+    case "EVENT_POST":
+      return "event";
+    case "CLUB":
+      return "club";
+    case "DINING_LOCATION":
+      return "dining venue";
+    case "BROADCAST":
+      return "broadcast";
+    case "PROJECT_MEMBER":
+      return "member access";
+    case "PROJECT":
+      return "campus settings";
+    default:
+      return "item";
+  }
 }

--- a/packages/prisma/migrations/20260604120000_audit_log_campus_entities/migration.sql
+++ b/packages/prisma/migrations/20260604120000_audit_log_campus_entities/migration.sql
@@ -1,0 +1,9 @@
+-- Add Campus-app entity types to ActivityEntityType so per-write
+-- audit rows can be tagged with the right entity bucket (news /
+-- events / clubs / dining / broadcasts / member-overrides).
+ALTER TYPE "ActivityEntityType" ADD VALUE 'NEWS_POST';
+ALTER TYPE "ActivityEntityType" ADD VALUE 'EVENT_POST';
+ALTER TYPE "ActivityEntityType" ADD VALUE 'CLUB';
+ALTER TYPE "ActivityEntityType" ADD VALUE 'DINING_LOCATION';
+ALTER TYPE "ActivityEntityType" ADD VALUE 'BROADCAST';
+ALTER TYPE "ActivityEntityType" ADD VALUE 'PROJECT_MEMBER';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -312,6 +312,13 @@ enum ActivityEntityType {
   CESIUM_ASSET
   SHOWCASE_WORLD
   SHOWCASE_TAG
+  // Campus-app entities — see apps/campus/lib/audit.ts.
+  NEWS_POST
+  EVENT_POST
+  CLUB
+  DINING_LOCATION
+  BROADCAST
+  PROJECT_MEMBER
 }
 
 enum ActivityActionType {


### PR DESCRIPTION
## Summary
Replaces the `updatedAt`-synthesised changes feed from #198 with real `Activity` rows written on every campus write. The dashboard now shows the actor's name alongside each change ("Published Library news · 3h · by Maria") instead of a synthesised guess.

## Schema
Extends `ActivityEntityType` with six campus-specific buckets: `NEWS_POST`, `EVENT_POST`, `CLUB`, `DINING_LOCATION`, `BROADCAST`, `PROJECT_MEMBER`. Migration `20260604120000_audit_log_campus_entities` adds them via `ALTER TYPE ... ADD VALUE` — additive only, no backfill.

The `Activity` model itself was already in the platform schema; this PR is the first writer.

## Wiring
`lib/audit.ts` exposes a thin `recordAudit` helper, best-effort by design — a failed insert logs and swallows so the caller's primary write never gets rolled back. No-actor calls (system jobs, future ICS sync) drop rows silently rather than commit unattributable noise.

Wired into every campus write endpoint:
- news create / update / delete
- events create / update / delete
- clubs create / update / delete
- dining create / update / delete
- `PATCH /api/maps/[mapId]` — distinguishes `PUBLISHED` / `RENAMED` / settings-updated / card-image-updated / isPublic-flipped via a prior-state diff so the feed reads "Published Library" instead of one generic "Updated"
- `DELETE /api/maps/[mapId]`
- broadcast notify — message includes delivered/attempted counts
- project-member override PUT / DELETE — names the target ("Set Maria's role to Admin" / "Blocked Maria")
- seed-sample — one `ADDED` row with the seeded counts

## Read side
`lib/changes.ts` rewritten to query `Activity` ordered by `createdAt`. Each row carries `actor` (display name) + a pre-rendered `title`, so the dashboard renders without a second lookup. Six new `ChangeKind` buckets thread through to icons + verb labels in `WhatChangedCard`.

**Subscribers stay synthesised** — push subs are anonymous and per-device, an Activity row per install would drown the feed in noise. Same 7-day roll-up as before.

## Drive-by
`PATCH /api/maps/[mapId]` now actually honours `isPublic`. The Settings screen has been sending it since #199 but the route was silently ignoring the field. Caught by the prior-state diff while wiring the audit log.

## Test plan
- [ ] Apply migration on preview → the six new enum values exist.
- [ ] Create a news post → dashboard "What Changed" gains a row reading `New news · Library news · just now · by <you>`. Click → lands on `/news`.
- [ ] Toggle publish on Reach → row reads `Updated · Published <campus> · just now · by <you>`. Unpublish → `Unpublished <campus>`.
- [ ] Rename the campus → row reads `Renamed · Renamed campus to "<new>"`.
- [ ] Toggle Settings → "Require sign-in" → audit row says `Campus is now public` / `Campus now requires sign-in` correctly (and the visibility actually changes — drive-by fix).
- [ ] Block a member on the campus Members screen → audit row reads `Members · Blocked <name> from this campus`.
- [ ] Send a broadcast → row reads `Broadcast · Broadcast "<title>" — sent to N of M`.
- [ ] Push subscribers stat keeps incrementing; the 7-day "N new push subscribers" rolled-up row still appears alongside real audit entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)