### PR TITLE
feat(website): rewrite /campus to problem → solution → proof

### DIFF
--- a/apps/website/app/campus/page.tsx
+++ b/apps/website/app/campus/page.tsx
@@ -4,7 +4,7 @@ import { ProductPage, type ProductData } from "@/components/product-page";
 export const metadata: Metadata = {
   title: { absolute: "Klorad Campus | The campus app students actually use" },
   description:
-    "Mobile-first PWA for higher-ed campuses — indoor wayfinding, AI assistant, news / events / clubs / dining, push notifications, bilingual EN/ΕΛ. Installable. White-labelled per university.",
+    "Mobile-first PWA for higher-ed campuses: indoor wayfinding, an AI assistant, news, events, clubs, dining, and measurable push notifications. Bilingual EN and EL. Built for international presence and institutional data ownership. White-labelled per university.",
   alternates: { canonical: "/campus" },
 };
 
@@ -13,53 +13,158 @@ const data: ProductData = {
   heroImage: "/klorad-campus.webp",
   promise: "The campus app your students actually use.",
   lede:
-    "Klorad Campus is a mobile-first, installable PWA per university — indoor wayfinding, news, events, clubs, dining, and an AI assistant that answers in context. Brand it, link your MappedIn venue, share a QR. Students install it once and it lives on their home screen.",
+    "Klorad Campus is a mobile-first, installable PWA per university. It carries indoor wayfinding, news, events, clubs, dining, and an AI assistant that answers in context. Brand it, link your MappedIn venue, share a QR. Students install it once and it lives on their home screen.",
   intro:
     "For Greek higher education first, then any campus that wants a real app without writing one.",
   liveUrl: "https://campus.klorad.com",
   liveLabel: "Open the live campus →",
+
+  problem: {
+    title: "Today, campus information is scattered.",
+    body: "Students and prospective students hunt for what matters across channels the institution does not control. Announcements get buried, reach is never measured, and the research and international work of departments stays hard to find.",
+    cards: [
+      {
+        title: "Fragmented updates",
+        desc: "Important announcements and events get lost on external platforms ranked by algorithms, not by the institution.",
+      },
+      {
+        title: "Unmeasured reach",
+        desc: "The institution cannot tell what was read or who each update actually reached.",
+      },
+      {
+        title: "Underexposed value",
+        desc: "The research and international activity of departments and labs stays hard to find.",
+      },
+    ],
+    close:
+      "Klorad Campus replaces that with one branded, institutional surface, and makes reach measurable.",
+  },
+
   capabilities: [
     {
       title: "Native-app feel",
-      desc: "Persistent shell, instant tab swaps with skeletons, pull-to-refresh, install-to-home-screen. The same gestures iOS and Android users already trust.",
+      desc: "Lives on the home screen, used every day. Persistent shell, instant tab swaps with skeletons, pull-to-refresh, install to home screen. The same gestures iOS and Android users already trust.",
     },
     {
       title: "Klio, the campus assistant",
-      desc: "Ask in plain language — 'step-free route to the library', 'any robotics clubs?', 'what's open for lunch?'. Klio answers with inline source cards that deep-link straight into the right surface.",
+      desc: "Ask in plain language: 'which lab has a drone I can use?', 'is there a handball team?', 'is the Leo 200 scanner available anywhere?', 'which universities do we partner with?', 'step-free route to the library', 'what's open for lunch?'. Klio answers with inline source cards that deep link straight into the right surface.",
     },
     {
       title: "White-labelled per university",
-      desc: "Each campus is its own tenant — own name, logo, primary colour, hero, content. The whole palette derives from one hex; theme even tints the mobile browser chrome.",
+      desc: "Each campus is its own tenant. It carries its own name, logo, primary colour, hero, and content. The whole palette derives from one hex, and the theme even tints the mobile browser chrome.",
     },
   ],
   features: [
     {
-      title: "Indoor & outdoor wayfinding",
-      desc: "Powered by MappedIn — the venue you author once becomes the public viewer. Step-free routes are a first-class toggle, not an afterthought.",
+      title: "Indoor and outdoor wayfinding",
+      desc: "Powered by MappedIn. The venue you author once becomes the public viewer. Step-free routes are a first-class toggle, not an afterthought.",
     },
     {
-      title: "News · events · clubs · dining",
-      desc: "Four content surfaces with bilingual EN + ΕΛ authoring, per-row image upload, building-anchored deep links, schedule-ahead publishing, and ICS feed sync.",
+      title: "News, events, clubs, dining",
+      desc: "Four content surfaces with bilingual EN and EL authoring, per-row image upload, building-anchored deep links, schedule-ahead publishing, and ICS feed sync.",
     },
     {
       title: "Klio with cited sources",
-      desc: "Claude tool-use answers grounded in your campus data — every mention drops a tappable card to the news post, event, club, dining venue, or directions on the map.",
+      desc: "Claude tool-use answers grounded in your campus data. Every mention drops a tappable card to the news post, event, club, dining venue, or directions on the map.",
     },
     {
-      title: "Push notifications",
-      desc: "Web push subscribed silently on install. Broadcast composer in the dashboard sends to every device. Anonymous endpoints — no student identity collected.",
+      title: "Measurable push notifications",
+      desc: "Web push is subscribed silently on install, with no account and no identity collected. Every broadcast reports delivery and open analytics, so the institution knows what was read and who it reached.",
     },
     {
       title: "QR-shareable everything",
-      desc: "Every state of the map is in the URL — building selected, route configured, step highlighted. Generate a QR for a printed sign and students get the exact same view on tap.",
+      desc: "Every state of the map is in the URL: building selected, route configured, step highlighted. Generate a QR for a printed sign and students get the exact same view on tap.",
     },
     {
       title: "Five-minute setup, no developer",
-      desc: "Rector dashboard: link your MappedIn venue, set the brand colour, write the welcome copy in EN and ΕΛ, publish. The first campus goes live the same morning.",
+      desc: "Rector dashboard: link your MappedIn venue, set the brand colour, write the welcome copy in EN and EL, publish. The first campus goes live the same morning.",
     },
   ],
+
+  internationalPresence: {
+    eyebrow: "International presence",
+    title: "Built for international presence.",
+    body: "Bilingual is the floor, not the ceiling. Every department, lab, and member can surface international programmes, partnerships, and publications.",
+    cards: [
+      {
+        title: "Departments and schools",
+        desc: "International programmes, partnerships, mobility.",
+      },
+      {
+        title: "Labs and researchers",
+        desc: "Publications and research activity, systematically surfaced.",
+      },
+      {
+        title: "Partnership network",
+        desc: "'Which universities do we partner with' answered in the app, not the registry office.",
+      },
+      {
+        title: "Bilingual EN and EL",
+        desc: "On every field, extensible to more languages.",
+      },
+    ],
+  },
+
+  dataHub: {
+    eyebrow: "Data hub",
+    title: "Your data stays yours, and works for you.",
+    body: "Everyday use produces institutional data that stays in your ownership and turns into knowledge for decisions.",
+    cards: [
+      {
+        title: "Activity demand",
+        desc: "Which clubs and services draw the most interest.",
+      },
+      {
+        title: "Lab performance",
+        desc: "Which labs attract participation and why.",
+      },
+      {
+        title: "Movement patterns",
+        desc: "Which routes and spaces are searched most.",
+      },
+      {
+        title: "Evidence for decisions",
+        desc: "Data that supports planning and resource allocation.",
+      },
+    ],
+  },
+
+  digitalTwin: {
+    eyebrow: "Dynamic digital twin",
+    tag: "On the roadmap",
+    title: "A living digital twin, not a static map.",
+    body: "The campus model is dynamic. With sensors and operational data, it updates over time and supports operational decisions. The capabilities listed below are sensor-dependent and on the roadmap, not shipped today.",
+    cards: [
+      {
+        title: "Usage heatmaps",
+        desc: "With sensors, real frequency of use for spaces and routes.",
+      },
+      {
+        title: "Evacuation support",
+        desc: "Estimate the real distribution of people, beyond the paper plan.",
+      },
+      {
+        title: "Real-time accessibility",
+        desc: "Suggest alternative step-free routes around works.",
+      },
+      {
+        title: "Infrastructure planning",
+        desc: "Mapping feeds future interventions and resource optimisation.",
+      },
+    ],
+  },
+
+  credibility: {
+    body: "Built on a peer-reviewed architecture (ISPRS Int. J. Geo-Inf., 2025). In production today.",
+    cta: { label: "Read the research", href: "/research" },
+    image: {
+      src: "/research/klorad-system-model.png",
+      alt: "Klorad system model architecture: access, world, and integration layers.",
+    },
+  },
+
   builtOn:
-    "Klorad Campus is a world built on the Klorad platform. It runs on the same World model, the three renderers, and the live-data backbone behind every Klorad product — so the same plumbing scales to Mobility, Virtual Heritage, and Urban next.",
+    "Klorad Campus is a world built on the Klorad platform. It runs on the same World model, the three renderers, and the live-data backbone behind every Klorad product. The same plumbing scales to Mobility, Virtual Heritage, and Urban next.",
   ctaTitle: "Put your campus in your students' pockets.",
 };
 

