### PR TITLE
feat(campus): saved routes — rector-curated wayfinding chips

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/CampusMapPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/CampusMapPageClient.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Compass, Route } from "lucide-react";
+import { Compass } from "lucide-react";
 import { Panel } from "@klorad/design-system";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
 import { IndoorMapIdCard } from "@/app/(dashboard)/components/IndoorMapIdCard";
 import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
+import { SavedRoutesCard } from "./SavedRoutesCard";
 
 interface Props {
   orgId: string;
@@ -62,34 +63,7 @@ export default function CampusMapPageClient({ orgId: _orgId, mapId }: Props) {
       </div>
 
       <section className="mt-6">
-        <Panel className="rounded-2xl p-6">
-          <div className="mb-4 flex items-start justify-between gap-3">
-            <div>
-              <h2 className="text-sm font-semibold text-text-primary">
-                Saved routes
-              </h2>
-              <p className="mt-0.5 text-xs text-text-tertiary">
-                Pre-computed From → To routes that students can share via QR
-                or deep link.
-              </p>
-            </div>
-          </div>
-          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent-soft text-accent">
-              <Route size={18} strokeWidth={1.6} aria-hidden />
-            </div>
-            <p className="text-sm font-medium text-text-primary">
-              No saved routes yet
-            </p>
-            <p className="max-w-sm text-xs text-text-tertiary">
-              Curate a route — Library → Main Cafeteria, say — and we&rsquo;ll
-              generate a QR code students can scan from a printed sign.
-            </p>
-            <span className="mt-2 text-[10px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
-              Coming next
-            </span>
-          </div>
-        </Panel>
+        <SavedRoutesCard mapId={mapId} />
       </section>
     </div>
   );

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/SavedRoutesCard.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/map/SavedRoutesCard.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import useSWR, { mutate as globalMutate } from "swr";
+import { toast } from "react-toastify";
+import {
+  ArrowRight,
+  Check,
+  Pencil,
+  Plus,
+  Route,
+  Trash2,
+  X,
+} from "lucide-react";
+import { Button, Field, Input, Panel } from "@klorad/design-system";
+import { AnchorPicker, type AnchorValue } from "@/lib/admin/AnchorPicker";
+import {
+  MAX_SAVED_ROUTES,
+  parseSavedRoutes,
+  type SavedRoute,
+} from "@/lib/saved-routes";
+
+interface Props {
+  mapId: string;
+}
+
+interface MapResponse {
+  id: string;
+  sceneData?: Record<string, unknown>;
+}
+
+interface SceneShape {
+  indoorMapId?: string;
+  savedRoutes?: unknown;
+  [k: string]: unknown;
+}
+
+const fetcher = (url: string): Promise<MapResponse> =>
+  fetch(url).then((r) => r.json());
+
+interface DraftRoute {
+  /** Id is empty for a brand-new draft; populated for an edit. */
+  id: string;
+  name: string;
+  nameEl: string;
+  from: AnchorValue;
+  to: AnchorValue;
+  accessible: boolean;
+}
+
+const EMPTY_ANCHOR: AnchorValue = { refName: "", refId: "" };
+const EMPTY_DRAFT: DraftRoute = {
+  id: "",
+  name: "",
+  nameEl: "",
+  from: EMPTY_ANCHOR,
+  to: EMPTY_ANCHOR,
+  accessible: false,
+};
+
+/**
+ * Authoring card for `sceneData.savedRoutes`. List on the left
+ * (compact rows, edit / delete inline), draft form on the right
+ * when the rector clicks "Add route" or the edit pencil. Saves
+ * merge the whole `savedRoutes` array back via the existing
+ * `/api/maps/[mapId]` PATCH route — same pattern as the rest of
+ * sceneData (defaultLocale, klio, etc.).
+ *
+ * AnchorPicker handles the MappedIn space lookup for both stops.
+ * When `indoorMapId` is unset we still render a disabled card so
+ * the rector knows the order: link MappedIn first.
+ */
+export function SavedRoutesCard({ mapId }: Props) {
+  const { data: server } = useSWR<MapResponse>(
+    `/api/maps/${mapId}`,
+    fetcher,
+  );
+
+  const scene = (server?.sceneData ?? {}) as SceneShape;
+  const indoorMapId = scene.indoorMapId ?? null;
+  const savedRoutes = useMemo(
+    () => parseSavedRoutes(scene.savedRoutes),
+    [scene.savedRoutes],
+  );
+
+  const [draft, setDraft] = useState<DraftRoute | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const persist = async (next: SavedRoute[]) => {
+    if (!server || saving) return;
+    setSaving(true);
+    try {
+      const nextScene = { ...(server.sceneData ?? {}), savedRoutes: next };
+      const res = await fetch(`/api/maps/${mapId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sceneData: nextScene }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      await globalMutate(`/api/maps/${mapId}`);
+      return true;
+    } catch {
+      toast.error("Couldn't save routes");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSubmitDraft = async () => {
+    if (!draft) return;
+    if (!draft.name.trim()) {
+      toast.error("Give the route a name");
+      return;
+    }
+    if (!draft.from.refId || !draft.to.refId) {
+      toast.error("Pick both an origin and a destination");
+      return;
+    }
+    if (draft.from.refId === draft.to.refId) {
+      toast.error("Origin and destination must be different");
+      return;
+    }
+    const isNew = !draft.id;
+    if (isNew && savedRoutes.length >= MAX_SAVED_ROUTES) {
+      toast.error(`Max ${MAX_SAVED_ROUTES} saved routes per campus`);
+      return;
+    }
+    const id = draft.id || makeId();
+    const next: SavedRoute = {
+      id,
+      name: draft.name.trim().slice(0, 60),
+      nameEl: draft.nameEl.trim() ? draft.nameEl.trim().slice(0, 60) : undefined,
+      from: { refId: draft.from.refId, refName: draft.from.refName },
+      to: { refId: draft.to.refId, refName: draft.to.refName },
+      accessible: draft.accessible,
+    };
+    const ok = await persist(
+      isNew
+        ? [...savedRoutes, next]
+        : savedRoutes.map((r) => (r.id === id ? next : r)),
+    );
+    if (ok) {
+      setDraft(null);
+      toast.success(isNew ? "Route saved" : "Route updated");
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    const ok = await persist(savedRoutes.filter((r) => r.id !== id));
+    if (ok) toast.success("Route deleted");
+  };
+
+  const editingId = draft?.id ?? null;
+
+  return (
+    <Panel className="rounded-2xl p-6">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
+            <Route size={16} strokeWidth={1.75} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-text-primary">
+              Saved routes
+            </h2>
+            <p className="mt-0.5 text-xs text-text-tertiary">
+              Pre-computed From → To routes that students see as chips on
+              the public map. Up to {MAX_SAVED_ROUTES} per campus.
+            </p>
+          </div>
+        </div>
+        {indoorMapId && !draft ? (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setDraft({ ...EMPTY_DRAFT })}
+            disabled={savedRoutes.length >= MAX_SAVED_ROUTES}
+          >
+            <Plus size={12} strokeWidth={1.75} aria-hidden />
+            Add route
+          </Button>
+        ) : null}
+      </div>
+
+      {!indoorMapId ? (
+        <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+          Link a MappedIn venue first — saved routes pick from real
+          MappedIn spaces.
+        </div>
+      ) : null}
+
+      {indoorMapId ? (
+        <div className="space-y-4">
+          {savedRoutes.length > 0 ? (
+            <ul className="space-y-2 list-none">
+              {savedRoutes.map((r) => (
+                <RouteRow
+                  key={r.id}
+                  route={r}
+                  isEditing={editingId === r.id}
+                  onEdit={() =>
+                    setDraft({
+                      id: r.id,
+                      name: r.name,
+                      nameEl: r.nameEl ?? "",
+                      from: { refId: r.from.refId, refName: r.from.refName },
+                      to: { refId: r.to.refId, refName: r.to.refName },
+                      accessible: r.accessible,
+                    })
+                  }
+                  onDelete={() => void handleDelete(r.id)}
+                />
+              ))}
+            </ul>
+          ) : !draft ? (
+            <div className="rounded-xl border border-dashed border-line-soft bg-surface-2/40 px-4 py-6 text-center text-xs text-text-tertiary">
+              No saved routes yet. Add one — Library → Main Cafeteria,
+              say — and students see it as a chip on the public map.
+            </div>
+          ) : null}
+
+          {draft ? (
+            <DraftForm
+              draft={draft}
+              indoorMapId={indoorMapId}
+              onChange={setDraft}
+              onCancel={() => setDraft(null)}
+              onSubmit={() => void handleSubmitDraft()}
+              saving={saving}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </Panel>
+  );
+}
+
+interface RouteRowProps {
+  route: SavedRoute;
+  isEditing: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function RouteRow({ route, isEditing, onEdit, onDelete }: RouteRowProps) {
+  return (
+    <li
+      className={`flex items-center gap-3 rounded-xl border bg-surface-2/30 p-3 ${
+        isEditing ? "border-accent" : "border-line-soft"
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-text-primary">
+          {route.name}
+          {route.nameEl ? (
+            <span className="ml-2 text-xs font-normal text-text-tertiary">
+              · {route.nameEl}
+            </span>
+          ) : null}
+        </p>
+        <p className="mt-0.5 flex items-center gap-1 truncate text-xs text-text-tertiary">
+          <span>{route.from.refName}</span>
+          <ArrowRight size={11} strokeWidth={1.75} aria-hidden />
+          <span>{route.to.refName}</span>
+          {route.accessible ? (
+            <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
+              Step-free
+            </span>
+          ) : null}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onEdit}
+        aria-label="Edit route"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-text-primary"
+      >
+        <Pencil size={13} strokeWidth={1.75} aria-hidden />
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        aria-label="Delete route"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-red-500"
+      >
+        <Trash2 size={13} strokeWidth={1.75} aria-hidden />
+      </button>
+    </li>
+  );
+}
+
+interface DraftFormProps {
+  draft: DraftRoute;
+  indoorMapId: string;
+  onChange: (next: DraftRoute) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  saving: boolean;
+}
+
+function DraftForm({
+  draft,
+  indoorMapId,
+  onChange,
+  onCancel,
+  onSubmit,
+  saving,
+}: DraftFormProps) {
+  const remainingEn = 60 - draft.name.length;
+  const remainingEl = 60 - draft.nameEl.length;
+  return (
+    <div className="space-y-4 rounded-xl border border-line-soft bg-surface-2/30 p-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field
+          label="Chip name · EN"
+          hint={`${remainingEn} characters left`}
+        >
+          <Input
+            value={draft.name}
+            onChange={(e) =>
+              onChange({ ...draft, name: e.target.value.slice(0, 60) })
+            }
+            placeholder="Library → Cafeteria"
+            maxLength={60}
+          />
+        </Field>
+        <Field
+          label="Chip name · ΕΛ (optional)"
+          hint={`${remainingEl} characters left`}
+        >
+          <Input
+            value={draft.nameEl}
+            onChange={(e) =>
+              onChange({ ...draft, nameEl: e.target.value.slice(0, 60) })
+            }
+            placeholder="Βιβλιοθήκη → Καφέ"
+            maxLength={60}
+          />
+        </Field>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label="From">
+          <AnchorPicker
+            indoorMapId={indoorMapId}
+            value={draft.from}
+            onChange={(v) => onChange({ ...draft, from: v })}
+            placeholder="Pick origin…"
+            ariaLabel="Origin space"
+          />
+        </Field>
+        <Field label="To">
+          <AnchorPicker
+            indoorMapId={indoorMapId}
+            value={draft.to}
+            onChange={(v) => onChange({ ...draft, to: v })}
+            placeholder="Pick destination…"
+            ariaLabel="Destination space"
+          />
+        </Field>
+      </div>
+      <label className="flex items-start gap-3 rounded-xl border border-line-soft bg-surface-1 p-3">
+        <input
+          type="checkbox"
+          checked={draft.accessible}
+          onChange={(e) =>
+            onChange({ ...draft, accessible: e.target.checked })
+          }
+          className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-accent"
+        />
+        <span className="min-w-0">
+          <span className="block text-sm font-medium text-text-primary">
+            Step-free route
+          </span>
+          <span className="mt-0.5 block text-xs text-text-tertiary">
+            MappedIn computes the route avoiding stairs.
+          </span>
+        </span>
+      </label>
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={onCancel}
+          disabled={saving}
+        >
+          <X size={12} strokeWidth={1.75} aria-hidden />
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={onSubmit}
+          disabled={saving}
+        >
+          <Check size={12} strokeWidth={1.75} aria-hidden />
+          {saving ? "Saving…" : draft.id ? "Update route" : "Save route"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Cheap client-side id — no need for cuid here; routes are
+ *  rector-scoped and the `id` only has to be unique within one
+ *  campus's array. Random + timestamp is plenty. */
+function makeId(): string {
+  return (
+    Date.now().toString(36) +
+    "-" +
+    Math.random().toString(36).slice(2, 8)
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/map/MapPageClient.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/MapPageClient.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ChevronDown, ChevronUp, Compass, Search, X } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Compass,
+  Route,
+  Search,
+  X,
+} from "lucide-react";
 // Lucide's `X` is also imported here for the building header's close
 // chip. Renamed to disambiguate from the search-clear button below.
 import {
@@ -28,6 +35,7 @@ import {
   type PickerOption,
 } from "@/lib/consumer/RouteEndpointPicker";
 import type { SpaceOption } from "@/lib/mappedin/WayfindingControls";
+import { routeLabel, type SavedRoute } from "@/lib/saved-routes";
 
 interface Props {
   venue: MappedinVenue;
@@ -38,6 +46,9 @@ interface Props {
   projectId: string;
   campusName: string;
   klioHref: string;
+  /** Rector-defined saved routes — rendered as chips below the
+   *  search bar. Empty when none are configured. */
+  savedRoutes?: SavedRoute[];
 }
 
 const PLACEHOLDER: Record<Locale, string> = {
@@ -104,6 +115,7 @@ export function MapPageClient({
   accentColor,
   projectId,
   campusName,
+  savedRoutes = [],
 }: Props) {
   const viewerRef = useRef<MappedinViewerHandle | null>(null);
   const [buildings, setBuildings] = useState<BuildingsListItem[]>([]);
@@ -455,6 +467,36 @@ export function MapPageClient({
               </button>
             ) : null}
           </div>
+          {savedRoutes.length > 0 ? (
+            <div
+              className="mt-2 flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              role="list"
+              aria-label="Saved routes"
+            >
+              {savedRoutes.map((r) => (
+                <button
+                  key={r.id}
+                  type="button"
+                  role="listitem"
+                  onClick={() => {
+                    setFromId(r.from.refId);
+                    setToId(r.to.refId);
+                    setAccessible(r.accessible);
+                    setRouteMode(true);
+                  }}
+                  className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-white px-3 py-1.5 text-xs font-medium text-[var(--brand-text)] shadow-sm transition-opacity hover:opacity-80"
+                >
+                  <Route
+                    size={12}
+                    strokeWidth={1.75}
+                    aria-hidden
+                    className="text-[var(--brand-primary)]"
+                  />
+                  {routeLabel(r, locale)}
+                </button>
+              ))}
+            </div>
+          ) : null}
         </div>
       )}
 

--- a/apps/campus/app/(public)/campus/[token]/map/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/lib/i18n-core";
 import NotPublishedPlaceholder from "../NotPublishedPlaceholder";
 import { MapPageClient } from "./MapPageClient";
+import { parseSavedRoutes } from "@/lib/saved-routes";
 
 type Params = Promise<{ token: string }>;
 type Search = Promise<{
@@ -43,7 +44,9 @@ export default async function CampusMapPage({
     indoorMapId?: string;
     branding?: { primaryColor?: string; name?: string; logo?: string };
     defaultLocale?: unknown;
+    savedRoutes?: unknown;
   } | null;
+  const savedRoutes = parseSavedRoutes(scene?.savedRoutes);
   const locale = detectLocale(
     typeof sp.lang === "string" ? sp.lang : null,
     pickDefaultLocale(scene?.defaultLocale),
@@ -79,6 +82,7 @@ export default async function CampusMapPage({
           projectId={map.id}
           campusName={campusName}
           klioHref={`/campus/${token}/klio${lang}`}
+          savedRoutes={savedRoutes}
         />
       </main>
     );

--- a/apps/campus/lib/saved-routes.ts
+++ b/apps/campus/lib/saved-routes.ts
@@ -1,0 +1,91 @@
+/**
+ * Saved routes — rector-defined named walking tours through the
+ * campus's MappedIn spaces. Surfaced as chips on the public map
+ * (`Library → Main Cafeteria`, `Accessible route to the Gym`, etc.);
+ * tapping a chip fires the existing from→to wayfinding pipeline.
+ *
+ * Persisted under `Project.sceneData.savedRoutes`. Same merge
+ * pattern as `defaultLocale` and `klio` config.
+ *
+ * MVP scope: two stops per route (origin + destination), plus an
+ * accessible-routing flag. The MappedIn viewer's `route(from, to)`
+ * doesn't natively chain multi-stop tours, so a real waypoint
+ * route would draw N segments one after another — a separate arc.
+ */
+
+export type Locale = "en" | "el";
+
+/** A single stop. References a MappedIn space the rector picked via
+ *  the existing `AnchorPicker`. `refId` is the MappedIn space id;
+ *  `refName` is the human label cached at authoring time so the chip
+ *  reads correctly even when MappedIn's API is slow. */
+export interface SavedRouteStop {
+  refId: string;
+  refName: string;
+}
+
+export interface SavedRoute {
+  /** Stable id — set once on creation, never reused. Used as the
+   *  React key and the chip's data-route-id attribute. */
+  id: string;
+  /** EN name — required. Falls back to the chip label when EL is
+   *  unset. Capped at 60 chars to keep the chip pill-sized. */
+  name: string;
+  /** EL name — optional. */
+  nameEl?: string;
+  /** Origin space. */
+  from: SavedRouteStop;
+  /** Destination space. */
+  to: SavedRouteStop;
+  /** Draw the step-free variant when true. */
+  accessible: boolean;
+}
+
+/** Hard cap so a buggy rector can't ship a 200-chip strip that
+ *  scrolls forever on the public map. */
+export const MAX_SAVED_ROUTES = 8;
+
+/** Narrow `sceneData.savedRoutes` (Prisma `Json`) into a validated
+ *  `SavedRoute[]`. Anything malformed is silently filtered — better
+ *  to lose one row than to crash the dashboard. */
+export function parseSavedRoutes(value: unknown): SavedRoute[] {
+  if (!Array.isArray(value)) return [];
+  const out: SavedRoute[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const id = typeof e.id === "string" ? e.id : "";
+    const name = typeof e.name === "string" ? e.name.trim() : "";
+    const from = parseStop(e.from);
+    const to = parseStop(e.to);
+    if (!id || !name || !from || !to) continue;
+    const nameEl =
+      typeof e.nameEl === "string" && e.nameEl.trim().length > 0
+        ? e.nameEl.trim().slice(0, 60)
+        : undefined;
+    out.push({
+      id,
+      name: name.slice(0, 60),
+      nameEl,
+      from,
+      to,
+      accessible: e.accessible === true,
+    });
+  }
+  return out.slice(0, MAX_SAVED_ROUTES);
+}
+
+function parseStop(value: unknown): SavedRouteStop | null {
+  if (!value || typeof value !== "object") return null;
+  const e = value as Record<string, unknown>;
+  const refId = typeof e.refId === "string" ? e.refId.trim() : "";
+  const refName = typeof e.refName === "string" ? e.refName.trim() : "";
+  if (!refId || !refName) return null;
+  return { refId, refName: refName.slice(0, 80) };
+}
+
+/** Pick the right locale's label for a chip. Falls back to EN. */
+export function routeLabel(route: SavedRoute, locale: Locale): string {
+  if (locale === "el" && route.nameEl?.trim()) return route.nameEl;
+  return route.name;
+}


### PR DESCRIPTION
## Summary
- Rectors can curate up to 8 named walking routes between two MappedIn spaces (bilingual labels, optional accessible flag) from the Map & Wayfinding screen.
- The public map renders saved routes as tappable chips beneath the search bar; tapping a chip seeds from/to/accessible and enters the existing route mode.
- Persisted under \`Project.sceneData.savedRoutes\` via the same merge-then-PATCH pattern as \`defaultLocale\` / \`klio\`.

## Why this shape
- Reuses the existing \`AnchorPicker\` for stop selection — no new MappedIn machinery.
- Cached \`refName\` per stop so chips read correctly even when MappedIn's API is slow.
- Parser silently drops malformed rows; cap at \`MAX_SAVED_ROUTES = 8\` so a buggy rector can't ship a 200-chip strip.
- MVP intentionally limits each route to two stops — \`route(from, to)\` doesn't natively chain segments. Multi-stop tours are a separate arc.

## Test plan
- [ ] Open Map & Wayfinding for a campus with \`indoorMapId\` set, add a route with EN + EL names and Accessible toggled.
- [ ] Refresh — the route persists; edit changes one row, delete removes it.
- [ ] On the public map, the chip strip appears below the search bar (only when at least one saved route exists).
- [ ] Tapping a chip enters route mode with the right origin, destination, and accessible setting.
- [ ] Verify the EN/EL labels swap with the public viewer's language toggle.
- [ ] Map & Wayfinding card disables the editor when no \`indoorMapId\` is set yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)