### PR TITLE
feat(campus): stock image picker for news / events / clubs / dining

### DIFF
--- a/apps/campus/USER-PATH.md
+++ b/apps/campus/USER-PATH.md
@@ -252,7 +252,7 @@ Roughly in shipping order; "S" = size (S/M/L), "U" = user impact (low/med/high).
 | S | U | Item | Pointer |
 |---|---|---|---|
 | S | Med | Quick-action tiles on the public home are hardcoded (Map · Directions · Klio · Explore). Admin Home screen has no tile editor | Home admin / `ConsumerHome` |
-| M | Med | Stock-image picker + library for content covers (news / events / clubs / dining) | Polish follow-up — needs a stock-image source dep + a picker component |
+| M | Med | Stock-image picker + library for content covers (news / events / clubs / dining) | Polish follow-up — shipped |
 
 ### Post-MVP, useful
 | S | U | Item | Pointer |

--- a/apps/campus/app/(dashboard)/components/ImagePicker.tsx
+++ b/apps/campus/app/(dashboard)/components/ImagePicker.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toast } from "react-toastify";
+import { ImageIcon, Plus, Upload, X } from "lucide-react";
+import { Button, Modal } from "@klorad/design-system";
+import { uploadFile } from "@klorad/storage/client";
+import { STOCK_IMAGES, type StockImage } from "@/lib/stock-images";
+
+interface Props {
+  /** Currently-selected image URL (stock or uploaded). */
+  value: string | null;
+  /** Called when the rector picks a stock image or finishes an upload. */
+  onChange: (url: string | null) => void;
+  /** Storage prefix for uploaded files — passed straight to
+   *  `@klorad/storage`. Use `UPLOAD_PREFIXES.news` etc. */
+  uploadPrefix: string;
+  /** Default category tab when the modal opens. Picker filters to
+   *  this kind first so a dining admin sees food, not megaphones. */
+  defaultCategory: StockImage["category"];
+  /** Hint copy shown under the field label. */
+  hint?: string;
+}
+
+/**
+ * Two-mode image picker: pick a curated stock SVG, or upload your own.
+ *
+ * Renders a preview card. When empty, a single "Add image" button
+ * opens a modal that defaults to the stock grid filtered to the
+ * caller's category — clicking a tile commits and closes. The
+ * "Upload" mode swaps in a file input + drop zone wired to the
+ * existing storage client.
+ *
+ * When set, the preview shows the current image plus replace +
+ * clear controls. The replace flow re-opens the same modal so a
+ * rector can swap stock-for-stock or stock-for-upload without an
+ * intermediate "clear" step.
+ */
+export function ImagePicker({
+  value,
+  onChange,
+  uploadPrefix,
+  defaultCategory,
+  hint,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      {value ? (
+        <div className="flex items-start gap-3 rounded-xl border border-line-soft bg-surface-2/40 p-3">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={value}
+            alt=""
+            className="block h-20 w-32 shrink-0 rounded-md object-cover"
+          />
+          <div className="flex flex-col gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => setOpen(true)}
+            >
+              <ImageIcon size={12} strokeWidth={1.75} aria-hidden />
+              Replace
+            </Button>
+            <button
+              type="button"
+              onClick={() => onChange(null)}
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-text-tertiary underline-offset-2 hover:text-red-500 hover:underline"
+            >
+              <X size={11} strokeWidth={1.75} aria-hidden />
+              Clear
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-xs text-text-tertiary transition-colors hover:border-accent hover:text-accent"
+        >
+          <Plus size={14} strokeWidth={1.75} aria-hidden />
+          Add image
+        </button>
+      )}
+      {hint ? (
+        <p className="text-[11px] text-text-tertiary">{hint}</p>
+      ) : null}
+
+      <PickerModal
+        open={open}
+        defaultCategory={defaultCategory}
+        uploadPrefix={uploadPrefix}
+        onPick={(url) => {
+          onChange(url);
+          setOpen(false);
+        }}
+        onClose={() => setOpen(false)}
+      />
+    </div>
+  );
+}
+
+interface ModalProps {
+  open: boolean;
+  defaultCategory: StockImage["category"];
+  uploadPrefix: string;
+  onPick: (url: string) => void;
+  onClose: () => void;
+}
+
+function PickerModal({
+  open,
+  defaultCategory,
+  uploadPrefix,
+  onPick,
+  onClose,
+}: ModalProps) {
+  const [mode, setMode] = useState<"stock" | "upload">("stock");
+  const [category, setCategory] = useState<StockImage["category"]>(
+    defaultCategory,
+  );
+  const [uploading, setUploading] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleUpload = async (file: File) => {
+    setUploading(true);
+    try {
+      const result = await uploadFile(file, { prefix: uploadPrefix });
+      onPick(result.publicUrl);
+    } catch (err) {
+      console.error(err);
+      toast.error("Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <Modal open={open} title="Pick an image" onClose={onClose}>
+      <div className="space-y-4">
+        <div className="inline-flex rounded-full bg-surface-2 p-0.5">
+          {(["stock", "upload"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              aria-pressed={mode === m}
+              className={
+                mode === m
+                  ? "rounded-full bg-accent px-3 py-1 text-xs font-semibold text-accent-contrast"
+                  : "rounded-full px-3 py-1 text-xs font-medium text-text-secondary hover:text-text-primary"
+              }
+            >
+              {m === "stock" ? "Stock" : "Upload"}
+            </button>
+          ))}
+        </div>
+
+        {mode === "stock" ? (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-1.5">
+              {(["news", "events", "clubs", "dining"] as const).map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setCategory(c)}
+                  aria-pressed={category === c}
+                  className={
+                    category === c
+                      ? "rounded-full bg-accent-soft px-3 py-1 text-[11px] font-medium capitalize text-accent"
+                      : "rounded-full bg-surface-2 px-3 py-1 text-[11px] font-medium capitalize text-text-secondary hover:text-text-primary"
+                  }
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+            <ul className="grid list-none gap-3 sm:grid-cols-3">
+              {STOCK_IMAGES.filter((img) => img.category === category).map(
+                (img) => (
+                  <li key={img.id}>
+                    <button
+                      type="button"
+                      onClick={() => onPick(img.url)}
+                      className="group flex w-full flex-col gap-1.5 overflow-hidden rounded-xl border border-line-soft bg-surface-1 text-left transition-colors hover:border-accent"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={img.url}
+                        alt=""
+                        className="block aspect-[16/9] w-full object-cover"
+                      />
+                      <span className="px-3 pb-2 text-[11px] font-medium text-text-secondary group-hover:text-text-primary">
+                        {img.label}
+                      </span>
+                    </button>
+                  </li>
+                ),
+              )}
+            </ul>
+          </div>
+        ) : (
+          <div
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault();
+              const file = e.dataTransfer.files[0];
+              if (file) void handleUpload(file);
+            }}
+            className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-10 text-center"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent">
+              <Upload size={18} strokeWidth={1.75} aria-hidden />
+            </div>
+            <p className="text-sm font-medium text-text-primary">
+              Drop an image or pick one
+            </p>
+            <p className="max-w-xs text-xs text-text-tertiary">
+              PNG, JPG or WebP. Roughly 1600 × 900 keeps the card crisp on
+              every screen.
+            </p>
+            <input
+              ref={inputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) void handleUpload(file);
+              }}
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => inputRef.current?.click()}
+              disabled={uploading}
+            >
+              <Upload size={12} strokeWidth={1.75} aria-hidden />
+              {uploading ? "Uploading…" : "Choose a file"}
+            </Button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/clubs/ClubsAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Pencil, Plus, Trash2, X } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import {
   Button,
   Field,
@@ -12,8 +12,8 @@ import {
   Select,
   Textarea,
 } from "@klorad/design-system";
-import { uploadFile } from "@klorad/storage/client";
 import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
+import { ImagePicker } from "@/app/(dashboard)/components/ImagePicker";
 import {
   deriveInitials,
   type Club,
@@ -53,23 +53,9 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
   const [externalLink, setExternalLink] = useState("");
   const [popularityScore, setPopularityScore] = useState("");
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const previewInitials = (initialsOverride.trim() || deriveInitials(name)).slice(0, 3);
-
-  const handleImage = async (file: File) => {
-    setUploading(true);
-    try {
-      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.clubs });
-      setImageUrl(result.publicUrl);
-    } catch (e) {
-      console.error(e);
-      toast.error("Image upload failed");
-    } finally {
-      setUploading(false);
-    }
-  };
 
   const reset = () => {
     setEditingId(null);
@@ -377,40 +363,16 @@ export function ClubsAdminClient({ mapId, initialClubs }: Props) {
             />
           </Field>
 
-          <Field label="Image (optional)">
-            {imageUrl ? (
-              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={imageUrl}
-                  alt=""
-                  className="h-16 w-16 rounded-md object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => setImageUrl(null)}
-                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
-                >
-                  <X size={14} strokeWidth={1.75} />
-                </button>
-              </div>
-            ) : (
-              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
-                <Plus size={16} strokeWidth={1.75} />
-                {uploading ? "Uploading…" : "Add image"}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  disabled={uploading}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) void handleImage(file);
-                    e.target.value = "";
-                  }}
-                />
-              </label>
-            )}
+          <Field
+            label="Image (optional)"
+            hint="Pick a stock cover or upload your own."
+          >
+            <ImagePicker
+              value={imageUrl}
+              onChange={setImageUrl}
+              uploadPrefix={UPLOAD_PREFIXES.clubs}
+              defaultCategory="clubs"
+            />
           </Field>
 
           <div className="flex justify-end gap-2 pt-2">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/dining/DiningAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Pencil, Plus, Trash2, X } from "lucide-react";
