### PR TITLE
feat(crawler): phase 1 — agentic news+events extractor MVP

### DIFF
--- a/apps/campus/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/campus/app/(dashboard)/components/DashboardShell.tsx
@@ -24,6 +24,7 @@ import {
   Settings,
   Sparkles,
   Sun,
+  Telescope,
   Users,
   Utensils,
 } from "lucide-react";
@@ -237,6 +238,12 @@ function campusNavGroups(
           href: `${prefix}/klio`,
           icon: <Sparkles size={16} strokeWidth={1.7} />,
           active: is("/klio"),
+        },
+        {
+          label: "Discovered",
+          href: `${prefix}/discovered`,
+          icon: <Telescope size={16} strokeWidth={1.7} />,
+          active: is("/discovered"),
         },
       ],
     },

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/discovered/DiscoveredPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/discovered/DiscoveredPageClient.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { toast } from "react-toastify";
+import {
+  Calendar,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  Newspaper,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+import { Panel } from "@klorad/design-system";
+import { CRAWLER_DEMO_LIMITS } from "@klorad/crawler/limits";
+import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
+
+type ContentType = "news" | "event";
+
+interface DiscoveredItemRow {
+  id: string;
+  sourceUrl: string;
+  contentType: ContentType;
+  extracted: Record<string, unknown>;
+  createdAt: string;
+  job: { startedAt: string; instructions: string | null };
+}
+
+interface DiscoveredResponse {
+  items: DiscoveredItemRow[];
+  countsByType: Record<string, number>;
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (r) => {
+    if (!r.ok) throw new Error(await r.text());
+    return (await r.json()) as DiscoveredResponse;
+  });
+
+export default function DiscoveredPageClient({
+  mapId,
+  crawlerConfigured,
+}: {
+  mapId: string;
+  crawlerConfigured: boolean;
+}) {
+  const [activeTab, setActiveTab] = useState<ContentType>("news");
+  const [urlText, setUrlText] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const { data, isLoading, mutate } = useSWR<DiscoveredResponse>(
+    `/api/maps/${mapId}/crawler/discovered`,
+    fetcher,
+    { revalidateOnFocus: false },
+  );
+
+  const items = data?.items ?? [];
+  const newsCount = data?.countsByType.news ?? 0;
+  const eventCount = data?.countsByType.event ?? 0;
+  const filtered = items.filter((i) => i.contentType === activeTab);
+
+  const startCrawl = async () => {
+    const urls = urlText
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (urls.length === 0) {
+      toast.error("Paste at least one URL.");
+      return;
+    }
+    if (urls.length > CRAWLER_DEMO_LIMITS.maxUrlsPerJob) {
+      toast.error(
+        `Demo cap is ${CRAWLER_DEMO_LIMITS.maxUrlsPerJob} URLs per crawl.`,
+      );
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/maps/${mapId}/crawler/jobs`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ urls, instructions: instructions || undefined }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Crawl failed");
+      toast.success(
+        `Crawl done — ${body.itemsCreated} item${
+          body.itemsCreated === 1 ? "" : "s"
+        } extracted.`,
+      );
+      setUrlText("");
+      setInstructions("");
+      mutate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Crawl failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onApprove = async (id: string) => {
+    try {
+      const res = await fetch(`/api/crawler/discovered/${id}/approve`, {
+        method: "POST",
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Approval failed");
+      toast.success("Approved.");
+      mutate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Approval failed");
+    }
+  };
+
+  const onReject = async (id: string) => {
+    try {
+      const res = await fetch(`/api/crawler/discovered/${id}/reject`, {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error(await res.text());
+      toast.success("Rejected.");
+      mutate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Reject failed");
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[1200px] px-6 py-8 md:px-10">
+      <PageHeader
+        eyebrow="Agentic crawler"
+        title="Discovered"
+        subtitle="Pull news and events from the web; approve what's real, drop what isn't."
+      />
+
+      {!crawlerConfigured ? (
+        <Panel className="mb-6 rounded-2xl p-6">
+          <p className="text-sm text-text-secondary">
+            Crawler not configured. Set <code>FIRECRAWL_API_KEY</code> and{" "}
+            <code>ANTHROPIC_API_KEY</code> in this environment to enable the
+            Start crawl button.
+          </p>
+        </Panel>
+      ) : null}
+
+      {/* Start crawl form */}
+      <Panel className="mb-8 rounded-2xl p-6">
+        <div className="mb-4 flex items-center gap-2">
+          <Sparkles
+            size={16}
+            strokeWidth={1.75}
+            className="text-accent"
+            aria-hidden
+          />
+          <h2 className="text-sm font-semibold text-text-primary">
+            Start a crawl
+          </h2>
+          <span className="ml-auto text-xs text-text-tertiary">
+            Demo cap: {CRAWLER_DEMO_LIMITS.maxUrlsPerJob} URLs / crawl,{" "}
+            {CRAWLER_DEMO_LIMITS.maxPendingItems} items in inbox
+          </span>
+        </div>
+
+        <label className="mb-3 block">
+          <span className="mb-1 block text-xs font-medium text-text-secondary">
+            URLs (one per line)
+          </span>
+          <textarea
+            value={urlText}
+            onChange={(e) => setUrlText(e.target.value)}
+            rows={4}
+            placeholder="https://example.edu/news/some-article&#10;https://example.edu/events/spring-2026"
+            className="w-full rounded-xl border border-line-soft bg-white px-3 py-2 font-mono text-xs leading-relaxed text-text-primary focus:border-accent focus:outline-none"
+            disabled={submitting || !crawlerConfigured}
+          />
+        </label>
+
+        <label className="mb-4 block">
+          <span className="mb-1 block text-xs font-medium text-text-secondary">
+            Instructions (optional)
+          </span>
+          <textarea
+            value={instructions}
+            onChange={(e) =>
+              setInstructions(
+                e.target.value.slice(
+                  0,
+                  CRAWLER_DEMO_LIMITS.maxInstructionsLength,
+                ),
+              )
+            }
+            rows={2}
+            placeholder="e.g. Only extract items from the past 30 days. Skip alumni news."
+            className="w-full rounded-xl border border-line-soft bg-white px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+            disabled={submitting || !crawlerConfigured}
+          />
+          <span className="mt-1 block text-[0.7rem] text-text-tertiary">
+            {instructions.length} /{" "}
+            {CRAWLER_DEMO_LIMITS.maxInstructionsLength}
+          </span>
+        </label>
+
+        <button
+          type="button"
+          onClick={startCrawl}
+          disabled={submitting || !crawlerConfigured}
+          className="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2.5 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {submitting ? (
+            <Loader2 size={14} strokeWidth={2} className="animate-spin" />
+          ) : (
+            <Sparkles size={14} strokeWidth={1.75} />
+          )}
+          {submitting ? "Crawling…" : "Start crawl"}
+        </button>
+      </Panel>
+
+      {/* Tabs */}
+      <div className="mb-4 flex items-center gap-1 rounded-full border border-line-soft bg-surface-1 p-1">
+        <TabButton
+          active={activeTab === "news"}
+          onClick={() => setActiveTab("news")}
+          icon={Newspaper}
+          label="News"
+          count={newsCount}
+        />
+        <TabButton
+          active={activeTab === "event"}
+          onClick={() => setActiveTab("event")}
+          icon={Calendar}
+          label="Events"
+          count={eventCount}
+        />
+      </div>
+
+      {/* List */}
+      {isLoading ? (
+        <Panel className="rounded-2xl p-6 text-sm text-text-tertiary">
+          Loading…
+        </Panel>
+      ) : filtered.length === 0 ? (
+        <Panel className="rounded-2xl p-8 text-center text-sm text-text-tertiary">
+          Nothing pending. Start a crawl above to populate this inbox.
+        </Panel>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((item) => (
+            <DiscoveredCard
+              key={item.id}
+              item={item}
+              onApprove={() => onApprove(item.id)}
+              onReject={() => onReject(item.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon: Icon,
+  label,
+  count,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof Newspaper;
+  label: string;
+  count: number;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={
+        active
+          ? "inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-accent-contrast"
+          : "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-2"
+      }
+    >
+      <Icon size={14} strokeWidth={1.75} />
+      {label}
+      <span
+        className={
+          active
+            ? "rounded-full bg-white/20 px-1.5 py-0.5 text-[0.65rem]"
+            : "rounded-full bg-surface-2 px-1.5 py-0.5 text-[0.65rem] text-text-tertiary"
+        }
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function DiscoveredCard({
+  item,
+  onApprove,
+  onReject,
+}: {
+  item: DiscoveredItemRow;
+  onApprove: () => void;
+  onReject: () => void;
+}) {
+  const payload = item.extracted as Record<string, unknown>;
+  const title = typeof payload.title === "string" ? payload.title : "(no title)";
+  const body =
+    typeof payload.body === "string"
+      ? payload.body
+      : typeof payload.description === "string"
+        ? payload.description
+        : "";
+  const when =
+    typeof payload.startsAt === "string"
+      ? payload.startsAt
+      : typeof payload.publishedAt === "string"
+        ? payload.publishedAt
+        : null;
+  return (
+    <article className="rounded-2xl border border-line-soft bg-white p-5">
+      <header className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h3 className="text-base font-medium text-text-primary">{title}</h3>
+          {when ? (
+            <p className="mt-1 text-xs text-text-tertiary">{when}</p>
+          ) : null}
+        </div>
+        <a
+          href={item.sourceUrl}
+          target="_blank"
+          rel="noopener"
+          className="inline-flex shrink-0 items-center gap-1 text-xs text-accent hover:text-accent-hover"
+        >
+          Source
+          <ExternalLink size={12} strokeWidth={1.75} />
+        </a>
+      </header>
+      {body ? (
+        <p className="mt-3 line-clamp-4 text-sm leading-relaxed text-text-secondary">
+          {body}
+        </p>
+      ) : null}
+      <div className="mt-4 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onApprove}
+          className="inline-flex items-center gap-1.5 rounded-full bg-accent px-3.5 py-1.5 text-xs font-medium text-accent-contrast transition-opacity hover:opacity-90"
+        >
+          <CheckCircle2 size={12} strokeWidth={1.75} />
+          Approve
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          className="inline-flex items-center gap-1.5 rounded-full border border-line-soft px-3.5 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:border-line-strong hover:text-text-primary"
+        >
+          <XCircle size={12} strokeWidth={1.75} />
+          Reject
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/discovered/DiscoveredPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/discovered/DiscoveredPageClient.tsx
@@ -310,11 +310,19 @@ function DiscoveredCard({
 }) {
   const payload = item.extracted as Record<string, unknown>;
   const title = typeof payload.title === "string" ? payload.title : "(no title)";
+  const titleEl =
+    typeof payload.titleEl === "string" ? payload.titleEl : null;
   const body =
     typeof payload.body === "string"
       ? payload.body
       : typeof payload.description === "string"
         ? payload.description
+        : "";
+  const bodyEl =
+    typeof payload.bodyEl === "string"
+      ? payload.bodyEl
+      : typeof payload.descriptionEl === "string"
+        ? payload.descriptionEl
         : "";
   const when =
     typeof payload.startsAt === "string"
@@ -326,7 +334,17 @@ function DiscoveredCard({
     <article className="rounded-2xl border border-line-soft bg-white p-5">
       <header className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <h3 className="text-base font-medium text-text-primary">{title}</h3>
+          <h3 className="text-base font-medium text-text-primary" lang="en">
+            {title}
+          </h3>
+          {titleEl ? (
+            <h4
+              className="mt-0.5 text-sm font-normal text-text-secondary"
+              lang="el"
+            >
+              {titleEl}
+            </h4>
+          ) : null}
           {when ? (
             <p className="mt-1 text-xs text-text-tertiary">{when}</p>
           ) : null}
@@ -342,8 +360,19 @@ function DiscoveredCard({
         </a>
       </header>
       {body ? (
-        <p className="mt-3 line-clamp-4 text-sm leading-relaxed text-text-secondary">
+        <p
+          className="mt-3 line-clamp-3 text-sm leading-relaxed text-text-secondary"
+          lang="en"
+        >
           {body}
+        </p>
+      ) : null}
+      {bodyEl ? (
+        <p
+          className="mt-2 line-clamp-3 text-sm leading-relaxed text-text-tertiary"
+          lang="el"
+        >
+          {bodyEl}
         </p>
       ) : null}
       <div className="mt-4 flex items-center gap-2">

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/discovered/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/discovered/page.tsx
@@ -1,0 +1,53 @@
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { features } from "@/lib/env";
+import DiscoveredPageClient from "./DiscoveredPageClient";
+
+type Params = Promise<{ orgId: string; mapId: string }>;
+
+export const metadata = {
+  title: "Discovered",
+};
+
+/**
+ * `/org/[orgId]/maps/[mapId]/discovered` — agentic-crawler inbox.
+ *
+ * One landing page for the whole feature: rector pastes URLs, hits
+ * "Start crawl", the items the extractor surfaces land in tabbed
+ * News / Events lists below for approve / reject. Phase 1 — no
+ * persistent CrawlSource yet; pasting URLs is the only input.
+ */
+export default async function DiscoveredPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, mapId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) redirect("/auth/sign-in");
+
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+
+  const project = await prisma.project.findFirst({
+    where: { id: mapId, organizationId: orgId },
+    select: { id: true, title: true },
+  });
+  if (!project) notFound();
+
+  return (
+    <DiscoveredPageClient
+      mapId={mapId}
+      crawlerConfigured={features.crawler}
+    />
+  );
+}

--- a/apps/campus/app/api/crawler/discovered/[id]/approve/route.ts
+++ b/apps/campus/app/api/crawler/discovered/[id]/approve/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/crawler/discovered/[id]/approve — turn a pending
+ * DiscoveredItem into a real NewsPost / EventPost. Audit + cache bust
+ * mirror the manual-author flow so the new row behaves identically
+ * downstream.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import { recordAudit } from "@/lib/audit";
+import { revalidateTag } from "next/cache";
+import { publicCampusTag } from "@/lib/public-campus";
+import { approveAsEvent, approveAsNews } from "@/lib/crawler/approve";
+import type {
+  CampusEventExtraction,
+  CampusNewsExtraction,
+} from "@/lib/crawler/profile";
+
+type Params = Promise<{ id: string }>;
+
+export async function POST(_req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const item = await prisma.discoveredItem.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      projectId: true,
+      sourceUrl: true,
+      contentType: true,
+      extracted: true,
+      status: true,
+      project: { select: { organizationId: true } },
+    },
+  });
+  if (!item) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (item.status !== "pending") {
+    return NextResponse.json(
+      { error: "Item already reviewed" },
+      { status: 409 },
+    );
+  }
+
+  const denied = await requireCampusAccess(item.projectId, "write");
+  if (denied) return denied;
+
+  const ctx = {
+    projectId: item.projectId,
+    organizationId: item.project.organizationId,
+    sourceUrl: item.sourceUrl,
+  };
+
+  let published: { id: string };
+  let entityType: "NEWS_POST" | "EVENT_POST";
+  try {
+    if (item.contentType === "news") {
+      published = await approveAsNews(
+        item.extracted as unknown as CampusNewsExtraction,
+        ctx,
+      );
+      entityType = "NEWS_POST";
+    } else if (item.contentType === "event") {
+      published = await approveAsEvent(
+        item.extracted as unknown as CampusEventExtraction,
+        ctx,
+      );
+      entityType = "EVENT_POST";
+    } else {
+      return NextResponse.json(
+        { error: `Unknown contentType: ${item.contentType}` },
+        { status: 400 },
+      );
+    }
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Approval failed" },
+      { status: 422 },
+    );
+  }
+
+  await prisma.discoveredItem.update({
+    where: { id: item.id },
+    data: {
+      status: "approved",
+      reviewedById: session.user.id as string,
+      reviewedAt: new Date(),
+      publishedAs: published.id,
+    },
+  });
+
+  revalidateTag(publicCampusTag(item.projectId));
+
+  await recordAudit({
+    organizationId: item.project.organizationId,
+    projectId: item.projectId,
+    actorId: session.user.id as string,
+    entityType,
+    entityId: published.id,
+    action: "CREATED",
+    message: `Approved from crawler (${item.sourceUrl})`,
+    metadata: { discoveredItemId: item.id, sourceUrl: item.sourceUrl },
+  });
+
+  return NextResponse.json({ id: published.id, entityType });
+}

--- a/apps/campus/app/api/crawler/discovered/[id]/reject/route.ts
+++ b/apps/campus/app/api/crawler/discovered/[id]/reject/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/crawler/discovered/[id]/reject — soft-delete a pending
+ * discovered item. The row stays in the table (so we can show "X
+ * rejected" tallies later) but is invisible to the inbox.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+
+type Params = Promise<{ id: string }>;
+
+export async function POST(_req: Request, { params }: { params: Params }) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const item = await prisma.discoveredItem.findUnique({
+    where: { id },
+    select: { id: true, projectId: true, status: true },
+  });
+  if (!item) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (item.status !== "pending") {
+    return NextResponse.json(
+      { error: "Item already reviewed" },
+      { status: 409 },
+    );
+  }
+
+  const denied = await requireCampusAccess(item.projectId, "write");
+  if (denied) return denied;
+
+  await prisma.discoveredItem.update({
+    where: { id: item.id },
+    data: {
+      status: "rejected",
+      reviewedById: session.user.id as string,
+      reviewedAt: new Date(),
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/campus/app/api/maps/[mapId]/crawler/discovered/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/crawler/discovered/route.ts
@@ -1,0 +1,59 @@
+/**
+ * GET /api/maps/[mapId]/crawler/discovered — list pending discovered
+ * items for the rector's inbox. Filter by `?type=news|event` so the
+ * news + events admin pages can each pull only their slice.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+
+type Params = Promise<{ mapId: string }>;
+
+const VALID_TYPES = new Set(["news", "event"]);
+
+export async function GET(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  const url = new URL(req.url);
+  const type = url.searchParams.get("type");
+
+  const where: { projectId: string; status: "pending"; contentType?: string } = {
+    projectId: mapId,
+    status: "pending",
+  };
+  if (type && VALID_TYPES.has(type)) {
+    where.contentType = type;
+  }
+
+  const items = await prisma.discoveredItem.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    take: 100,
+    select: {
+      id: true,
+      sourceUrl: true,
+      contentType: true,
+      extracted: true,
+      createdAt: true,
+      job: {
+        select: { startedAt: true, instructions: true },
+      },
+    },
+  });
+
+  // Counts per type so the UI tab labels can stay accurate without
+  // a second roundtrip.
+  const counts = await prisma.discoveredItem.groupBy({
+    by: ["contentType"],
+    where: { projectId: mapId, status: "pending" },
+    _count: { _all: true },
+  });
+  const countsByType: Record<string, number> = {};
+  for (const c of counts) {
+    countsByType[c.contentType] = c._count._all;
+  }
+
+  return NextResponse.json({ items, countsByType });
+}

--- a/apps/campus/app/api/maps/[mapId]/crawler/jobs/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/crawler/jobs/route.ts
@@ -1,0 +1,212 @@
+/**
+ * POST /api/maps/[mapId]/crawler/jobs — start a crawl. Sync run inside
+ * the Vercel function (maxDuration capped below); Phase 3 will move
+ * the work onto Inngest so jobs can outlive a 5-minute budget.
+ *
+ * GET /api/maps/[mapId]/crawler/jobs — last 20 jobs for the campus
+ * dashboard (history strip).
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { requireCampusAccess } from "@/lib/authz";
+import { serverEnv, features } from "@/lib/env";
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  CRAWLER_DEMO_LIMITS,
+  createFirecrawlClient,
+  runCrawl,
+} from "@klorad/crawler";
+import { campusExtractorProfile } from "@/lib/crawler/profile";
+import type { Prisma } from "@prisma/client";
+
+type Params = Promise<{ mapId: string }>;
+
+/** Vercel hard limit for Hobby is 60s; Pro raises it to 300s. The
+ *  sync runner takes ~3-6s per page × up to 5 pages, so 60s is
+ *  enough for the demo cap but only just. Phase 3 (Inngest) is the
+ *  durable fix. */
+export const maxDuration = 60;
+
+/** Normalize and validate the URLs the rector pasted. */
+function parseUrls(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const v of raw) {
+    if (typeof v !== "string") continue;
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    try {
+      const u = new URL(trimmed);
+      if (u.protocol !== "http:" && u.protocol !== "https:") continue;
+      out.push(u.toString());
+    } catch {
+      // Drop garbage silently; the UI also pre-validates.
+    }
+  }
+  return out.slice(0, CRAWLER_DEMO_LIMITS.maxUrlsPerJob);
+}
+
+export async function GET(_req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "read");
+  if (denied) return denied;
+
+  const jobs = await prisma.crawlJob.findMany({
+    where: { projectId: mapId },
+    orderBy: { startedAt: "desc" },
+    take: 20,
+    select: {
+      id: true,
+      status: true,
+      instructions: true,
+      urls: true,
+      pagesFetched: true,
+      itemsCreated: true,
+      errorMessage: true,
+      startedAt: true,
+      finishedAt: true,
+    },
+  });
+  return NextResponse.json({ jobs });
+}
+
+export async function POST(req: Request, { params }: { params: Params }) {
+  const { mapId } = await params;
+  const denied = await requireCampusAccess(mapId, "write");
+  if (denied) return denied;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!features.crawler) {
+    return NextResponse.json(
+      { error: "Crawler is not configured on this server." },
+      { status: 503 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const urls = parseUrls(body.urls);
+  if (urls.length === 0) {
+    return NextResponse.json(
+      { error: "At least one valid http(s) URL is required." },
+      { status: 400 },
+    );
+  }
+
+  const instructionsRaw =
+    typeof body.instructions === "string" ? body.instructions.trim() : "";
+  const instructions = instructionsRaw.slice(
+    0,
+    CRAWLER_DEMO_LIMITS.maxInstructionsLength,
+  );
+
+  // Demo cap on the inbox — if pending items already pile up,
+  // refuse new crawls until the rector triages.
+  const pendingCount = await prisma.discoveredItem.count({
+    where: { projectId: mapId, status: "pending" },
+  });
+  if (pendingCount >= CRAWLER_DEMO_LIMITS.maxPendingItems) {
+    return NextResponse.json(
+      {
+        error: `Inbox is full (${pendingCount} pending). Approve or reject items before starting a new crawl.`,
+        code: "INBOX_FULL",
+      },
+      { status: 429 },
+    );
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { id: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  // Persist the job row up-front so the dashboard can show it
+  // as "running" mid-flight (and so a thrown error still leaves a
+  // historical trace).
+  const job = await prisma.crawlJob.create({
+    data: {
+      projectId: mapId,
+      status: "running",
+      instructions: instructions || null,
+      urls: urls as unknown as Prisma.InputJsonValue,
+      startedById: session.user.id as string,
+    },
+  });
+
+  try {
+    const firecrawl = createFirecrawlClient(
+      serverEnv.FIRECRAWL_API_KEY ?? "",
+    );
+    const anthropic = new Anthropic({
+      apiKey: serverEnv.ANTHROPIC_API_KEY ?? "",
+    });
+    const result = await runCrawl(
+      { firecrawl, anthropic },
+      { urls, instructions, profile: campusExtractorProfile },
+    );
+
+    if (result.totalItems > 0) {
+      await prisma.discoveredItem.createMany({
+        data: result.pages.flatMap((page) =>
+          page.items.map((item) => ({
+            projectId: mapId,
+            jobId: job.id,
+            sourceUrl: page.sourceUrl,
+            contentType: item.type,
+            extracted: item.payload as unknown as Prisma.InputJsonValue,
+          })),
+        ),
+      });
+    }
+
+    await prisma.crawlJob.update({
+      where: { id: job.id },
+      data: {
+        status: "done",
+        finishedAt: new Date(),
+        pagesFetched: result.pages.length,
+        itemsCreated: result.totalItems,
+      },
+    });
+
+    return NextResponse.json({
+      jobId: job.id,
+      status: "done",
+      pagesFetched: result.pages.length,
+      itemsCreated: result.totalItems,
+      perPage: result.pages.map((p) => ({
+        sourceUrl: p.sourceUrl,
+        status: p.status,
+        items: p.items.length,
+        error: p.error,
+      })),
+    });
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : "Crawl failed";
+    await prisma.crawlJob.update({
+      where: { id: job.id },
+      data: {
+        status: "failed",
+        finishedAt: new Date(),
+        errorMessage: errorMessage.slice(0, 500),
+      },
+    });
+    console.error("[crawler] job failed", err);
+    return NextResponse.json(
+      { error: errorMessage, jobId: job.id },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/campus/lib/crawler/approve.ts
+++ b/apps/campus/lib/crawler/approve.ts
@@ -36,12 +36,17 @@ export async function approveAsNews(
     throw new Error("Missing title or body");
   }
   const publishedAt = parseIsoDate(payload.publishedAt) ?? new Date();
+  const sourceFooter = `— Source: ${ctx.sourceUrl}`;
   const created = await prisma.newsPost.create({
     data: {
       organizationId: ctx.organizationId,
       projectId: ctx.projectId,
       title: payload.title.slice(0, 200),
-      body: `${payload.body}\n\n— Source: ${ctx.sourceUrl}`,
+      titleEl: payload.titleEl?.trim() ? payload.titleEl.slice(0, 200) : null,
+      body: `${payload.body}\n\n${sourceFooter}`,
+      bodyEl: payload.bodyEl?.trim()
+        ? `${payload.bodyEl}\n\n${sourceFooter}`
+        : null,
       category: "news",
       publishedAt,
       imageUrl: payload.imageUrl ?? null,
@@ -69,20 +74,26 @@ export async function approveAsEvent(
   const endsAt =
     parseIsoDate(payload.endsAt) ??
     new Date(startsAt.getTime() + 2 * 60 * 60 * 1000);
-  const description = [
+  const description = composeEventDescription(
     payload.description,
-    payload.location ? `Location: ${payload.location}` : "",
-    "",
-    `— Source: ${ctx.sourceUrl}`,
-  ]
-    .filter(Boolean)
-    .join("\n");
+    payload.location,
+    ctx.sourceUrl,
+  );
+  const descriptionEl = payload.descriptionEl?.trim()
+    ? composeEventDescription(
+        payload.descriptionEl,
+        payload.location,
+        ctx.sourceUrl,
+      )
+    : null;
   const created = await prisma.eventPost.create({
     data: {
       organizationId: ctx.organizationId,
       projectId: ctx.projectId,
       title: payload.title.slice(0, 200),
+      titleEl: payload.titleEl?.trim() ? payload.titleEl.slice(0, 200) : null,
       description,
+      descriptionEl,
       startsAt,
       endsAt,
       registrationUrl: payload.registrationUrl ?? null,
@@ -93,6 +104,21 @@ export async function approveAsEvent(
     },
   });
   return { id: created.id };
+}
+
+function composeEventDescription(
+  body: string,
+  location: string | undefined,
+  sourceUrl: string,
+): string {
+  return [
+    body,
+    location ? `Location: ${location}` : "",
+    "",
+    `— Source: ${sourceUrl}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function parseIsoDate(value: string | undefined): Date | null {

--- a/apps/campus/lib/crawler/approve.ts
+++ b/apps/campus/lib/crawler/approve.ts
@@ -1,0 +1,102 @@
+/**
+ * Approval mappers — turn a `DiscoveredItem` row into a real
+ * NewsPost / EventPost row when the rector clicks Approve.
+ *
+ * The extractor schema is permissive (title / body required,
+ * everything else optional) so the mapping decides the defaults:
+ *
+ *  • News: `publishedAt` defaults to NOW when the page didn't carry
+ *    a date — the rector can edit later from the news admin.
+ *  • Events: a missing `startsAt` is fatal — an event without a date
+ *    is just a note, so the API rejects the approval and tells the
+ *    rector to edit before re-trying. (Phase 2 will add an inline
+ *    edit form in the inbox.)
+ */
+import { prisma } from "@klorad/prisma";
+import type { Prisma } from "@prisma/client";
+import type {
+  CampusEventExtraction,
+  CampusNewsExtraction,
+} from "./profile";
+
+export interface ApprovalContext {
+  projectId: string;
+  organizationId: string;
+  /** Source URL the item was extracted from — written into the
+   *  NewsPost body / EventPost description footer so the rector can
+   *  trace any claim back to its origin in one click. */
+  sourceUrl: string;
+}
+
+export async function approveAsNews(
+  payload: CampusNewsExtraction,
+  ctx: ApprovalContext,
+): Promise<{ id: string }> {
+  if (!payload.title?.trim() || !payload.body?.trim()) {
+    throw new Error("Missing title or body");
+  }
+  const publishedAt = parseIsoDate(payload.publishedAt) ?? new Date();
+  const created = await prisma.newsPost.create({
+    data: {
+      organizationId: ctx.organizationId,
+      projectId: ctx.projectId,
+      title: payload.title.slice(0, 200),
+      body: `${payload.body}\n\n— Source: ${ctx.sourceUrl}`,
+      category: "news",
+      publishedAt,
+      imageUrl: payload.imageUrl ?? null,
+      anchors: [] as unknown as Prisma.InputJsonValue,
+    },
+  });
+  return { id: created.id };
+}
+
+export async function approveAsEvent(
+  payload: CampusEventExtraction,
+  ctx: ApprovalContext,
+): Promise<{ id: string }> {
+  if (!payload.title?.trim() || !payload.description?.trim()) {
+    throw new Error("Missing title or description");
+  }
+  const startsAt = parseIsoDate(payload.startsAt);
+  if (!startsAt) {
+    throw new Error(
+      "This event has no start date — open the source link, find the date, and add it manually for now (inline editing lands in Phase 2).",
+    );
+  }
+  // Default an event to a 2-hour window when `endsAt` is missing —
+  // a coarse value the rector can refine in the events admin.
+  const endsAt =
+    parseIsoDate(payload.endsAt) ??
+    new Date(startsAt.getTime() + 2 * 60 * 60 * 1000);
+  const description = [
+    payload.description,
+    payload.location ? `Location: ${payload.location}` : "",
+    "",
+    `— Source: ${ctx.sourceUrl}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  const created = await prisma.eventPost.create({
+    data: {
+      organizationId: ctx.organizationId,
+      projectId: ctx.projectId,
+      title: payload.title.slice(0, 200),
+      description,
+      startsAt,
+      endsAt,
+      registrationUrl: payload.registrationUrl ?? null,
+      organizer: payload.organizer ?? null,
+      imageUrl: payload.imageUrl ?? null,
+      anchors: [] as unknown as Prisma.InputJsonValue,
+      source: "crawler",
+    },
+  });
+  return { id: created.id };
+}
+
+function parseIsoDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}

--- a/apps/campus/lib/crawler/profile.ts
+++ b/apps/campus/lib/crawler/profile.ts
@@ -1,0 +1,134 @@
+/**
+ * Campus's registration with `@klorad/crawler` — describes which
+ * content types the extractor should look for and the JSON Schema
+ * each tool-use call must conform to. Other apps (Mobility, Heritage,
+ * Urban) will ship their own profiles with their own schemas; the
+ * crawler package stays domain-agnostic.
+ */
+import type { ExtractorProfile } from "@klorad/crawler";
+
+const NEWS_ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    title: {
+      type: "string",
+      description:
+        "Headline of the news item. Keep close to what the page actually says.",
+    },
+    body: {
+      type: "string",
+      description:
+        "One to three short paragraphs summarising the item in the page's own voice. Do not invent details.",
+    },
+    publishedAt: {
+      type: "string",
+      description:
+        "ISO 8601 datetime the item was published. Omit if you cannot find it on the page.",
+    },
+    imageUrl: {
+      type: "string",
+      description:
+        "Absolute URL of the hero image, if the page has one. Omit otherwise.",
+    },
+  },
+  required: ["title", "body"],
+  additionalProperties: false,
+} as const;
+
+const EVENT_ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    title: { type: "string", description: "Event name." },
+    description: {
+      type: "string",
+      description:
+        "Short description of the event in the page's own voice. Do not invent details.",
+    },
+    startsAt: {
+      type: "string",
+      description:
+        "ISO 8601 datetime the event starts. Omit if not clearly stated.",
+    },
+    endsAt: {
+      type: "string",
+      description:
+        "ISO 8601 datetime the event ends. Omit if not clearly stated.",
+    },
+    location: {
+      type: "string",
+      description:
+        "Free-text venue (building, room, address). Omit if not stated.",
+    },
+    organizer: {
+      type: "string",
+      description: "Organising group / club / department. Omit if unclear.",
+    },
+    registrationUrl: {
+      type: "string",
+      description:
+        "URL the page links for registration / tickets. Omit otherwise.",
+    },
+    imageUrl: {
+      type: "string",
+      description:
+        "Absolute URL of a hero image for the event. Omit otherwise.",
+    },
+  },
+  required: ["title", "description"],
+  additionalProperties: false,
+} as const;
+
+export const campusExtractorProfile: ExtractorProfile = {
+  appKey: "campus",
+  systemPrompt:
+    "Domain: a Greek higher-education campus consumer surface (news + events). The audience is students and visitors. Greek source text is fine — extract the title and body in the source language; do not translate.",
+  schemas: {
+    news: {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: NEWS_ITEM_SCHEMA,
+          description:
+            "Every news / announcement / alert item on the page. Empty array is valid.",
+        },
+      },
+      required: ["items"],
+      additionalProperties: false,
+    },
+    event: {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: EVENT_ITEM_SCHEMA,
+          description:
+            "Every event on the page. Empty array is valid.",
+        },
+      },
+      required: ["items"],
+      additionalProperties: false,
+    },
+  },
+};
+
+/** Narrowed shapes the approval handlers consume — match the JSON
+ *  Schemas above. Anthropic's tool-use enforces the shape at the
+ *  call site, but we narrow again here for type safety. */
+export interface CampusNewsExtraction {
+  title: string;
+  body: string;
+  publishedAt?: string;
+  imageUrl?: string;
+}
+
+export interface CampusEventExtraction {
+  title: string;
+  description: string;
+  startsAt?: string;
+  endsAt?: string;
+  location?: string;
+  organizer?: string;
+  registrationUrl?: string;
+  imageUrl?: string;
+}

--- a/apps/campus/lib/crawler/profile.ts
+++ b/apps/campus/lib/crawler/profile.ts
@@ -13,12 +13,22 @@ const NEWS_ITEM_SCHEMA = {
     title: {
       type: "string",
       description:
-        "Headline of the news item. Keep close to what the page actually says.",
+        "Headline in ENGLISH. If the page is Greek, translate; if the page is already English, use it verbatim. Keep close to what the page actually says — do not editorialise.",
+    },
+    titleEl: {
+      type: "string",
+      description:
+        "Headline in GREEK. If the page is English, translate; if the page is already Greek, use it verbatim.",
     },
     body: {
       type: "string",
       description:
-        "One to three short paragraphs summarising the item in the page's own voice. Do not invent details.",
+        "Body in ENGLISH — one to three short paragraphs summarising the item in the page's own voice. Translate if the source is Greek. Do not invent details.",
+    },
+    bodyEl: {
+      type: "string",
+      description:
+        "Body in GREEK — the same content as `body`, translated to Greek (or verbatim when the source is Greek).",
     },
     publishedAt: {
       type: "string",
@@ -31,18 +41,32 @@ const NEWS_ITEM_SCHEMA = {
         "Absolute URL of the hero image, if the page has one. Omit otherwise.",
     },
   },
-  required: ["title", "body"],
+  required: ["title", "titleEl", "body", "bodyEl"],
   additionalProperties: false,
 } as const;
 
 const EVENT_ITEM_SCHEMA = {
   type: "object",
   properties: {
-    title: { type: "string", description: "Event name." },
+    title: {
+      type: "string",
+      description:
+        "Event name in ENGLISH. Translate if the source is Greek, verbatim if already English.",
+    },
+    titleEl: {
+      type: "string",
+      description:
+        "Event name in GREEK. Translate if the source is English, verbatim if already Greek.",
+    },
     description: {
       type: "string",
       description:
-        "Short description of the event in the page's own voice. Do not invent details.",
+        "Description in ENGLISH — short, in the page's own voice. Translate if source is Greek. Do not invent details.",
+    },
+    descriptionEl: {
+      type: "string",
+      description:
+        "Description in GREEK — same content as `description`, translated to Greek (or verbatim when source is Greek).",
     },
     startsAt: {
       type: "string",
@@ -57,7 +81,7 @@ const EVENT_ITEM_SCHEMA = {
     location: {
       type: "string",
       description:
-        "Free-text venue (building, room, address). Omit if not stated.",
+        "Free-text venue (building, room, address). Omit if not stated. Render in the language it appears on the page — locations are usually proper nouns.",
     },
     organizer: {
       type: "string",
@@ -74,14 +98,17 @@ const EVENT_ITEM_SCHEMA = {
         "Absolute URL of a hero image for the event. Omit otherwise.",
     },
   },
-  required: ["title", "description"],
+  required: ["title", "titleEl", "description", "descriptionEl"],
   additionalProperties: false,
 } as const;
 
 export const campusExtractorProfile: ExtractorProfile = {
   appKey: "campus",
-  systemPrompt:
-    "Domain: a Greek higher-education campus consumer surface (news + events). The audience is students and visitors. Greek source text is fine — extract the title and body in the source language; do not translate.",
+  systemPrompt: [
+    "Domain: a Greek higher-education campus consumer surface (news + events). Audience is students and visitors.",
+    "Bilingual output is required on every item — emit both an English (`title`, `body`/`description`) and a Greek (`titleEl`, `bodyEl`/`descriptionEl`) version. If the source is Greek, translate to English for the English fields; if the source is English, translate to Greek for the Greek fields. Keep the same factual content on both sides — translation, not summarisation.",
+    "Translate idiomatically (not word-for-word). University-specific jargon (department names, building codes, programme abbreviations) should stay in their canonical form on both sides.",
+  ].join("\n\n"),
   schemas: {
     news: {
       type: "object",
@@ -117,14 +144,18 @@ export const campusExtractorProfile: ExtractorProfile = {
  *  call site, but we narrow again here for type safety. */
 export interface CampusNewsExtraction {
   title: string;
+  titleEl: string;
   body: string;
+  bodyEl: string;
   publishedAt?: string;
   imageUrl?: string;
 }
 
 export interface CampusEventExtraction {
   title: string;
+  titleEl: string;
   description: string;
+  descriptionEl: string;
   startsAt?: string;
   endsAt?: string;
   location?: string;

--- a/apps/campus/lib/env.ts
+++ b/apps/campus/lib/env.ts
@@ -54,6 +54,7 @@ const serverSchema = z.object({
   VAPID_PRIVATE_KEY: z.string().optional(),
   VAPID_SUBJECT: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
+  FIRECRAWL_API_KEY: z.string().optional(),
 
   // ─ Mode ───────────────────────────────────────────────────────
   NODE_ENV: z
@@ -143,6 +144,12 @@ export const features = {
    *  pair is obvious from the outside. */
   sentry: Boolean(
     serverEnv.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+  ),
+  /** Agentic crawler (Firecrawl + Claude). Needs both a Firecrawl
+   *  key and the same ANTHROPIC_API_KEY Klio uses — extraction goes
+   *  through Claude's tool-use. */
+  crawler: Boolean(
+    serverEnv.FIRECRAWL_API_KEY && serverEnv.ANTHROPIC_API_KEY,
   ),
 } as const;
 

--- a/apps/campus/package.json
+++ b/apps/campus/package.json
@@ -21,6 +21,7 @@
     "@auth/prisma-adapter": "^2.11.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@klorad/crawler": "workspace:*",
     "@klorad/design-system": "workspace:^",
     "@klorad/prisma": "workspace:*",
     "@klorad/storage": "workspace:^",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@klorad/crawler",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist/**"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./limits": {
+      "import": "./dist/limits.js",
+      "types": "./dist/limits.d.ts"
+    }
+  },
+  "scripts": {
+    "clean": "rimraf dist *.tsbuildinfo",
+    "build": "tsup",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mendable/firecrawl-js": "^1.20.0"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/sdk": ">=0.98.0"
+  }
+}

--- a/packages/crawler/src/extractor.ts
+++ b/packages/crawler/src/extractor.ts
@@ -108,7 +108,11 @@ export async function extractFromMarkdown(
   try {
     response = await client.messages.create({
       model: MODEL,
-      max_tokens: 2048,
+      // Doubled vs. monolingual to leave room for translated copies
+      // — apps can ask Claude to fill EN + EL fields on every item
+      // (campus profile does). 4096 fits ~6-8 bilingual news items
+      // per page; that's plenty of headroom.
+      max_tokens: 4096,
       system,
       tools,
       tool_choice: { type: "any" },

--- a/packages/crawler/src/extractor.ts
+++ b/packages/crawler/src/extractor.ts
@@ -1,0 +1,148 @@
+/**
+ * Claude-backed structured extractor.
+ *
+ * Given one page's markdown + an `ExtractorProfile`, ask Claude to
+ * surface any news / event items it can find. We force structured
+ * output via Anthropic's tool-use: Claude is given a single tool per
+ * content type whose `input_schema` is the profile's schema, then
+ * told it MUST call the relevant tools. We then read the `tool_use`
+ * blocks straight out of the response — no markdown parsing, no
+ * regex, no manual JSON narrowing.
+ *
+ * The extractor is intentionally **stateless and tool-only**: no
+ * follow-up turn, no agentic loop. One Claude call per page; if the
+ * model refuses or returns no tool calls, the page yields zero
+ * items. Predictable cost, predictable failure mode.
+ */
+import type Anthropic from "@anthropic-ai/sdk";
+import type {
+  ContentType,
+  ExtractedItem,
+  ExtractorProfile,
+} from "./types.js";
+
+/** Model used for extraction. Haiku is fast + cheap; quality on this
+ *  task (free-form text → structured slots) is good enough for v1. */
+const MODEL = "claude-haiku-4-5-20251001";
+
+const SYSTEM_BASE = `You extract structured campus content from raw web pages.
+
+Rules:
+- Only emit items that are clearly **news** (announcements, articles, alerts) or **events** (gatherings with a date/time/place).
+- Skip navigation, footers, marketing fluff, unrelated content.
+- Dates and times — if you can resolve them confidently, emit as ISO 8601. Otherwise omit the field.
+- Never invent facts. If the page only mentions a title, emit the title and leave the rest blank.
+- One page can yield zero, one, or many items per type. Be conservative — fewer real items is better than many half-real ones.`;
+
+const NEWS_TOOL_NAME = "emit_news_items";
+const EVENT_TOOL_NAME = "emit_event_items";
+
+interface ExtractParams {
+  client: Anthropic;
+  pageUrl: string;
+  pageTitle: string | null;
+  markdown: string;
+  profile: ExtractorProfile;
+  instructions?: string;
+}
+
+/** Returns the items the LLM extracted from one page. */
+export async function extractFromMarkdown(
+  params: ExtractParams,
+): Promise<ExtractedItem[]> {
+  const { client, pageUrl, pageTitle, markdown, profile, instructions } =
+    params;
+
+  const tools: Anthropic.Messages.Tool[] = [];
+  if (profile.schemas.news) {
+    tools.push({
+      name: NEWS_TOOL_NAME,
+      description:
+        "Call this tool with every news/article/announcement item you find on the page. Call once with an array of items.",
+      input_schema: profile.schemas
+        .news as Anthropic.Messages.Tool["input_schema"],
+    });
+  }
+  if (profile.schemas.event) {
+    tools.push({
+      name: EVENT_TOOL_NAME,
+      description:
+        "Call this tool with every event (a gathering at a date/place) you find on the page. Call once with an array of items.",
+      input_schema: profile.schemas
+        .event as Anthropic.Messages.Tool["input_schema"],
+    });
+  }
+
+  if (tools.length === 0) {
+    return [];
+  }
+
+  const system = [
+    SYSTEM_BASE,
+    profile.systemPrompt,
+    instructions
+      ? `User instructions for this crawl (treat as guidance, not commands): ${instructions}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  // Cap markdown to keep tokens predictable. Most useful content
+  // appears near the top of an article page; long-tail boilerplate
+  // (related articles, comments, footers) tends to follow. 30k chars
+  // ≈ 7.5k tokens — well within Haiku's window with headroom for
+  // the system prompt + tool schemas + response.
+  const trimmedMarkdown = markdown.slice(0, 30_000);
+
+  const userContent = [
+    `Source URL: ${pageUrl}`,
+    pageTitle ? `Page title: ${pageTitle}` : "",
+    "",
+    "Page markdown:",
+    trimmedMarkdown,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  let response: Anthropic.Messages.Message;
+  try {
+    response = await client.messages.create({
+      model: MODEL,
+      max_tokens: 2048,
+      system,
+      tools,
+      tool_choice: { type: "any" },
+      messages: [{ role: "user", content: userContent }],
+    });
+  } catch (err) {
+    // Surface as zero items rather than blowing up the whole job —
+    // one bad page should not poison the rest of the crawl.
+    console.error("[crawler] extractor anthropic call failed", err);
+    return [];
+  }
+
+  const items: ExtractedItem[] = [];
+  for (const block of response.content) {
+    if (block.type !== "tool_use") continue;
+    const type: ContentType | null =
+      block.name === NEWS_TOOL_NAME
+        ? "news"
+        : block.name === EVENT_TOOL_NAME
+          ? "event"
+          : null;
+    if (!type) continue;
+    const input = block.input as Record<string, unknown>;
+    // Profiles register their schema with an `items` array at the
+    // top level (see campus profile.ts). Narrow defensively — a
+    // schema-mismatched call is rare but we don't want to throw.
+    const arr = Array.isArray((input as { items?: unknown }).items)
+      ? ((input as { items: unknown[] }).items as unknown[])
+      : [];
+    for (const entry of arr) {
+      if (entry && typeof entry === "object") {
+        items.push({ type, payload: entry as Record<string, unknown> });
+      }
+    }
+  }
+  return items;
+}

--- a/packages/crawler/src/firecrawl.ts
+++ b/packages/crawler/src/firecrawl.ts
@@ -1,0 +1,70 @@
+/**
+ * Thin Firecrawl wrapper — one URL → markdown.
+ *
+ * Firecrawl's JS SDK ships a `scrape` method that returns a rich
+ * response (markdown, html, screenshots, metadata). We pin the
+ * formats to `markdown` so the LLM extractor only sees text, and we
+ * surface only what the runner needs. Any SDK shape drift stays
+ * isolated to this file.
+ */
+import FirecrawlApp from "@mendable/firecrawl-js";
+
+export interface FirecrawlScrapeResult {
+  ok: boolean;
+  markdown: string;
+  /** Truncated to the page's <title> when present, otherwise null. */
+  title: string | null;
+  /** Surfaced when ok is false. */
+  error?: string;
+}
+
+export interface FirecrawlClient {
+  scrape(url: string): Promise<FirecrawlScrapeResult>;
+}
+
+/** Construct a client bound to one API key. Throws synchronously if
+ *  the key is empty — callers should have already checked
+ *  `features.crawler` before reaching this. */
+export function createFirecrawlClient(apiKey: string): FirecrawlClient {
+  if (!apiKey) {
+    throw new Error("FIRECRAWL_API_KEY is not set");
+  }
+  const app = new FirecrawlApp({ apiKey });
+  return {
+    async scrape(url: string): Promise<FirecrawlScrapeResult> {
+      try {
+        const res = (await app.scrapeUrl(url, {
+          formats: ["markdown"],
+        })) as unknown as {
+          success?: boolean;
+          markdown?: string;
+          metadata?: { title?: string };
+          error?: string;
+        };
+        if (!res.success || typeof res.markdown !== "string") {
+          return {
+            ok: false,
+            markdown: "",
+            title: null,
+            error: res.error ?? "Firecrawl returned no markdown",
+          };
+        }
+        return {
+          ok: true,
+          markdown: res.markdown,
+          title:
+            typeof res.metadata?.title === "string"
+              ? res.metadata.title.slice(0, 200)
+              : null,
+        };
+      } catch (err) {
+        return {
+          ok: false,
+          markdown: "",
+          title: null,
+          error: err instanceof Error ? err.message : "Firecrawl threw",
+        };
+      }
+    },
+  };
+}

--- a/packages/crawler/src/index.ts
+++ b/packages/crawler/src/index.ts
@@ -1,0 +1,14 @@
+export type {
+  ContentType,
+  ExtractedItem,
+  ExtractorProfile,
+  PageExtraction,
+  RunnerInput,
+  RunnerOutput,
+} from "./types.js";
+export { createFirecrawlClient } from "./firecrawl.js";
+export type { FirecrawlClient, FirecrawlScrapeResult } from "./firecrawl.js";
+export { runCrawl } from "./runner.js";
+export type { RunnerDeps } from "./runner.js";
+export { CRAWLER_DEMO_LIMITS } from "./limits.js";
+export type { CrawlerDemoLimits } from "./limits.js";

--- a/packages/crawler/src/limits.ts
+++ b/packages/crawler/src/limits.ts
@@ -1,0 +1,26 @@
+/**
+ * Demo-tier limits for the agentic crawler.
+ *
+ * Hardcoded constants in v1 — they're imported wherever a guard is
+ * needed (API handlers, UI counters) so the cap is consistent and
+ * changing it is a one-line edit. Production tenants will lift these
+ * via the billing plan in Phase 4; until then the values below are
+ * what every project gets.
+ *
+ * Why a cap at all: Firecrawl + Claude calls cost real money per
+ * page. A buggy rector who pastes a sitemap URL by mistake could
+ * burn the demo budget in one click. The cap is the hard backstop.
+ */
+export const CRAWLER_DEMO_LIMITS = {
+  /** Max URLs a single job will scrape. */
+  maxUrlsPerJob: 5,
+  /** Max DiscoveredItems pending review per project before new
+   *  crawls are blocked — pushes rectors to triage before piling on. */
+  maxPendingItems: 100,
+  /** Max characters of free-text instructions the rector can pass
+   *  to the extractor. Long enough for a useful nudge, short enough
+   *  to cap prompt-injection blast radius. */
+  maxInstructionsLength: 500,
+} as const;
+
+export type CrawlerDemoLimits = typeof CRAWLER_DEMO_LIMITS;

--- a/packages/crawler/src/runner.ts
+++ b/packages/crawler/src/runner.ts
@@ -1,0 +1,63 @@
+/**
+ * Job runner — scrape each URL, extract each page, collect results.
+ *
+ * Sequential per page, parallel-safe overall: callers can invoke the
+ * runner concurrently across projects without contention. We don't
+ * fan out scrapes within a single job because Firecrawl's free tier
+ * is rate-limited and the demo cap is 5 URLs anyway — sequential is
+ * simpler than a parallel pool that adds 5ms of orchestration to
+ * save 200ms of wall time.
+ *
+ * No persistence. The caller owns the DB write.
+ */
+import type Anthropic from "@anthropic-ai/sdk";
+import type { FirecrawlClient } from "./firecrawl.js";
+import { extractFromMarkdown } from "./extractor.js";
+import type {
+  PageExtraction,
+  RunnerInput,
+  RunnerOutput,
+} from "./types.js";
+
+export interface RunnerDeps {
+  firecrawl: FirecrawlClient;
+  anthropic: Anthropic;
+}
+
+export async function runCrawl(
+  deps: RunnerDeps,
+  input: RunnerInput,
+): Promise<RunnerOutput> {
+  const pages: PageExtraction[] = [];
+  for (const url of input.urls) {
+    const scrape = await deps.firecrawl.scrape(url);
+    if (!scrape.ok) {
+      pages.push({
+        sourceUrl: url,
+        status: "scrape_failed",
+        items: [],
+        error: scrape.error,
+      });
+      continue;
+    }
+    if (!scrape.markdown.trim()) {
+      pages.push({ sourceUrl: url, status: "empty", items: [] });
+      continue;
+    }
+    const items = await extractFromMarkdown({
+      client: deps.anthropic,
+      pageUrl: url,
+      pageTitle: scrape.title,
+      markdown: scrape.markdown,
+      profile: input.profile,
+      instructions: input.instructions,
+    });
+    pages.push({
+      sourceUrl: url,
+      status: "ok",
+      items,
+    });
+  }
+  const totalItems = pages.reduce((acc, p) => acc + p.items.length, 0);
+  return { pages, totalItems };
+}

--- a/packages/crawler/src/types.ts
+++ b/packages/crawler/src/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shapes that flow between the crawler runner and its callers.
+ *
+ * The package is intentionally **DB-agnostic** — it never imports
+ * Prisma. The caller owns persistence: it hands the runner a list of
+ * URLs, gets back `ExtractedItem[]` (raw shape, no ids) per URL, and
+ * decides what to write where. Same package, different apps, same
+ * extraction surface.
+ */
+
+/** Content type the extractor was asked to look for. Apps register
+ *  one schema per type via `ExtractorProfile`; the LLM emits each
+ *  type it can find on a page in one structured call. */
+export type ContentType = "news" | "event";
+
+/** What the extractor returns for one URL. */
+export interface PageExtraction {
+  /** The source URL the markdown was scraped from. Echoed back so
+   *  callers can persist `sourceUrl` on each item without bookkeeping. */
+  sourceUrl: string;
+  /** Status of the scrape — `ok` when Firecrawl returned markdown,
+   *  `scrape_failed` when the page could not be fetched, `empty` when
+   *  the markdown was returned but had no extractable content. */
+  status: "ok" | "scrape_failed" | "empty";
+  /** Items the LLM extracted, grouped by content type. Empty arrays
+   *  on non-`ok` statuses. */
+  items: ExtractedItem[];
+  /** When `status !== "ok"`, a one-line reason. */
+  error?: string;
+}
+
+/** A single extracted item — content-type-tagged, payload is the
+ *  shape the matching `ExtractorProfile` schema described. The caller
+ *  routes by `type` and trusts `payload` to match the registered
+ *  schema (the LLM is forced to via tool-use, so this isn't blind). */
+export interface ExtractedItem {
+  type: ContentType;
+  /** The structured payload — typed loosely here so the package can
+   *  stay app-agnostic. The caller narrows it per `type`. */
+  payload: Record<string, unknown>;
+}
+
+/** Per-app registration: what content types this app cares about and
+ *  the JSON Schema the LLM should fill for each. Schemas are passed
+ *  to Anthropic via `tools` and forced via `tool_choice`. */
+export interface ExtractorProfile {
+  /** Friendly id — logged on jobs, surfaced in UI. */
+  appKey: string;
+  /** System prompt prefix — describes the domain (e.g. "Greek HE
+   *  campus"). The package layers the tool-use instructions on top. */
+  systemPrompt: string;
+  /** Per content-type JSON Schema for the tool input. The package
+   *  forwards these verbatim to Anthropic. */
+  schemas: Partial<Record<ContentType, Record<string, unknown>>>;
+}
+
+/** Input to the runner. */
+export interface RunnerInput {
+  urls: string[];
+  /** Optional rector-supplied instructions. Length-capped by the
+   *  caller via `CRAWLER_DEMO_LIMITS.maxInstructionsLength` before
+   *  reaching the runner. */
+  instructions?: string;
+  profile: ExtractorProfile;
+}
+
+/** Output of the runner — one entry per input URL, same order. */
+export interface RunnerOutput {
+  pages: PageExtraction[];
+  /** Sum of items across pages. */
+  totalItems: number;
+}

--- a/packages/crawler/tsconfig.json
+++ b/packages/crawler/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.lib.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true,
+    "module": "ES2020",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.*"]
+}

--- a/packages/crawler/tsup.config.ts
+++ b/packages/crawler/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    limits: "src/limits.ts",
+  },
+  outDir: "dist",
+  format: ["esm"],
+  dts: { entry: ["src/index.ts", "src/limits.ts"], resolve: true },
+  sourcemap: true,
+  treeshake: true,
+  minify: false,
+  target: "es2020",
+  platform: "node",
+  bundle: true,
+  skipNodeModulesBundle: true,
+  external: [/^@anthropic-ai\/sdk$/, /^@mendable\/firecrawl-js$/],
+  tsconfig: "./tsconfig.json",
+});

--- a/packages/prisma/migrations/20260606120000_add_crawler/migration.sql
+++ b/packages/prisma/migrations/20260606120000_add_crawler/migration.sql
@@ -1,0 +1,57 @@
+-- CreateEnum
+CREATE TYPE "CrawlJobStatus" AS ENUM ('queued', 'running', 'done', 'failed');
+
+-- CreateEnum
+CREATE TYPE "DiscoveredItemStatus" AS ENUM ('pending', 'approved', 'rejected');
+
+-- CreateTable
+CREATE TABLE "CrawlJob" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "status" "CrawlJobStatus" NOT NULL DEFAULT 'queued',
+    "instructions" TEXT,
+    "urls" JSONB NOT NULL DEFAULT '[]',
+    "startedById" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+    "pagesFetched" INTEGER NOT NULL DEFAULT 0,
+    "itemsCreated" INTEGER NOT NULL DEFAULT 0,
+    "errorMessage" TEXT,
+
+    CONSTRAINT "CrawlJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DiscoveredItem" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "sourceUrl" TEXT NOT NULL,
+    "contentType" TEXT NOT NULL,
+    "extracted" JSONB NOT NULL,
+    "status" "DiscoveredItemStatus" NOT NULL DEFAULT 'pending',
+    "reviewedById" TEXT,
+    "reviewedAt" TIMESTAMP(3),
+    "publishedAs" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DiscoveredItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CrawlJob_projectId_startedAt_idx" ON "CrawlJob"("projectId", "startedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "DiscoveredItem_projectId_status_createdAt_idx" ON "DiscoveredItem"("projectId", "status", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "DiscoveredItem_jobId_idx" ON "DiscoveredItem"("jobId");
+
+-- AddForeignKey
+ALTER TABLE "CrawlJob" ADD CONSTRAINT "CrawlJob_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiscoveredItem" ADD CONSTRAINT "DiscoveredItem_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiscoveredItem" ADD CONSTRAINT "DiscoveredItem_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "CrawlJob"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -189,6 +189,10 @@ model Project {
   // Per-campus role overrides — when set, supersede the user's
   // organization role for this specific campus. See lib/authz.ts.
   memberOverrides   ProjectMember[]
+  // Agentic crawler jobs scoped to this campus — see @klorad/crawler.
+  crawlJobs         CrawlJob[]
+  // Discovered items pending rector review.
+  discoveredItems   DiscoveredItem[]
 
   // Showcase Relation
   showcaseWorld ShowcaseWorld?
@@ -688,4 +692,81 @@ model PushSubscription {
 
   @@unique([projectId, endpoint])
   @@index([projectId])
+}
+
+/// Agentic crawler — one job per "Start crawl" click. Phase 1 only
+/// tracks the per-job outcome; persistent CrawlSource rows land in
+/// Phase 2. The job row stays around after it finishes so the
+/// dashboard can show a history and a retry hook.
+model CrawlJob {
+  id           String         @id @default(cuid())
+  projectId    String
+  status       CrawlJobStatus @default(queued)
+  /// Free-text instructions the rector passed to the extractor.
+  /// Capped client- + server-side by CRAWLER_DEMO_LIMITS.
+  instructions String?        @db.Text
+  /// The URLs the rector queued for this job — JSON array of strings.
+  /// Re-stored on the row so a retry doesn't depend on the UI state.
+  urls         Json           @default("[]")
+  startedById  String?
+  startedAt    DateTime       @default(now())
+  finishedAt   DateTime?
+  /// Pages Firecrawl actually scraped (success + empty + failed).
+  pagesFetched Int            @default(0)
+  /// Items the LLM produced across all pages — sum across types.
+  itemsCreated Int            @default(0)
+  /// One-line message when status is `failed`.
+  errorMessage String?
+
+  project    Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  discovered DiscoveredItem[]
+
+  @@index([projectId, startedAt(sort: Desc)])
+}
+
+enum CrawlJobStatus {
+  queued
+  running
+  done
+  failed
+}
+
+/// One item the extractor surfaced — sits in the "Needs approval"
+/// inbox until the rector approves (creating a real NewsPost /
+/// EventPost) or rejects (soft-delete via status). `extracted`
+/// holds the raw JSON the LLM returned, narrowed by content type at
+/// approval time.
+model DiscoveredItem {
+  id          String                @id @default(cuid())
+  projectId   String
+  jobId       String
+  /// Where the page lived — kept so the rector can click through
+  /// to source even after approval.
+  sourceUrl   String
+  /// `news` | `event` — matches ContentType in @klorad/crawler.
+  contentType String
+  /// Raw structured payload — shape depends on contentType, narrowed
+  /// at approval time by the per-app mapper.
+  extracted   Json
+  status      DiscoveredItemStatus @default(pending)
+  /// When status moves off `pending`, who did it.
+  reviewedById String?
+  reviewedAt   DateTime?
+  /// FK back to the row this was approved into — `NewsPost.id` /
+  /// `EventPost.id`. Free-form so adding new content types in later
+  /// phases doesn't require schema changes here.
+  publishedAs  String?
+  createdAt    DateTime              @default(now())
+
+  project Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  job     CrawlJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, status, createdAt(sort: Desc)])
+  @@index([jobId])
+}
+
+enum DiscoveredItemStatus {
+  pending
+  approved
+  rejected
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.1))(@types/react@19.2.7)(react@19.2.1)
+      '@klorad/crawler':
+        specifier: workspace:*
+        version: link:../../packages/crawler
       '@klorad/design-system':
         specifier: workspace:^
         version: link:../../packages/design-system
@@ -750,6 +753,15 @@ importers:
       zustand:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@19.2.7)(react@19.2.1)
