### PR TITLE
feat(campus): public images on news + events, per-route loading skeletons

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/clubs/loading.tsx
+++ b/apps/campus/app/(public)/campus/[token]/clubs/loading.tsx
@@ -1,0 +1,10 @@
+import { ExploreLoadingShell } from "@/lib/consumer/ExploreLoadingShell";
+import { ClubsListSkeleton } from "@/lib/consumer/ClubsListSkeleton";
+
+export default function ClubsLoading() {
+  return (
+    <ExploreLoadingShell activeTabIndex={2}>
+      <ClubsListSkeleton rows={6} />
+    </ExploreLoadingShell>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/dining/loading.tsx
+++ b/apps/campus/app/(public)/campus/[token]/dining/loading.tsx
@@ -1,0 +1,10 @@
+import { ExploreLoadingShell } from "@/lib/consumer/ExploreLoadingShell";
+import { DiningListSkeleton } from "@/lib/consumer/DiningListSkeleton";
+
+export default function DiningLoading() {
+  return (
+    <ExploreLoadingShell activeTabIndex={3}>
+      <DiningListSkeleton rows={4} />
+    </ExploreLoadingShell>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/events/loading.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/loading.tsx
@@ -1,0 +1,10 @@
+import { ExploreLoadingShell } from "@/lib/consumer/ExploreLoadingShell";
+import { EventsListSkeleton } from "@/lib/consumer/EventsListSkeleton";
+
+export default function EventsLoading() {
+  return (
+    <ExploreLoadingShell activeTabIndex={1}>
+      <EventsListSkeleton rows={6} />
+    </ExploreLoadingShell>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/klio/loading.tsx
+++ b/apps/campus/app/(public)/campus/[token]/klio/loading.tsx
@@ -1,0 +1,25 @@
+/**
+ * Skeleton for the Klio chat surface. The real screen is a
+ * full-bleed chat column with an input chip pinned at the bottom;
+ * the placeholder shells out that same shape so the chat input
+ * doesn't pop in late.
+ */
+export default function KlioLoading() {
+  return (
+    <main
+      aria-hidden
+      className="flex h-[calc(100dvh-3.5rem)] w-full flex-col bg-[var(--brand-page)]"
+    >
+      <div className="mx-auto flex w-full max-w-[820px] flex-1 flex-col gap-4 px-4 py-8 md:px-6">
+        <div className="h-8 w-40 animate-pulse rounded-md bg-[var(--brand-line)]" />
+        <div className="h-4 w-64 animate-pulse rounded-md bg-[var(--brand-line)]" />
+        <div className="mt-6 flex flex-1 flex-col gap-3">
+          <div className="h-16 w-3/4 animate-pulse rounded-2xl bg-white" />
+          <div className="ml-auto h-12 w-1/2 animate-pulse rounded-2xl bg-[color-mix(in_srgb,var(--brand-primary)_15%,#ffffff)]" />
+          <div className="h-20 w-2/3 animate-pulse rounded-2xl bg-white" />
+        </div>
+        <div className="mt-4 h-12 w-full animate-pulse rounded-full bg-white shadow-sm" />
+      </div>
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/map/loading.tsx
+++ b/apps/campus/app/(public)/campus/[token]/map/loading.tsx
@@ -1,0 +1,21 @@
+/**
+ * Skeleton for the public map route. The real surface fills the
+ * remaining viewport (`100dvh - 3.5rem` for the ConsumerNav), so we
+ * mirror that bound exactly to avoid a layout shift the moment the
+ * MappedIn viewer mounts.
+ */
+export default function MapLoading() {
+  return (
+    <main
+      aria-hidden
+      className="flex h-[calc(100dvh-3.5rem)] w-full flex-col bg-[var(--brand-page)]"
+    >
+      <div className="bg-[var(--brand-page)] px-4 pt-3 pb-3 md:px-6">
+        <div className="h-11 w-full animate-pulse rounded-full bg-white shadow-sm" />
+      </div>
+      <div className="min-h-0 flex-1 md:px-6 md:pt-3">
+        <div className="h-full w-full animate-pulse overflow-hidden bg-white md:rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/news/loading.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/loading.tsx
@@ -1,0 +1,10 @@
+import { ExploreLoadingShell } from "@/lib/consumer/ExploreLoadingShell";
+import { NewsListSkeleton } from "@/lib/consumer/NewsListSkeleton";
+
+export default function NewsLoading() {
+  return (
+    <ExploreLoadingShell activeTabIndex={0}>
+      <NewsListSkeleton rows={6} />
+    </ExploreLoadingShell>
+  );
+}

--- a/apps/campus/app/(public)/campus/[token]/news/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/page.tsx
@@ -90,6 +90,7 @@ export default async function NewsPage({
     title: pickText(p.title, locale) || "",
     body: pickText(p.body, locale) || "",
     publishedAt: p.publishedAt,
+    imageUrl: null,
     anchors: p.place
       ? [
           {

--- a/apps/campus/lib/consumer/EventsListClient.tsx
+++ b/apps/campus/lib/consumer/EventsListClient.tsx
@@ -97,17 +97,29 @@ export function EventsListClient({
             href={href}
             className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
           >
-            <div
-              className="flex h-20 items-end justify-start p-4"
-              style={stripedBanner(accent)}
-            >
-              <Calendar
-                size={24}
-                strokeWidth={1.5}
-                style={{ color: accent }}
-                aria-hidden
-              />
-            </div>
+            {e.imageUrl ? (
+              <div className="relative aspect-[16/9] w-full overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={e.imageUrl}
+                  alt=""
+                  loading="lazy"
+                  className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                />
+              </div>
+            ) : (
+              <div
+                className="flex h-20 items-end justify-start p-4"
+                style={stripedBanner(accent)}
+              >
+                <Calendar
+                  size={24}
+                  strokeWidth={1.5}
+                  style={{ color: accent }}
+                  aria-hidden
+                />
+              </div>
+            )}
             <div className="flex flex-1 flex-col gap-2 p-5">
               <h2 className="text-base font-medium text-[var(--brand-text)]">
                 {e.title}

--- a/apps/campus/lib/consumer/ExploreLoadingShell.tsx
+++ b/apps/campus/lib/consumer/ExploreLoadingShell.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared skeleton chrome for the four Explore sub-routes (news,
+ * events, clubs, dining). Mirrors the real page's hero + pill-strip
+ * + subtitle so route transitions feel like the same surface
+ * updating, not a wholesale teardown — the SegmentedTabs underneath
+ * each page would otherwise unmount mid-flight and reflow the
+ * viewport.
+ *
+ * The active-tab placeholder accepts a 0-3 index so each `loading.tsx`
+ * can fill the right pill without needing access to URL state (which
+ * `loading.tsx` doesn't receive in the App Router).
+ */
+export function ExploreLoadingShell({
+  activeTabIndex,
+  children,
+}: {
+  activeTabIndex: 0 | 1 | 2 | 3;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      aria-hidden
+      className="mx-auto max-w-[820px] px-4 py-8 md:px-6 md:py-12"
+    >
+      <div className="h-9 w-32 animate-pulse rounded-md bg-[var(--brand-line)]" />
+      <nav className="mt-6 flex items-center gap-1 overflow-x-auto rounded-full border border-[var(--brand-line)] bg-white p-1">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={
+              i === activeTabIndex
+                ? "h-9 w-20 animate-pulse rounded-full bg-[color-mix(in_srgb,var(--brand-primary)_30%,#ffffff)]"
+                : "h-9 w-20 rounded-full"
+            }
+          />
+        ))}
+      </nav>
+      <div className="mt-4 h-4 w-48 animate-pulse rounded-md bg-[var(--brand-line)]" />
+      {children}
+    </section>
+  );
+}

--- a/apps/campus/lib/consumer/NewsListClient.tsx
+++ b/apps/campus/lib/consumer/NewsListClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { MapPin } from "lucide-react";
+import { MapPin, Newspaper } from "lucide-react";
 import { pickLocalized, type Locale } from "@/app/lib/i18n-core";
 import { relativeNewsTime, type NewsPost } from "@/lib/news";
 import { useCampusNews } from "@/lib/swr/useCampusNews";
@@ -12,6 +12,7 @@ interface LegacyDisplay {
   title: string;
   body: string;
   publishedAt: string;
+  imageUrl: string | null;
   anchors: Array<{ kind: "room" | "building"; refId: string; refName: string }>;
   detailHref: string;
 }
@@ -55,6 +56,7 @@ export function NewsListClient({
       title: pickLocalized(p.title, p.titleEl, locale),
       body: pickLocalized(p.body, p.bodyEl, locale),
       publishedAt: p.publishedAt,
+      imageUrl: p.imageUrl,
       anchors: p.anchors.map((a) => ({
         kind: a.kind,
         refId: a.refId,
@@ -82,27 +84,44 @@ export function NewsListClient({
   }
 
   return (
-    <div className="mt-6">
+    <div className="mt-6 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
       {merged.map((n) => (
         <article
           key={n.id}
-          className="border-b border-[var(--brand-line)] py-5 last:border-b-0"
+          className="flex flex-col overflow-hidden rounded-2xl border border-[var(--brand-line)] bg-white transition-colors hover:border-[var(--brand-primary)]"
         >
-          <Link href={n.detailHref} className="group block">
-            <h2 className="text-base font-medium text-[var(--brand-text)] transition-colors group-hover:text-[var(--brand-primary)]">
-              {n.title}
-            </h2>
-            <p className="mt-1 line-clamp-3 text-sm leading-relaxed text-[var(--brand-text-muted)]">
-              {n.body}
-            </p>
-            <div className="mt-2 flex flex-wrap items-center gap-3 text-[0.7rem] uppercase tracking-wide text-[var(--brand-text-muted)]">
-              <span>{relativeNewsTime(n.publishedAt)}</span>
-              {n.anchors[0] ? (
-                <span className="inline-flex items-center gap-1 normal-case tracking-normal">
-                  <MapPin size={12} strokeWidth={1.75} />
-                  {n.anchors[0].refName}
-                </span>
-              ) : null}
+          <Link href={n.detailHref} className="group flex flex-1 flex-col">
+            <div className="relative aspect-[16/9] w-full overflow-hidden bg-[color-mix(in_srgb,var(--brand-primary)_6%,#ffffff)]">
+              {n.imageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={n.imageUrl}
+                  alt=""
+                  loading="lazy"
+                  className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-[var(--brand-primary)]/40">
+                  <Newspaper size={28} strokeWidth={1.5} aria-hidden />
+                </div>
+              )}
+            </div>
+            <div className="flex flex-1 flex-col gap-2 p-5">
+              <h2 className="text-base font-medium text-[var(--brand-text)] transition-colors group-hover:text-[var(--brand-primary)]">
+                {n.title}
+              </h2>
+              <p className="line-clamp-3 text-sm leading-relaxed text-[var(--brand-text-muted)]">
+                {n.body}
+              </p>
+              <div className="mt-auto flex flex-wrap items-center gap-3 pt-2 text-[0.7rem] uppercase tracking-wide text-[var(--brand-text-muted)]">
+                <span>{relativeNewsTime(n.publishedAt)}</span>
+                {n.anchors[0] ? (
+                  <span className="inline-flex items-center gap-1 normal-case tracking-normal">
+                    <MapPin size={12} strokeWidth={1.75} />
+                    {n.anchors[0].refName}
+                  </span>
+                ) : null}
+              </div>
             </div>
           </Link>
         </article>

--- a/apps/campus/lib/consumer/types.ts
+++ b/apps/campus/lib/consumer/types.ts
@@ -38,6 +38,9 @@ export interface ConsumerEvent {
   bannerColor: AccentName;
   /** Lucide icon name used on the banner. */
   bannerIcon: "music" | "trophy" | "sprout" | "calendar";
+  /** Optional hero image — rendered above the title when present;
+   *  falls back to the striped banner + icon when null. */
+  imageUrl?: string | null;
   anchors: ConsumerAnchor[];
   /** Vanity admin-set "expected attendance" — see [[campus-consumer-pivot]]. */
   expectedAttendance?: number;

--- a/apps/campus/lib/events-merge.ts
+++ b/apps/campus/lib/events-merge.ts
@@ -30,6 +30,7 @@ export function eventPostToConsumer(e: EventPost): ConsumerEvent {
     endsAt: e.endsAt,
     bannerColor: e.bannerColor,
     bannerIcon: e.bannerIcon,
+    imageUrl: e.imageUrl,
     anchors: e.anchors.map((a) => ({
       kind: a.kind,
       refId: a.refId,
@@ -49,6 +50,7 @@ export function icsToConsumer(e: CampusEvent): ConsumerEvent {
     endsAt: e.end,
     bannerColor: "teal",
     bannerIcon: "calendar",
+    imageUrl: null,
     anchors: e.location
       ? [{ kind: "building", refId: "", refName: e.location }]
       : [],


### PR DESCRIPTION
## Summary
- **News + events lists** now render the `imageUrl` the dashboard already saves. Clubs and dining were already wired; news and events were the missing legs.
- **Per-route `loading.tsx`** for each main-nav and explore-sub-tab destination, so soft-navs show the right shaped skeleton instantly — not the generic 6-card fallback that lived on the layout.

## What renders the image now
| Surface | Before | Now |
|---|---|---|
| News list (`/campus/[token]/news`) | Stacked text-only rows | 16:9 image-card grid (1/2/3-col responsive), matches the existing skeleton; Newspaper-glyph fallback when null |
| Events list (`/campus/[token]/events`) | Striped Calendar banner always | 16:9 hero image when `imageUrl` is set; striped banner is the fallback for ICS-feed events and unset rows |
| News detail | Already rendered | Unchanged |
| Events detail | Already rendered | Unchanged |
| Clubs / Dining | Already rendered | Unchanged |

`ConsumerEvent` + `mergeEvents` now carry `imageUrl` end-to-end so the events rail on home and the events list share one source of truth.

## Skeletons — new files
- `lib/consumer/ExploreLoadingShell.tsx` — shared chrome (hero placeholder + pill-strip with the active tab pre-highlighted + subtitle) so the four explore tabs feel like one surface updating, not a teardown.
- `app/(public)/campus/[token]/news/loading.tsx` → `ExploreLoadingShell + NewsListSkeleton`
- `app/(public)/campus/[token]/events/loading.tsx` → `+ EventsListSkeleton`
- `app/(public)/campus/[token]/clubs/loading.tsx` → `+ ClubsListSkeleton`
- `app/(public)/campus/[token]/dining/loading.tsx` → `+ DiningListSkeleton`
- `app/(public)/campus/[token]/map/loading.tsx` — search-chip + full-bleed viewer placeholder, sized to `100dvh - 3.5rem` so the MappedIn viewer slots in without reflow.
- `app/(public)/campus/[token]/klio/loading.tsx` — chat column + pinned input placeholder.

Per-route `loading.tsx` files take precedence over the existing layout-level one, so home (`/campus/[token]`) still falls back to the generic skeleton — it loads fast enough that a tailored one was unnecessary.

## Why segmented tabs are baked into the skeleton
`SegmentedTabs` lives on each page (not in the layout), so on soft-nav between news ↔ events the real component unmounts. Without something tab-shaped in `loading.tsx`, the strip would flash gone, then re-appear half a second later. The shell pre-renders four pill placeholders with the right one filled in — no flash, no reflow.

## Test plan
- [ ] Upload an image on a news post in the dashboard → public `/campus/[token]/news` shows it in the card grid.
- [ ] Upload an image on an event → public `/campus/[token]/events` shows it instead of the striped banner.
- [ ] Posts/events without images render the Newspaper / Calendar fallback.
- [ ] Click between News / Events / Clubs / Dining on the public surface — the segmented strip stays put through the transition, the active pill is the new tab from the moment the click registers, and the skeleton matches the list it's about to load.
- [ ] Click Map from the bottom nav → search chip + viewer skeleton instead of the generic 6-card grid.
- [ ] Klio same — chat column + input skeleton.
- [ ] First load (hard refresh) on any of these still SSR's real content; loading.tsx only shows on soft-nav (verify there's no skeleton flash on hard refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)