### PR TITLE
fix(campus): public consumer page wasn't exposing the notification bell

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/page.tsx
@@ -264,6 +264,7 @@ export default async function CampusHomePage({
       events={events}
       clubs={clubs}
       dining={dining}
+      vapidPublicKey={process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY}
     />
   );
 }


### PR DESCRIPTION
## Summary
- One-line fix: pass `vapidPublicKey={process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY}` from the public consumer page into `<ConsumerHome>`.

## Why broadcasts were going to 0 subscribers
- `NotificationButton` ([lib/consumer/NotificationButton.tsx:47, 63](apps/campus/lib/consumer/NotificationButton.tsx)) silently returns `null` when `vapidPublicKey` is falsy — one of the documented "silent-disable" gates.
- The public page (`app/(public)/campus/[token]/page.tsx`) never passed the prop down, so the bell never rendered on any tenant.
- Installing the PWA to the home screen ≠ subscribing to push. The browser only prompts for Notification permission when `pushManager.subscribe` is called inside a user gesture — i.e. tapping the bell. No bell → no permission prompt → no rows in `PushSubscription` → `sendPushToProject` queries `findMany({ where: { projectId } })` and gets `[]`.
- Reach (dashboard) was already wired correctly. The public consumer page was the missing leg.

## Test plan
- [ ] Open a published campus's public home in a browser that supports Push (Chrome / Edge / Safari 16+).
- [ ] Confirm the "Get notifications" bell now renders.
- [ ] Tap it, grant permission, observe a row in `PushSubscription` for that `projectId`.
- [ ] From the dashboard's Reach screen, send a broadcast and confirm subscriber count is non-zero and the device receives the push.
- [ ] Tap the bell again to unsubscribe; the row is removed via DELETE `/api/push/subscribe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)