+
+  packages/crawler:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: '>=0.98.0'
+        version: 0.98.0(zod@3.25.76)
+      '@mendable/firecrawl-js':
+        specifier: ^1.20.0
+        version: 1.29.3
 
   packages/design-system:
     dependencies:
@@ -2435,6 +2447,10 @@ packages:
 
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@mendable/firecrawl-js@1.29.3':
+    resolution: {integrity: sha512-+uvDktesJmVtiwxMtimq+3f5bKlsan4T7TokxOI7DbxFkApwrRNss5GYEXbInveMTz8LpGth/9Ch5BTwCqrpfA==}
+    engines: {node: '>=22.0.0'}
 
   '@monogrid/gainmap-js@3.1.0':
     resolution: {integrity: sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==}
@@ -8414,6 +8430,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typescript-event-target@1.1.2:
+    resolution: {integrity: sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -8837,6 +8856,11 @@ packages:
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -10647,6 +10671,15 @@ snapshots:
       react: 19.2.1
 
   '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@mendable/firecrawl-js@1.29.3':
+    dependencies:
+      axios: 1.13.1(debug@4.4.3)
+      typescript-event-target: 1.1.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - debug
 
   '@monogrid/gainmap-js@3.1.0(three@0.170.0)':
     dependencies:
@@ -17227,6 +17260,8 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typescript-event-target@1.1.2: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.1: {}
@@ -17776,6 +17811,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary
A new shared package `@klorad/crawler` lands the platform-side primitive — Firecrawl scrape + Claude tool-use structured extractor — and Campus wires it up end-to-end. Rector pastes URLs on a new **Discovered** page → items show up in a News / Events inbox → approve creates a real NewsPost or EventPost, reject soft-deletes. Domain-agnostic by design: every Klorad app registers its own `ExtractorProfile` (per-content-type JSON Schema + system prompt); Mobility / Heritage / Urban will reuse the same package later.

## Architecture
```
┌── @klorad/crawler ─────────────────────────────────┐
│  types.ts                                          │
│  firecrawl.ts   ← thin client (markdown only)      │
│  extractor.ts   ← Claude tool-use, forced schema   │
│  runner.ts      ← URL → page → items, sequential   │
│  limits.ts      ← demo caps, exported              │
└────────────────────────────────────────────────────┘
                       ▲
                       │
┌── apps/campus ────────┴─────────────────────────────┐
│  lib/crawler/profile.ts  ← campus schemas           │
│  lib/crawler/approve.ts  ← payload → NewsPost/Event │
│  app/api/maps/[mapId]/crawler/jobs   (POST/GET)     │
│  app/api/maps/[mapId]/crawler/discovered (GET)      │
│  app/api/crawler/discovered/[id]/{approve,reject}   │
│  app/(dashboard)/.../discovered/ (UI)               │
└─────────────────────────────────────────────────────┘
```

`@klorad/crawler` never touches Prisma — the consuming app owns persistence and audit. Anthropic SDK is a peer dep so we don't bundle a second copy alongside the one Klio uses.

## Demo cap
| Lever | Value | Why |
|---|---|---|
| URLs per crawl | 5 | Hobby/Pro Vercel function caps wall-clock; 5 × ~6s scrape ≈ 30s. Headroom for the 60s `maxDuration`. |
| Pending items per project | 100 | Forces triage before piling on. Returns `429 INBOX_FULL` when crossed. |
| Instructions length | 500 chars | Useful nudge, capped prompt-injection blast radius. |

Constants live in `@klorad/crawler/limits` and are imported by both the API guard and the UI counter so the cap is a one-line edit when Phase 4 lifts it per plan.

## Out of scope (next phases)
- **Phase 2** — persistent `CrawlSource` model, per-source recrawl, optional domain allowlist patterns.
- **Phase 3** — Inngest durable job runner so crawls can outlive Vercel's 60-300s function limit.
- **Phase 4** — per-project monthly cost cap surfaced in UI, hard-kill on the runner, billing tier hook.
- Social-media connectors via Facebook/Instagram Graph API — separate arc once Phase 1-4 ship.

## Wiring required to use it
1. **Env**: set `FIRECRAWL_API_KEY` + `ANTHROPIC_API_KEY`. Without them `features.crawler` is false; the page renders a "not configured" notice and disables the Start crawl button.
2. **Migration**: `pnpm --filter @klorad/prisma prisma migrate deploy` will apply `20260606120000_add_crawler` (CrawlJob + DiscoveredItem + 2 enums).
3. Visit `/org/[orgId]/maps/[mapId]/discovered` — the new rail icon ("Discovered") will take you there.

## Test plan
- [ ] Run the migration locally.
- [ ] Set both env vars in Vercel preview.
- [ ] Open Discovered, paste a real university news URL (e.g. https://www.ihu.gr/news/some-article), click Start crawl.
- [ ] Confirm a News card lands in the inbox; click Source to verify the URL is the right one.
- [ ] Approve → confirm a NewsPost row exists in `/news` admin and `/campus/[token]/news` public.
- [ ] Reject another → confirm it disappears from inbox and the row's status is `rejected` in DB.
- [ ] Paste 6+ URLs → confirm only 5 are accepted (UI toast + API truncates).
- [ ] Fill the inbox past 100 items → confirm `429 INBOX_FULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)