+import { Pencil, Plus, Trash2 } from "lucide-react";
 import {
   Button,
   Field,
@@ -12,8 +12,8 @@ import {
   Select,
   Textarea,
 } from "@klorad/design-system";
-import { uploadFile } from "@klorad/storage/client";
 import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
+import { ImagePicker } from "@/app/(dashboard)/components/ImagePicker";
 import { type DiningLocation } from "@/lib/dining-db";
 import { type HoursShift, type Weekday } from "@/lib/dining-hours";
 import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
@@ -185,21 +185,7 @@ export function DiningAdminClient({
   const [menuUrl, setMenuUrl] = useState("");
   const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-
-  const handleImage = async (file: File) => {
-    setUploading(true);
-    try {
-      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.dining });
-      setImageUrl(result.publicUrl);
-    } catch (e) {
-      console.error(e);
-      toast.error("Image upload failed");
-    } finally {
-      setUploading(false);
-    }
-  };
 
   const reset = () => {
     setEditingId(null);
@@ -477,40 +463,16 @@ export function DiningAdminClient({
             />
           </Field>
 
-          <Field label="Image (optional)">
-            {imageUrl ? (
-              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={imageUrl}
-                  alt=""
-                  className="h-16 w-16 rounded-md object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => setImageUrl(null)}
-                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
-                >
-                  <X size={14} strokeWidth={1.75} />
-                </button>
-              </div>
-            ) : (
-              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
-                <Plus size={16} strokeWidth={1.75} />
-                {uploading ? "Uploading…" : "Add image"}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  disabled={uploading}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) void handleImage(file);
-                    e.target.value = "";
-                  }}
-                />
-              </label>
-            )}
+          <Field
+            label="Image (optional)"
+            hint="Pick a stock cover or upload your own."
+          >
+            <ImagePicker
+              value={imageUrl}
+              onChange={setImageUrl}
+              uploadPrefix={UPLOAD_PREFIXES.dining}
+              defaultCategory="dining"
+            />
           </Field>
 
           <div className="flex justify-end gap-2 pt-2">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Pencil, Plus, Trash2, X } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import {
   Button,
   Field,
@@ -12,8 +12,8 @@ import {
   Select,
   Textarea,
 } from "@klorad/design-system";
-import { uploadFile } from "@klorad/storage/client";
 import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
+import { ImagePicker } from "@/app/(dashboard)/components/ImagePicker";
 import {
   formatEventWhen,
   type EventPost,
@@ -79,21 +79,7 @@ export function EventsAdminClient({
   const [organizer, setOrganizer] = useState("");
   const [expectedAttendance, setExpectedAttendance] = useState("");
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-
-  const handleImage = async (file: File) => {
-    setUploading(true);
-    try {
-      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.events });
-      setImageUrl(result.publicUrl);
-    } catch (e) {
-      console.error(e);
-      toast.error("Image upload failed");
-    } finally {
-      setUploading(false);
-    }
-  };
 
   const reset = () => {
     setEditingId(null);
@@ -435,40 +421,16 @@ export function EventsAdminClient({
             </Field>
           </div>
 
-          <Field label="Image (optional)">
-            {imageUrl ? (
-              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={imageUrl}
-                  alt=""
-                  className="h-16 w-16 rounded-md object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => setImageUrl(null)}
-                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
-                >
-                  <X size={14} strokeWidth={1.75} />
-                </button>
-              </div>
-            ) : (
-              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
-                <Plus size={16} strokeWidth={1.75} />
-                {uploading ? "Uploading…" : "Add image"}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  disabled={uploading}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) void handleImage(file);
-                    e.target.value = "";
-                  }}
-                />
-              </label>
-            )}
+          <Field
+            label="Image (optional)"
+            hint="Pick a stock cover or upload your own."
+          >
+            <ImagePicker
+              value={imageUrl}
+              onChange={setImageUrl}
+              uploadPrefix={UPLOAD_PREFIXES.events}
+              defaultCategory="events"
+            />
           </Field>
 
           <div className="flex justify-end gap-2 pt-2">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Image from "next/image";
 import { toast } from "react-toastify";
-import { Pencil, Plus, Trash2, X } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import {
   Button,
   Field,
@@ -12,8 +12,8 @@ import {
   Select,
   Textarea,
 } from "@klorad/design-system";
-import { uploadFile } from "@klorad/storage/client";
 import { UPLOAD_PREFIXES } from "@/lib/uploads/prefixes";
+import { ImagePicker } from "@/app/(dashboard)/components/ImagePicker";
 import {
   formatNewsDate,
   type NewsPost,
@@ -64,21 +64,7 @@ export function NewsAdminClient({
   const [publishedAt, setPublishedAt] = useState(todayISODate());
   const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-
-  const handleImage = async (file: File) => {
-    setUploading(true);
-    try {
-      const result = await uploadFile(file, { prefix: UPLOAD_PREFIXES.news });
-      setImageUrl(result.publicUrl);
-    } catch (e) {
-      console.error(e);
-      toast.error("Image upload failed");
-    } finally {
-      setUploading(false);
-    }
-  };
 
   const reset = () => {
     setEditingId(null);
@@ -341,40 +327,16 @@ export function NewsAdminClient({
             />
           </Field>
 
-          <Field label="Image (optional)">
-            {imageUrl ? (
-              <div className="flex items-center gap-3 rounded-lg border border-solid border-line-soft p-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={imageUrl}
-                  alt=""
-                  className="h-16 w-16 rounded-md object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => setImageUrl(null)}
-                  className="ml-auto flex items-center gap-1 rounded-md p-1 text-text-tertiary hover:bg-surface-2 hover:text-red-600"
-                >
-                  <X size={14} strokeWidth={1.75} />
-                </button>
-              </div>
-            ) : (
-              <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-line-soft px-3 py-2 text-sm text-text-tertiary transition-colors hover:border-accent hover:text-accent">
-                <Plus size={16} strokeWidth={1.75} />
-                {uploading ? "Uploading…" : "Add image"}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  disabled={uploading}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) void handleImage(file);
-                    e.target.value = "";
-                  }}
-                />
-              </label>
-            )}
+          <Field
+            label="Image (optional)"
+            hint="Pick a stock cover or upload your own."
+          >
+            <ImagePicker
+              value={imageUrl}
+              onChange={setImageUrl}
+              uploadPrefix={UPLOAD_PREFIXES.news}
+              defaultCategory="news"
+            />
           </Field>
 
           <div className="flex justify-end gap-2 pt-2">

--- a/apps/campus/lib/sample-seed.ts
+++ b/apps/campus/lib/sample-seed.ts
@@ -15,6 +15,7 @@
  */
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
+import { stockById } from "@/lib/stock-images";
 import type {
   ClubColor,
   EventBanner,
@@ -36,6 +37,9 @@ interface SeedNews {
   category: NewsCategory;
   /** Days ago — turned into a real Date relative to now() at write time. */
   publishedDaysAgo: number;
+  /** Stock image id from `lib/stock-images.ts`. Optional — when set,
+   *  the seeded row lands with the matching public/stock SVG. */
+  stockImage?: string;
   anchors: SeedAnchor[];
 }
 
@@ -53,6 +57,7 @@ interface SeedEvent {
   expectedAttendance: number;
   organizer?: string;
   registrationUrl?: string;
+  stockImage?: string;
   anchors: SeedAnchor[];
 }
 
@@ -67,6 +72,7 @@ interface SeedClub {
   meetsCadence: string;
   externalLink: string;
   popularityScore: number;
+  stockImage?: string;
 }
 
 interface SeedDining {
@@ -81,6 +87,7 @@ interface SeedDining {
   hours: Array<{ day: number; open: string; close: string }>;
   cuisine: string;
   menuUrl?: string;
+  stockImage?: string;
   anchors: SeedAnchor[];
 }
 
@@ -109,6 +116,7 @@ const NEWS: SeedNews[] = [
       "Το Engineering South παραμένει ανοιχτό 24/7 έως τις 9 Ιουνίου. Ησυχία στους ορόφους 2 και 3· δωρεάν καφές στον δεύτερο όροφο κάθε βράδυ από τις 8 μ.μ. Φέρτε τη φοιτητική σας ταυτότητα μετά τις 11 μ.μ.",
     category: "announcement",
     publishedDaysAgo: 3,
+    stockImage: "news-campus",
     anchors: [
       { kind: "building", refId: "", refName: "Engineering South Building" },
     ],
@@ -118,6 +126,7 @@ const NEWS: SeedNews[] = [
     body: "Closed May 28 — June 2 for a kitchen refit. Grab-and-go meals available at the Marketplace in the meantime. The patio remains open for seating.",
     category: "alert",
     publishedDaysAgo: 1,
+    stockImage: "news-megaphone",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
   {
@@ -128,6 +137,7 @@ const NEWS: SeedNews[] = [
       "Έξι νέοι εκτυπωτές έφτασαν την περασμένη εβδομάδα — ελεύθερη πρόσβαση κάθε καθημερινό απόγευμα. Εκπαίδευση την Τρίτη στις 4 μ.μ.· δεν χρειάζεται εγγραφή.",
     category: "news",
     publishedDaysAgo: 7,
+    stockImage: "news-bulletin",
     anchors: [
       { kind: "building", refId: "", refName: "Graphic Arts Building" },
     ],
@@ -137,6 +147,7 @@ const NEWS: SeedNews[] = [
     body: "All-campus fire drill at 10:30 am Wednesday. Plan ~10 minutes outside. Faculty: please assist with attendance at your assembly point.",
     category: "alert",
     publishedDaysAgo: 0,
+    stockImage: "news-megaphone",
     anchors: [
       { kind: "building", refId: "", refName: "Mott Athletics Center" },
       { kind: "building", refId: "", refName: "Engineering South Building" },
@@ -174,6 +185,7 @@ const EVENTS: SeedEvent[] = [
     bannerIcon: "music",
     expectedAttendance: 84,
     organizer: "Student union",
+    stockImage: "events-stage",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
   {
@@ -186,6 +198,7 @@ const EVENTS: SeedEvent[] = [
     bannerIcon: "trophy",
     expectedAttendance: 212,
     organizer: "Intramural sports",
+    stockImage: "events-sports",
     anchors: [
       { kind: "building", refId: "", refName: "Mott Athletics Center" },
     ],
@@ -229,6 +242,7 @@ const EVENTS: SeedEvent[] = [
     bannerIcon: "sprout",
     expectedAttendance: 180,
     organizer: "Student affairs",
+    stockImage: "events-confetti",
     anchors: [
       { kind: "building", refId: "", refName: "1901 Marketplace Building" },
     ],
@@ -290,6 +304,7 @@ const CLUBS: SeedClub[] = [
     meetsCadence: "Meets Wednesdays at 6 pm",
     externalLink: "https://discord.gg/example",
     popularityScore: 90,
+    stockImage: "clubs-circle",
   },
   {
     name: "Film club",
@@ -301,6 +316,7 @@ const CLUBS: SeedClub[] = [
     meetsCadence: "Screenings every Friday at 8 pm",
     externalLink: "https://instagram.com/example",
     popularityScore: 80,
+    stockImage: "clubs-quad",
   },
   {
     name: "Hiking & outdoors",
@@ -312,6 +328,7 @@ const CLUBS: SeedClub[] = [
     meetsCadence: "Trips most Saturdays",
     externalLink: "https://discord.gg/example",
     popularityScore: 85,
+    stockImage: "clubs-hands",
   },
   {
     name: "Sustainability union",
@@ -323,6 +340,7 @@ const CLUBS: SeedClub[] = [
     meetsCadence: "Meets Mondays at 5 pm",
     externalLink: "https://instagram.com/example",
     popularityScore: 70,
+    stockImage: "clubs-circle",
   },
   {
     name: "Chess club",
@@ -363,6 +381,7 @@ const DINING: SeedDining[] = [
       { day: 6, open: "09:00", close: "15:00" },
     ],
     cuisine: "Sandwiches, salads, coffee",
+    stockImage: "dining-salad",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
   {
@@ -372,6 +391,7 @@ const DINING: SeedDining[] = [
     hoursText: "",
     hours: shiftRange(0, 6, "07:00", "21:00"),
     cuisine: "International, fast-casual",
+    stockImage: "dining-pizza",
     anchors: [
       { kind: "building", refId: "", refName: "1901 Marketplace Building" },
     ],
@@ -387,6 +407,7 @@ const DINING: SeedDining[] = [
       { day: 0, open: "08:00", close: "16:00" },
     ],
     cuisine: "Smoothies, bowls",
+    stockImage: "dining-salad",
     anchors: [
       { kind: "building", refId: "", refName: "Mott Athletics Center" },
     ],
@@ -400,6 +421,7 @@ const DINING: SeedDining[] = [
     hoursText: "Late-night window opens at 9 pm",
     hours: shiftRange(0, 6, "11:00", "25:00"),
     cuisine: "Pizza, salads",
+    stockImage: "dining-pizza",
     anchors: [{ kind: "building", refId: "", refName: "Cafe Pavilion" }],
   },
   {
@@ -416,6 +438,7 @@ const DINING: SeedDining[] = [
       { day: 0, open: "10:00", close: "20:00" },
     ],
     cuisine: "Coffee, pastries",
+    stockImage: "dining-coffee",
     anchors: [
       { kind: "building", refId: "", refName: "Engineering South Building" },
     ],
@@ -449,6 +472,7 @@ export async function seedSampleCampus(
     bodyEl: n.bodyEl ?? null,
     category: n.category,
     publishedAt: new Date(now - n.publishedDaysAgo * day),
+    imageUrl: stockById(n.stockImage ?? "")?.url ?? null,
     anchors: n.anchors as unknown as Prisma.InputJsonValue,
   }));
 
@@ -468,6 +492,7 @@ export async function seedSampleCampus(
       expectedAttendance: e.expectedAttendance,
       organizer: e.organizer ?? null,
       registrationUrl: e.registrationUrl ?? null,
+      imageUrl: stockById(e.stockImage ?? "")?.url ?? null,
       anchors: e.anchors as unknown as Prisma.InputJsonValue,
     };
   });
@@ -485,6 +510,8 @@ export async function seedSampleCampus(
     meetsCadence: c.meetsCadence,
     externalLink: c.externalLink,
     popularityScore: c.popularityScore,
+    imageUrl: stockById(c.stockImage ?? "")?.url ?? null,
+    anchors: [] as unknown as Prisma.InputJsonValue,
   }));
 
   const diningRows = DINING.map((d) => ({
@@ -498,6 +525,7 @@ export async function seedSampleCampus(
     hours: d.hours as unknown as Prisma.InputJsonValue,
     cuisine: d.cuisine,
     menuUrl: d.menuUrl ?? null,
+    imageUrl: stockById(d.stockImage ?? "")?.url ?? null,
     anchors: d.anchors as unknown as Prisma.InputJsonValue,
   }));
 

--- a/apps/campus/lib/stock-images.ts
+++ b/apps/campus/lib/stock-images.ts
@@ -1,0 +1,61 @@
+/**
+ * Curated stock image library for the campus content admins. Twelve
+ * bundled SVGs covering news, events, clubs and dining. Used as the
+ * default "Stock" tab in `ImagePicker` and threaded through the
+ * sample seed so a fresh campus opens onto something that already
+ * looks designed.
+ *
+ * Why SVG, not real photos:
+ *   - zero external dependency (no Unsplash quota, no API key, no
+ *     CDN that can go down on demo day)
+ *   - 1-2 KB each — about 0.1% of a real JPG
+ *   - License-clean — drawn in-house, no attribution dance
+ *   - Stay sharp at any card size since the campus cards use the
+ *     same banner image at very different aspect ratios
+ *
+ * Keep the array short — a stock library that feels curated lands
+ * better with rectors than one that requires scrolling.
+ */
+export interface StockImage {
+  id: string;
+  /** Public URL — served from `public/stock/*.svg`. */
+  url: string;
+  /** Which content kind it fits best. The picker filters by this
+   *  so the dining admin opens to dining images, etc. */
+  category: "news" | "events" | "clubs" | "dining";
+  /** Short label shown under the thumbnail. */
+  label: string;
+}
+
+export const STOCK_IMAGES: StockImage[] = [
+  // News
+  { id: "news-bulletin", url: "/stock/news-bulletin.svg", category: "news", label: "Bulletin board" },
+  { id: "news-megaphone", url: "/stock/news-megaphone.svg", category: "news", label: "Announcement" },
+  { id: "news-campus", url: "/stock/news-campus.svg", category: "news", label: "Campus at dusk" },
+  // Events
+  { id: "events-stage", url: "/stock/events-stage.svg", category: "events", label: "Live stage" },
+  { id: "events-confetti", url: "/stock/events-confetti.svg", category: "events", label: "Celebration" },
+  { id: "events-sports", url: "/stock/events-sports.svg", category: "events", label: "Athletics" },
+  // Clubs
+  { id: "clubs-circle", url: "/stock/clubs-circle.svg", category: "clubs", label: "Group circle" },
+  { id: "clubs-hands", url: "/stock/clubs-hands.svg", category: "clubs", label: "Hands joined" },
+  { id: "clubs-quad", url: "/stock/clubs-quad.svg", category: "clubs", label: "On the quad" },
+  // Dining
+  { id: "dining-coffee", url: "/stock/dining-coffee.svg", category: "dining", label: "Coffee" },
+  { id: "dining-pizza", url: "/stock/dining-pizza.svg", category: "dining", label: "Pizza" },
+  { id: "dining-salad", url: "/stock/dining-salad.svg", category: "dining", label: "Salad" },
+];
+
+/** Subset by category — the picker uses this to default to "your
+ *  category" when the modal opens. */
+export function stockByCategory(
+  category: StockImage["category"],
+): StockImage[] {
+  return STOCK_IMAGES.filter((img) => img.category === category);
+}
+
+/** Look up a stock image by URL. Used by the seed to thread URLs
+ *  via id without hardcoding paths twice. */
+export function stockById(id: string): StockImage | undefined {
+  return STOCK_IMAGES.find((img) => img.id === id);
+}

--- a/apps/campus/public/stock/clubs-circle.svg
+++ b/apps/campus/public/stock/clubs-circle.svg
@@ -1,0 +1,40 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Student club gathering in a circle">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b22d68"/>
+      <stop offset="100%" stop-color="#5b1230"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g fill="#ffe2ec">
+    <circle cx="250" cy="170" r="34"/>
+    <rect x="218" y="200" width="64" height="80" rx="14"/>
+  </g>
+  <g fill="#ffd166">
+    <circle cx="345" cy="155" r="34"/>
+    <rect x="313" y="185" width="64" height="80" rx="14"/>
+  </g>
+  <g fill="#9bf6c5">
+    <circle cx="440" cy="160" r="34"/>
+    <rect x="408" y="190" width="64" height="80" rx="14"/>
+  </g>
+  <g fill="#a5d8ff">
+    <circle cx="535" cy="175" r="34"/>
+    <rect x="503" y="205" width="64" height="80" rx="14"/>
+  </g>
+  <g fill="#caa9ff">
+    <circle cx="300" cy="280" r="34"/>
+    <rect x="268" y="310" width="64" height="80" rx="14"/>
+  </g>
+  <g fill="#ffadb0">
+    <circle cx="400" cy="290" r="34"/>
+    <rect x="368" y="320" width="64" height="80" rx="14"/>
+  </g>
+  <g fill="#a0e7ff">
+    <circle cx="500" cy="280" r="34"/>
+    <rect x="468" y="310" width="64" height="80" rx="14"/>
+  </g>
+  <g opacity="0.5" stroke="#ffffff" stroke-width="2" fill="none">
+    <path d="M250 170 Q400 50 535 175"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/clubs-hands.svg
+++ b/apps/campus/public/stock/clubs-hands.svg
@@ -1,0 +1,37 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Hands joined together">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#534ab7"/>
+      <stop offset="100%" stop-color="#251f63"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g transform="translate(120 130)">
+    <g fill="#ffd1ba" transform="translate(30 80) rotate(-30)">
+      <rect x="0" y="0" width="80" height="160" rx="40"/>
+      <rect x="-12" y="0" width="20" height="100" rx="10"/>
+      <rect x="84" y="20" width="22" height="80" rx="10"/>
+    </g>
+    <g fill="#ffe3a6" transform="translate(170 30) rotate(-5)">
+      <rect x="0" y="0" width="80" height="180" rx="40"/>
+      <rect x="-14" y="20" width="20" height="100" rx="10"/>
+      <rect x="80" y="20" width="22" height="90" rx="10"/>
+    </g>
+    <g fill="#ffbf9c" transform="translate(310 30) rotate(5)">
+      <rect x="0" y="0" width="80" height="180" rx="40"/>
+      <rect x="-14" y="20" width="20" height="90" rx="10"/>
+      <rect x="80" y="20" width="22" height="100" rx="10"/>
+    </g>
+    <g fill="#f6cfa0" transform="translate(440 80) rotate(30)">
+      <rect x="0" y="0" width="80" height="160" rx="40"/>
+      <rect x="-14" y="0" width="22" height="80" rx="10"/>
+      <rect x="80" y="0" width="20" height="100" rx="10"/>
+    </g>
+  </g>
+  <g fill="#ffffff" opacity="0.5">
+    <circle cx="180" cy="80" r="6"/>
+    <circle cx="640" cy="120" r="6"/>
+    <circle cx="120" cy="350" r="6"/>
+    <circle cx="700" cy="360" r="6"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/clubs-quad.svg
+++ b/apps/campus/public/stock/clubs-quad.svg
@@ -1,0 +1,35 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Students on the campus quad">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a5d8ff"/>
+      <stop offset="100%" stop-color="#e5b8ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="280" fill="url(#sky)"/>
+  <rect x="0" y="280" width="800" height="170" fill="#5da972"/>
+  <circle cx="660" cy="100" r="50" fill="#ffd166"/>
+  <g fill="#3a7a4d" opacity="0.95">
+    <ellipse cx="120" cy="280" rx="130" ry="30"/>
+    <ellipse cx="430" cy="280" rx="180" ry="30"/>
+    <ellipse cx="680" cy="280" rx="150" ry="30"/>
+  </g>
+  <g fill="#ffffff">
+    <circle cx="270" cy="305" r="14"/>
+    <rect x="258" y="318" width="24" height="40" rx="10"/>
+    <circle cx="330" cy="300" r="14"/>
+    <rect x="318" y="313" width="24" height="44" rx="10"/>
+    <circle cx="390" cy="305" r="14"/>
+    <rect x="378" y="318" width="24" height="40" rx="10"/>
+    <circle cx="510" cy="305" r="14"/>
+    <rect x="498" y="318" width="24" height="40" rx="10"/>
+    <circle cx="570" cy="300" r="14"/>
+    <rect x="558" y="313" width="24" height="44" rx="10"/>
+  </g>
+  <g fill="#3a7a4d">
+    <rect x="260" y="358" width="22" height="40" rx="4"/>
+    <rect x="320" y="357" width="22" height="42" rx="4"/>
+    <rect x="380" y="358" width="22" height="40" rx="4"/>
+    <rect x="500" y="358" width="22" height="40" rx="4"/>
+    <rect x="560" y="357" width="22" height="42" rx="4"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/dining-coffee.svg
+++ b/apps/campus/public/stock/dining-coffee.svg
@@ -1,0 +1,28 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Coffee on a wooden table">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7a4a1a"/>
+      <stop offset="100%" stop-color="#3a210b"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <ellipse cx="400" cy="320" rx="260" ry="60" fill="#4d2a0e"/>
+  <g transform="translate(300 130)">
+    <ellipse cx="100" cy="180" rx="100" ry="14" fill="#1c0c04" opacity="0.55"/>
+    <rect x="20" y="60" width="160" height="120" rx="20" fill="#ffffff"/>
+    <ellipse cx="100" cy="60" rx="80" ry="18" fill="#3a210b"/>
+    <ellipse cx="100" cy="60" rx="80" ry="16" fill="#6a3e16"/>
+    <ellipse cx="100" cy="58" rx="62" ry="10" fill="#c19a76"/>
+    <ellipse cx="100" cy="50" rx="44" ry="6" fill="#ffe5cf"/>
+    <rect x="180" y="80" width="40" height="60" rx="20" fill="none" stroke="#ffffff" stroke-width="10"/>
+  </g>
+  <g fill="#ffffff" opacity="0.6">
+    <path d="M380 60 c-6 12 6 24 0 36 c-6 12 6 24 0 36" stroke="#ffffff" stroke-width="3" fill="none"/>
+    <path d="M410 60 c-6 12 6 24 0 36 c-6 12 6 24 0 36" stroke="#ffffff" stroke-width="3" fill="none"/>
+    <path d="M440 60 c-6 12 6 24 0 36 c-6 12 6 24 0 36" stroke="#ffffff" stroke-width="3" fill="none"/>
+  </g>
+  <g fill="#ffd166" opacity="0.9">
+    <circle cx="170" cy="380" r="14"/>
+    <circle cx="630" cy="380" r="14"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/dining-pizza.svg
+++ b/apps/campus/public/stock/dining-pizza.svg
@@ -1,0 +1,44 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Pizza on a wooden board">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a83e1a"/>
+      <stop offset="100%" stop-color="#5c1c0a"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g transform="translate(400 240)">
+    <circle r="160" fill="#3a210b"/>
+    <circle r="148" fill="#f0d28e"/>
+    <circle r="138" fill="#e8965a"/>
+    <circle r="118" fill="#d9523b"/>
+    <g fill="#fff3df">
+      <circle cx="-60" cy="-30" r="14"/>
+      <circle cx="40" cy="-50" r="14"/>
+      <circle cx="60" cy="40" r="14"/>
+      <circle cx="-30" cy="60" r="14"/>
+      <circle cx="-70" cy="40" r="14"/>
+      <circle cx="30" cy="20" r="14"/>
+    </g>
+    <g fill="#9a2415">
+      <circle cx="-30" cy="-50" r="10"/>
+      <circle cx="60" cy="-10" r="10"/>
+      <circle cx="0" cy="60" r="10"/>
+      <circle cx="-60" cy="20" r="10"/>
+      <circle cx="50" cy="60" r="10"/>
+      <circle cx="-10" cy="-15" r="10"/>
+    </g>
+    <g fill="#4d8d3a">
+      <ellipse cx="-50" cy="-10" rx="8" ry="4"/>
+      <ellipse cx="20" cy="-30" rx="8" ry="4"/>
+      <ellipse cx="40" cy="0" rx="8" ry="4"/>
+      <ellipse cx="-20" cy="30" rx="8" ry="4"/>
+      <ellipse cx="20" cy="50" rx="8" ry="4"/>
+    </g>
+  </g>
+  <g fill="#ffffff" opacity="0.4">
+    <circle cx="120" cy="70" r="6"/>
+    <circle cx="690" cy="80" r="6"/>
+    <circle cx="80" cy="380" r="6"/>
+    <circle cx="700" cy="370" r="6"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/dining-salad.svg
+++ b/apps/campus/public/stock/dining-salad.svg
@@ -1,0 +1,42 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Fresh bowl of salad">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d9e75"/>
+      <stop offset="100%" stop-color="#0a4e38"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g transform="translate(400 240)">
+    <ellipse cx="0" cy="100" rx="180" ry="20" fill="#022518" opacity="0.55"/>
+    <ellipse cx="0" cy="0" rx="180" ry="60" fill="#fefae0"/>
+    <ellipse cx="0" cy="0" rx="160" ry="48" fill="#fff8d6"/>
+    <g>
+      <ellipse cx="-70" cy="-18" rx="36" ry="22" fill="#65b35a"/>
+      <ellipse cx="-30" cy="-26" rx="34" ry="20" fill="#7ec762"/>
+      <ellipse cx="40" cy="-22" rx="40" ry="22" fill="#65b35a"/>
+      <ellipse cx="80" cy="-12" rx="32" ry="18" fill="#7ec762"/>
+      <ellipse cx="-90" cy="-2" rx="32" ry="18" fill="#7ec762"/>
+    </g>
+    <g fill="#d9523b">
+      <circle cx="-50" cy="-10" r="10"/>
+      <circle cx="20" cy="-18" r="10"/>
+      <circle cx="60" cy="-2" r="10"/>
+    </g>
+    <g fill="#ffd166">
+      <ellipse cx="-20" cy="-2" rx="10" ry="6"/>
+      <ellipse cx="40" cy="-16" rx="10" ry="6"/>
+      <ellipse cx="-65" cy="-22" rx="10" ry="6"/>
+    </g>
+    <g fill="#7a4a1a">
+      <rect x="-10" y="-14" width="20" height="8" rx="2"/>
+      <rect x="-46" y="0" width="20" height="8" rx="2"/>
+      <rect x="30" y="0" width="20" height="8" rx="2"/>
+    </g>
+  </g>
+  <g fill="#ffffff" opacity="0.5">
+    <circle cx="120" cy="80" r="6"/>
+    <circle cx="690" cy="100" r="6"/>
+    <circle cx="100" cy="370" r="6"/>
+    <circle cx="700" cy="380" r="6"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/events-confetti.svg
+++ b/apps/campus/public/stock/events-confetti.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Confetti celebration">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#c25700"/>
+      <stop offset="100%" stop-color="#7e2900"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g>
+    <rect x="120" y="80" width="14" height="22" rx="2" fill="#ffd166" transform="rotate(20 127 91)"/>
+    <rect x="200" y="60" width="14" height="22" rx="2" fill="#06d6a0" transform="rotate(-30 207 71)"/>
+    <rect x="300" y="100" width="14" height="22" rx="2" fill="#ef476f" transform="rotate(15 307 111)"/>
+    <rect x="420" y="60" width="14" height="22" rx="2" fill="#118ab2" transform="rotate(-45 427 71)"/>
+    <rect x="520" y="120" width="14" height="22" rx="2" fill="#ffd166" transform="rotate(60 527 131)"/>
+    <rect x="620" y="80" width="14" height="22" rx="2" fill="#06d6a0" transform="rotate(-20 627 91)"/>
+    <rect x="700" y="160" width="14" height="22" rx="2" fill="#ef476f" transform="rotate(40 707 171)"/>
+    <rect x="80" y="220" width="14" height="22" rx="2" fill="#118ab2" transform="rotate(-15 87 231)"/>
+    <rect x="640" y="280" width="14" height="22" rx="2" fill="#ffd166" transform="rotate(70 647 291)"/>
+    <rect x="170" y="340" width="14" height="22" rx="2" fill="#06d6a0" transform="rotate(35 177 351)"/>
+  </g>
+  <g fill="#ffffff" opacity="0.85">
+    <circle cx="400" cy="270" r="80"/>
+  </g>
+  <g fill="#c25700">
+    <rect x="380" y="240" width="40" height="6" rx="2"/>
+    <rect x="380" y="260" width="40" height="6" rx="2"/>
+    <rect x="380" y="280" width="40" height="6" rx="2"/>
+    <circle cx="400" cy="225" r="6"/>
+  </g>
+  <g stroke="#ffffff" stroke-width="3" fill="none" opacity="0.6">
+    <path d="M280 200 Q400 130 520 200"/>
+    <path d="M260 320 Q400 380 540 320"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/events-sports.svg
+++ b/apps/campus/public/stock/events-sports.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Athletic event">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e7c4a"/>
+      <stop offset="60%" stop-color="#0a5d38"/>
+      <stop offset="100%" stop-color="#06381f"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g stroke="#ffffff" stroke-width="3" fill="none" opacity="0.5">
+    <rect x="60" y="80" width="680" height="320"/>
+    <line x1="400" y1="80" x2="400" y2="400"/>
+    <circle cx="400" cy="240" r="60"/>
+    <rect x="60" y="160" width="100" height="160"/>
+    <rect x="640" y="160" width="100" height="160"/>
+  </g>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="400" cy="240" r="32"/>
+  </g>
+  <g fill="#1c1c1c">
+    <polygon points="380,240 400,220 420,240 412,256 388,256"/>
+    <polygon points="368,230 376,210 388,228"/>
+    <polygon points="432,230 424,210 412,228"/>
+    <polygon points="376,266 376,280 392,275"/>
+    <polygon points="424,266 424,280 408,275"/>
+  </g>
+  <g fill="#ffd166" opacity="0.85">
+    <path d="M180 360 c10 -25 35 -25 45 0 l-22 -10 z"/>
+    <path d="M580 100 c10 -25 35 -25 45 0 l-22 -10 z"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/events-stage.svg
+++ b/apps/campus/public/stock/events-stage.svg
@@ -1,0 +1,40 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stage lights at a campus event">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7e3a98"/>
+      <stop offset="100%" stop-color="#391849"/>
+    </linearGradient>
+    <radialGradient id="spot" cx="50%" cy="0%" r="60%">
+      <stop offset="0%" stop-color="#ffd166" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#ffd166" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <polygon points="220,0 280,300 160,300" fill="url(#spot)"/>
+  <polygon points="400,0 460,300 340,300" fill="url(#spot)"/>
+  <polygon points="580,0 640,300 520,300" fill="url(#spot)"/>
+  <rect x="0" y="300" width="800" height="150" fill="#1f0c2c"/>
+  <g fill="#1f0c2c">
+    <circle cx="220" cy="320" r="18"/>
+    <rect x="208" y="330" width="24" height="60" rx="4"/>
+    <circle cx="280" cy="315" r="18"/>
+    <rect x="268" y="325" width="24" height="65" rx="4"/>
+    <circle cx="340" cy="320" r="18"/>
+    <rect x="328" y="330" width="24" height="60" rx="4"/>
+    <circle cx="400" cy="310" r="20"/>
+    <rect x="386" y="322" width="28" height="68" rx="4"/>
+    <circle cx="460" cy="320" r="18"/>
+    <rect x="448" y="330" width="24" height="60" rx="4"/>
+    <circle cx="520" cy="315" r="18"/>
+    <rect x="508" y="325" width="24" height="65" rx="4"/>
+    <circle cx="580" cy="320" r="18"/>
+    <rect x="568" y="330" width="24" height="60" rx="4"/>
+  </g>
+  <g fill="#ffffff" opacity="0.7">
+    <circle cx="120" cy="90" r="3"/>
+    <circle cx="200" cy="60" r="2"/>
+    <circle cx="680" cy="80" r="3"/>
+    <circle cx="600" cy="50" r="2"/>
+    <circle cx="730" cy="160" r="2"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/news-bulletin.svg
+++ b/apps/campus/public/stock/news-bulletin.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bulletin board with announcements">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1976d2"/>
+      <stop offset="100%" stop-color="#0e3a72"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g opacity="0.85">
+    <rect x="120" y="80" width="240" height="290" rx="8" fill="#ffffff"/>
+    <rect x="155" y="115" width="170" height="10" rx="3" fill="#1976d2" opacity="0.6"/>
+    <rect x="155" y="140" width="120" height="6" rx="2" fill="#0e3a72" opacity="0.4"/>
+    <rect x="155" y="170" width="160" height="6" rx="2" fill="#0e3a72" opacity="0.3"/>
+    <rect x="155" y="186" width="140" height="6" rx="2" fill="#0e3a72" opacity="0.3"/>
+    <rect x="155" y="202" width="170" height="6" rx="2" fill="#0e3a72" opacity="0.3"/>
+    <rect x="155" y="240" width="170" height="6" rx="2" fill="#0e3a72" opacity="0.3"/>
+    <rect x="155" y="256" width="150" height="6" rx="2" fill="#0e3a72" opacity="0.3"/>
+    <circle cx="170" cy="320" r="6" fill="#ff5b3a"/>
+  </g>
+  <g opacity="0.6">
+    <rect x="430" y="50" width="240" height="160" rx="8" fill="#ffffff" transform="rotate(-3 550 130)"/>
+    <rect x="455" y="80" width="170" height="10" rx="3" fill="#1976d2" opacity="0.5" transform="rotate(-3 540 85)"/>
+    <rect x="455" y="105" width="190" height="6" rx="2" fill="#0e3a72" opacity="0.3" transform="rotate(-3 550 108)"/>
+    <rect x="455" y="125" width="160" height="6" rx="2" fill="#0e3a72" opacity="0.3" transform="rotate(-3 535 128)"/>
+    <circle cx="475" cy="175" r="5" fill="#22c55e" transform="rotate(-3 475 175)"/>
+  </g>
+  <g opacity="0.75">
+    <rect x="450" y="240" width="240" height="150" rx="8" fill="#ffffff" transform="rotate(2 570 315)"/>
+    <rect x="475" y="270" width="180" height="10" rx="3" fill="#1976d2" opacity="0.6" transform="rotate(2 565 275)"/>
+    <rect x="475" y="295" width="160" height="6" rx="2" fill="#0e3a72" opacity="0.3" transform="rotate(2 555 298)"/>
+    <rect x="475" y="315" width="180" height="6" rx="2" fill="#0e3a72" opacity="0.3" transform="rotate(2 565 318)"/>
+    <circle cx="495" cy="365" r="5" fill="#facc15" transform="rotate(2 495 365)"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/news-campus.svg
+++ b/apps/campus/public/stock/news-campus.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Campus skyline at dusk">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5b5fb3"/>
+      <stop offset="100%" stop-color="#2a2d6e"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <circle cx="650" cy="120" r="48" fill="#ffe97a" opacity="0.85"/>
+  <g fill="#1b1d4a" opacity="0.9">
+    <rect x="90" y="200" width="120" height="190"/>
+    <rect x="230" y="160" width="80" height="230"/>
+    <rect x="330" y="220" width="160" height="170"/>
+    <rect x="510" y="190" width="60" height="200"/>
+    <rect x="590" y="250" width="120" height="140"/>
+    <polygon points="290,160 290,135 270,135 270,160"/>
+    <polygon points="490,220 490,180 460,180 460,220"/>
+  </g>
+  <g fill="#ffe97a" opacity="0.8">
+    <rect x="110" y="225" width="14" height="14"/>
+    <rect x="140" y="225" width="14" height="14"/>
+    <rect x="110" y="255" width="14" height="14"/>
+    <rect x="170" y="255" width="14" height="14"/>
+    <rect x="110" y="285" width="14" height="14"/>
+    <rect x="170" y="285" width="14" height="14"/>
+    <rect x="250" y="195" width="12" height="12"/>
+    <rect x="280" y="195" width="12" height="12"/>
+    <rect x="250" y="245" width="12" height="12"/>
+    <rect x="280" y="245" width="12" height="12"/>
+    <rect x="345" y="245" width="12" height="12"/>
+    <rect x="425" y="245" width="12" height="12"/>
+    <rect x="345" y="295" width="12" height="12"/>
+    <rect x="455" y="295" width="12" height="12"/>
+    <rect x="615" y="280" width="12" height="12"/>
+    <rect x="675" y="280" width="12" height="12"/>
+    <rect x="615" y="325" width="12" height="12"/>
+    <rect x="675" y="325" width="12" height="12"/>
+  </g>
+</svg>

--- a/apps/campus/public/stock/news-megaphone.svg
+++ b/apps/campus/public/stock/news-megaphone.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Announcement megaphone graphic">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0e7c4a"/>
+      <stop offset="100%" stop-color="#073a23"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <g opacity="0.85" transform="translate(220 90)">
+    <path d="M0 95 L120 30 L120 230 L0 165 Z" fill="#ffffff"/>
+    <rect x="120" y="60" width="100" height="140" rx="14" fill="#ffe97a"/>
+    <rect x="220" y="100" width="80" height="60" rx="8" fill="#ff8e3a"/>
+    <circle cx="35" cy="130" r="22" fill="#ff5b3a"/>
+  </g>
+  <g opacity="0.55" stroke="#ffffff" stroke-width="3" fill="none">
+    <path d="M540 100 Q580 130 540 165"/>
+    <path d="M570 80 Q620 130 570 185"/>
+    <path d="M600 60 Q660 130 600 205"/>
+  </g>
+  <g opacity="0.4" fill="#ffffff">
+    <circle cx="100" cy="60" r="10"/>
+    <circle cx="700" cy="100" r="8"/>
+    <circle cx="160" cy="370" r="12"/>
+    <circle cx="660" cy="380" r="9"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
A bundled curated stock library + a "Stock or Upload" picker for every content admin, so a fresh rector lands on something that already looks designed and the seed-sample button populates imagery alongside copy.

## What's in
- **12 SVG illustrations** bundled in `apps/campus/public/stock/`, three per category (news / events / clubs / dining). Drawn in-house — no external dependency, no API key, no quota, ~1 KB each. Stay sharp at any card aspect.
- **`lib/stock-images.ts`** is the manifest: `STOCK_IMAGES` array, `stockByCategory(cat)`, `stockById(id)`. Kept short on purpose; curated reads better than scrollable.
- **`ImagePicker` component**: preview card with Replace + Clear when set, dashed "Add image" button when empty. Opens a Modal with two tabs:
  - **Stock** — category filter chips, click a tile to commit. Defaults to the caller's category (dining admin opens to food, not megaphones).
  - **Upload** — drop zone + file picker, wired to the existing `@klorad/storage` client + the per-category UPLOAD_PREFIX.
- **All four content admins** drop their per-file upload boilerplate (~35 LOC each) in favour of one `<ImagePicker />`. `handleImage` + `uploading` state + `uploadFile` import removed from each.
- **Sample seed** gains an optional `stockImage` field per row, resolved at write time via `stockById`. ~50% of news / events, all six clubs, and every dining row land with a stock cover so the demo opens onto something complete.

## Why bundled SVGs, not Unsplash / a stock library
- Zero external dependency — no quota that hits on demo day, no API key, no CDN that can rate-limit.
- ~1 KB each. The whole library is ~12 KB.
- License-clean — drawn in-house, no attribution dance.
- Sharp at any zoom; campus cards use the same banner at very different aspect ratios.

## What's deferred
- Identity hero is intentionally still on `UploadField` — that screen has a different UX (live phone preview, per-page placeholder fallback) and the stock library would feel out of place. Easy follow-up if a rector asks.

## Test plan
- [ ] `pnpm build` clean (verified).
- [ ] Open `/news` admin → "Add image" opens the modal, defaulted to the News stock category. Pick "Bulletin board" → preview appears, Save persists.
- [ ] Same flow on Events / Clubs / Dining — each defaults to its own category.
- [ ] Switch the picker to "Upload" → drop a file → upload completes via the existing storage client, preview swaps to the new URL.
- [ ] Existing rows with uploaded images still render and can be cleared / replaced.
- [ ] Run `Try with sample data` on a fresh campus → most rows arrive with a stock cover.
- [ ] Public viewer renders the stock SVGs at full bleed on news / events / clubs / dining list cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)