--- a/apps/website/components/product-page.tsx
+++ b/apps/website/components/product-page.tsx
@@ -8,16 +8,47 @@ import {
   btnGhost,
 } from "@/components/ui";
 
+/** Three-card grouping used by the Problem block. */
+export type ProductProblem = {
+  /** Optional eyebrow. Defaults to "The problem". */
+  eyebrow?: string;
+  title: string;
+  body: string;
+  cards: { title: string; desc: string }[];
+  /** Optional closing line shown below the card grid. */
+  close?: string;
+};
+
+/** Four-card grouping shared by International / Data Hub / Digital Twin. */
+export type ProductStrategySection = {
+  eyebrow?: string;
+  title: string;
+  body: string;
+  cards: { title: string; desc: string }[];
+  /** Optional small tag rendered above the heading. Used by the
+   *  Digital Twin section to flag that the capabilities listed are
+   *  sensor-dependent and on the roadmap, not shipped today. */
+  tag?: string;
+};
+
+/** Small proof band linking to the research page. */
+export type ProductCredibility = {
+  body: string;
+  cta: { label: string; href: string };
+  /** Optional thumbnail. Path under /public, e.g. "/research/klorad-system-model.png". */
+  image?: { src: string; alt: string };
+};
+
 export type ProductData = {
   /** Full product name, e.g. "Klorad Campus". */
   product: string;
   /** Optional hero background image (path under /public). */
   heroImage?: string;
-  /** Hero headline — the promise. */
+  /** Hero headline, the promise. */
   promise: string;
   /** Hero subhead. */
   lede: string;
-  /** Hero tertiary line — who it is for. */
+  /** Hero tertiary line, who it is for. */
   intro: string;
   /** Three core capability cards. */
   capabilities: { title: string; desc: string }[];
@@ -30,15 +61,28 @@ export type ProductData = {
   /**
    * Optional URL to a running instance. When present, surfaces a
    * "View live" button alongside the primary CTA in both the hero
-   * and the closing section — buyers click to see the product
+   * and the closing section. Buyers click to see the product
    * before booking the audit.
    */
   liveUrl?: string;
   /** Visible label for the live link. Defaults to "View live demo". */
   liveLabel?: string;
+  /**
+   * Optional problem section rendered between Hero and Capabilities.
+   * When present, the page reads problem then solution then proof.
+   */
+  problem?: ProductProblem;
+  /** Optional strategic sections rendered between Features and the
+   *  "Built on Klorad" band. Each section follows the same shape: a
+   *  SectionHead with body, then a four-card grid. */
+  internationalPresence?: ProductStrategySection;
+  dataHub?: ProductStrategySection;
+  digitalTwin?: ProductStrategySection;
+  /** Small credibility band rendered just before "Built on Klorad". */
+  credibility?: ProductCredibility;
 };
 
-/** Shared template for every Klorad product page (Campus, Mobility, …). */
+/** Shared template for every Klorad product page (Campus, Mobility, etc). */
 export function ProductPage({ data }: { data: ProductData }) {
   return (
     <div>
@@ -59,7 +103,7 @@ export function ProductPage({ data }: { data: ProductData }) {
                 className="object-cover object-left-top"
               />
             </div>
-            {/* theme-aware scrim — keeps the hero text legible over the image */}
+            {/* theme-aware scrim. Keeps the hero text legible over the image. */}
             <div aria-hidden className="absolute inset-0 hero-image-scrim" />
           </>
         )}
@@ -114,6 +158,36 @@ export function ProductPage({ data }: { data: ProductData }) {
         </div>
       </section>
 
+      {/* ── Problem ────────────────────────────────────────── */}
+      {data.problem && (
+        <section className="border-t border-line-soft bg-surface-2 py-24 md:py-32">
+          <div className="mx-auto max-w-container px-6 md:px-8">
+            <SectionHead
+              eyebrow={data.problem.eyebrow ?? "The problem"}
+              title={data.problem.title}
+              intro={data.problem.body}
+            />
+            <div className="mt-12 grid gap-5 md:grid-cols-3">
+              {data.problem.cards.map((c) => (
+                <div key={c.title} className="glass-panel rounded-2xl p-7">
+                  <h3 className="text-xl font-medium text-text-primary">
+                    {c.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+                    {c.desc}
+                  </p>
+                </div>
+              ))}
+            </div>
+            {data.problem.close && (
+              <p className="mt-10 max-w-3xl text-base leading-relaxed text-text-primary md:text-lg">
+                {data.problem.close}
+              </p>
+            )}
+          </div>
+        </section>
+      )}
+
       {/* ── Capabilities ───────────────────────────────────── */}
       <section className="border-t border-line-soft py-24 md:py-32">
         <div className="mx-auto max-w-container px-6 md:px-8">
@@ -157,6 +231,53 @@ export function ProductPage({ data }: { data: ProductData }) {
           </div>
         </div>
       </section>
+
+      {/* ── International presence ─────────────────────────── */}
+      <StrategySection section={data.internationalPresence} />
+
+      {/* ── Data hub ───────────────────────────────────────── */}
+      <StrategySection
+        section={data.dataHub}
+        background="bg-surface-2"
+      />
+
+      {/* ── Dynamic digital twin (roadmap) ─────────────────── */}
+      <StrategySection section={data.digitalTwin} />
+
+      {/* ── Credibility ────────────────────────────────────── */}
+      {data.credibility && (
+        <section className="border-t border-line-soft bg-surface-2 py-16 md:py-20">
+          <div className="mx-auto max-w-container px-6 md:px-8">
+            <div className="glass-panel flex flex-col items-start gap-6 rounded-2xl p-7 md:flex-row md:items-center md:gap-8 md:p-9">
+              {data.credibility.image && (
+                <div className="shrink-0 overflow-hidden rounded-xl border border-line-soft bg-bg">
+                  <Image
+                    src={data.credibility.image.src}
+                    alt={data.credibility.image.alt}
+                    width={180}
+                    height={92}
+                    sizes="180px"
+                    className="h-auto w-[180px]"
+                  />
+                </div>
+              )}
+              <div className="min-w-0 flex-1">
+                <Eyebrow>Peer-reviewed</Eyebrow>
+                <p className="mt-3 text-base leading-relaxed text-text-primary md:text-lg">
+                  {data.credibility.body}
+                </p>
+                <Link
+                  href={data.credibility.cta.href}
+                  className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-accent transition-colors hover:text-accent-hover"
+                >
+                  {data.credibility.cta.label}
+                  <ArrowIcon />
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ── Built on Klorad ────────────────────────────────── */}
       <section className="border-t border-line-soft py-24 md:py-32">
@@ -219,5 +340,55 @@ export function ProductPage({ data }: { data: ProductData }) {
         </div>
       </section>
     </div>
+  );
+}
+
+/** Shared layout for the International / Data Hub / Digital Twin
+ *  sections. They have the same shape (head with optional tag, body,
+ *  four-card grid) so they share one renderer. */
+function StrategySection({
+  section,
+  background,
+}: {
+  section?: ProductStrategySection;
+  background?: string;
+}) {
+  if (!section) return null;
+  return (
+    <section
+      className={`border-t border-line-soft py-24 md:py-32${
+        background ? ` ${background}` : ""
+      }`}
+    >
+      <div className="mx-auto max-w-container px-6 md:px-8">
+        <div className="max-w-3xl">
+          {section.tag && (
+            <span className="mb-5 inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent-soft px-3 py-1 text-[10px] font-medium uppercase tracking-[0.24em] text-accent">
+              <span aria-hidden className="h-1 w-1 rounded-full bg-accent" />
+              {section.tag}
+            </span>
+          )}
+          {section.eyebrow && <Eyebrow>{section.eyebrow}</Eyebrow>}
+          <h2 className="mt-5 text-3xl font-light leading-[1.12] text-text-primary md:text-[42px]">
+            {section.title}
+          </h2>
+          <p className="mt-5 text-base leading-relaxed text-text-secondary md:text-lg">
+            {section.body}
+          </p>
+        </div>
+        <div className="mt-12 grid gap-5 md:grid-cols-2 lg:grid-cols-4">
+          {section.cards.map((c) => (
+            <div key={c.title} className="glass-panel rounded-2xl p-6">
+              <h3 className="text-base font-medium text-text-primary">
+                {c.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+                {c.desc}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
Re-sequences `/campus` from feature-first to **problem → solution → proof**, and adds three strategic sections the old page never made: international presence, institutional data ownership, and a clearly-labelled roadmap digital-twin section. All copy is em-dash-free per the sales-collateral style.

## Page order (new)
1. Hero (kept, lede em-dashes scrubbed)
2. **Problem** *(new)* — Today, campus information is scattered.
3. Capabilities (kept; Native-app feel + Klio cards edited)
4. Features (kept; Push retitled and rewritten with delivery + open analytics)
5. **International presence** *(new)* — 4 cards
6. **Data hub** *(new)* — 4 cards, your-data-stays-yours framing
7. **Dynamic digital twin** *(new)* — 4 cards, **`On the roadmap` pill** above the heading and a body line explicitly stating the listed capabilities are sensor-dependent and not shipped today
8. **Credibility band** *(new)* — peer-reviewed callout linking to `/research`
9. Built on Klorad (kept)
10. CTA (kept)

## Copy edits to existing sections
- **Native-app feel** — leads with the outcome: *"Lives on the home screen, used every day."*
- **Klio** — six concrete example questions (drone lab, handball team, Leo 200 scanner, partner universities, step-free route, what's open for lunch).
- **Push** — retitled *"Measurable push notifications"*: *"Web push is subscribed silently on install, with no account and no identity collected. Every broadcast reports delivery and open analytics, so the institution knows what was read and who it reached."*
- **Em dashes** — six instances scrubbed across the page; replaced with periods, colons, or commas.

## ProductPage extension
Added five optional fields to `ProductData` (`problem`, `internationalPresence`, `dataHub`, `digitalTwin`, `credibility`) and matching render blocks. **Backward-compatible** — `/mobility`, `/virtual-heritage`, `/urban` don't pass them, so those pages render unchanged. Four-card strategy sections share a `<StrategySection>` helper so visual rhythm + alternating `bg-surface-2` stays consistent.

## What is NOT claimed as shipped
Only the **Dynamic digital twin** section labels capabilities as roadmap. The pill (`On the roadmap`) sits above the heading and the section body restates *"sensor-dependent and on the roadmap, not shipped today"*. Heatmaps, evacuation support, real-time accessibility, and infrastructure planning are all under that label.

## Bilingual EL (recommended, not built in this PR)
1. **Localised sibling route at `/el/campus` (recommended for v1).** Shared copy module (`lib/campus-copy.ts`) so EN + EL diverge only on strings; `app/el/layout.tsx` sets `lang="el"`; site-header gets an EN / ΕΛ toggle hidden until a Greek twin exists; sitemap gets `/el/campus` + `alternates.languages` on both pages for SEO.
2. `?lang=el` query toggle — rejected, bad for SEO + URL doesn't feel institutional.
3. Full `next-intl` setup with `/[locale]/...` — overkill for one page; revisit when 2–3 marketing pages need it.

Tell me to ship option 1 and I'll do it on its own branch.

## Test plan
- [ ] Open `/campus` on staging, scroll: hero → problem → capabilities → features → international → data hub → digital twin (with the **On the roadmap** pill visible) → credibility → built on → CTA.
- [ ] Verify the `On the roadmap` pill renders above the digital-twin heading in both light and dark themes.
- [ ] Verify the credibility band shows the system-model thumbnail and the "Read the research" link lands on `/research`.
- [ ] Visit `/mobility`, `/virtual-heritage`, `/urban` — confirm those pages are unchanged (regression check for the shared `ProductPage`).
- [ ] grep the rendered page source for `—` and `–` — none should appear in `/campus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)