### PR TITLE
fix(mobility): world viewer chrome — theme palette, height, operator overlay polish

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -547,39 +547,50 @@ function Legend({ devices }: { devices: DeviceRow[] }) {
   const needsReview = devices.filter((d) => d.needsReview).length;
   const publicCount = devices.filter((d) => d.isPublic).length;
   return (
-    <div className="pointer-events-auto absolute left-4 top-4 max-w-[260px] rounded-2xl border border-line-soft bg-bg/95 p-3 text-xs shadow-sm backdrop-blur">
-      <div className="mb-2 flex items-center gap-2">
-        <Layers size={12} strokeWidth={1.8} className="text-text-tertiary" aria-hidden />
-        <span className="font-medium text-text-primary">
-          {placed.length} / {devices.length} placed
-        </span>
-        {needsReview > 0 && (
-          <span className="rounded-full bg-yellow-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] text-yellow-600">
-            {needsReview} new
-          </span>
-        )}
-      </div>
-      <ul className="space-y-1">
-        {MARKER_LEGEND.map((row) => (
-          <li
-            key={row.tone}
-            className="flex items-center gap-2 text-[11px] text-text-secondary"
+    <div className="pointer-events-auto absolute left-4 top-4 max-w-[260px] overflow-hidden rounded-2xl border border-line-strong bg-surface-1/95 shadow-[0_8px_30px_rgba(0,0,0,0.18)] backdrop-blur-xl">
+      <div className="border-b border-line-soft bg-accent-soft/40 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-accent text-accent-contrast"
           >
-            <span
-              aria-hidden
-              className="h-2 w-2 shrink-0 rounded-full"
-              style={{
-                backgroundColor: row.colour,
-                boxShadow: `0 0 0 2px ${row.colour}33`,
-              }}
-            />
-            <span className="truncate">{row.label}</span>
-          </li>
-        ))}
-      </ul>
-      <p className="mt-3 border-t border-line-soft pt-2 text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
-        {publicCount} on traveller map
-      </p>
+            <Layers size={11} strokeWidth={2} />
+          </span>
+          <span className="text-xs font-semibold text-text-primary">
+            {placed.length}
+            <span className="text-text-tertiary"> / {devices.length}</span>{" "}
+            <span className="text-text-secondary">placed</span>
+          </span>
+          {needsReview > 0 && (
+            <span className="ml-auto rounded-full bg-yellow-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-yellow-700 dark:text-yellow-400">
+              {needsReview} new
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="px-3 py-2.5">
+        <ul className="space-y-1.5">
+          {MARKER_LEGEND.map((row) => (
+            <li
+              key={row.tone}
+              className="flex items-center gap-2 text-[11px] text-text-secondary"
+            >
+              <span
+                aria-hidden
+                className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-bg"
+                style={{
+                  backgroundColor: row.colour,
+                  boxShadow: `0 0 0 1px ${row.colour}80, 0 0 8px ${row.colour}55`,
+                }}
+              />
+              <span className="truncate">{row.label}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 border-t border-line-soft pt-2 text-[10px] font-medium uppercase tracking-[0.2em] text-text-tertiary">
+          <span className="text-text-secondary">{publicCount}</span> on traveller map
+        </p>
+      </div>
     </div>
   );
 }
@@ -590,11 +601,11 @@ function SourcesChip({ href }: { href: string }) {
   return (
     <Link
       href={href}
-      className="inline-flex items-center gap-1.5 rounded-full border border-line-soft bg-bg/95 px-3.5 py-2 text-xs font-medium text-text-primary shadow-sm backdrop-blur transition-colors hover:border-accent hover:text-accent"
+      className="inline-flex items-center gap-1.5 rounded-full border border-line-strong bg-surface-1/95 px-3.5 py-2 text-xs font-semibold text-text-primary shadow-[0_4px_14px_rgba(0,0,0,0.16)] backdrop-blur-xl transition-all hover:border-accent hover:bg-accent-soft hover:text-accent"
     >
-      <Database size={12} strokeWidth={1.8} aria-hidden />
+      <Database size={12} strokeWidth={2} aria-hidden />
       Data sources
-      <ArrowUpRight size={11} strokeWidth={1.8} aria-hidden />
+      <ArrowUpRight size={11} strokeWidth={2} aria-hidden />
     </Link>
   );
 }
@@ -618,17 +629,17 @@ function ConsoleSettingsChip({
         type="button"
         onClick={() => onOpenChange(!open)}
         aria-expanded={open}
-        className={`inline-flex items-center gap-1.5 rounded-full border bg-bg/95 px-3.5 py-2 text-xs font-medium shadow-sm backdrop-blur transition-colors ${
+        className={`inline-flex items-center gap-1.5 rounded-full border bg-surface-1/95 px-3.5 py-2 text-xs font-semibold shadow-[0_4px_14px_rgba(0,0,0,0.16)] backdrop-blur-xl transition-all ${
           open
-            ? "border-accent text-accent"
-            : "border-line-soft text-text-primary hover:border-accent hover:text-accent"
+            ? "border-accent bg-accent-soft text-accent"
+            : "border-line-strong text-text-primary hover:border-accent hover:bg-accent-soft hover:text-accent"
         }`}
       >
-        <Settings size={12} strokeWidth={1.8} aria-hidden />
+        <Settings size={12} strokeWidth={2} aria-hidden />
         Console
       </button>
       {open ? (
-        <div className="mt-2 w-[280px] rounded-2xl border border-line-soft bg-bg/95 p-4 text-xs shadow-md backdrop-blur">
+        <div className="mt-2 w-[280px] overflow-hidden rounded-2xl border border-line-strong bg-surface-1/95 text-xs shadow-[0_12px_36px_rgba(0,0,0,0.22)] backdrop-blur-xl"><div className="p-4">
           {/* Map style */}
           <p className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.22em] text-text-tertiary">
             <Layers size={11} strokeWidth={1.8} aria-hidden />
@@ -727,14 +738,18 @@ function ConsoleSettingsChip({
             />
           </div>
 
-          {/* Reset */}
-          <button
-            type="button"
-            onClick={() => onChange(DEFAULT_CONSOLE_SETTINGS)}
-            className="mt-4 w-full rounded-md border border-line-soft px-3 py-1.5 text-[11px] font-medium text-text-tertiary transition-colors hover:border-line-strong hover:text-text-primary"
-          >
-            Reset to defaults
-          </button>
+          </div>
+          {/* Reset — sits in its own subtly-tinted footer so the
+              destructive action reads as separate from the toggles. */}
+          <div className="border-t border-line-soft bg-surface-2/40 px-4 py-2.5">
+            <button
+              type="button"
+              onClick={() => onChange(DEFAULT_CONSOLE_SETTINGS)}
+              className="w-full rounded-md px-3 py-1.5 text-[11px] font-semibold text-text-tertiary transition-colors hover:bg-accent-soft hover:text-accent"
+            >
+              Reset to defaults
+            </button>
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/mobility/app/(public)/w/[slug]/PushOptIn.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/PushOptIn.tsx
@@ -160,8 +160,20 @@ export function PushOptIn({ slug, primary }: Props) {
       onClick={onClick}
       disabled={busy}
       aria-pressed={subscribed}
-      className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-[11px] font-medium text-white shadow-sm backdrop-blur transition-colors hover:bg-white/20 disabled:opacity-60"
-      style={subscribed ? { borderColor: primary, color: primary } : undefined}
+      className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[11px] font-medium shadow-sm backdrop-blur transition-colors disabled:opacity-60"
+      style={
+        subscribed
+          ? {
+              borderColor: primary,
+              color: primary,
+              backgroundColor: "var(--w-accent-soft)",
+            }
+          : {
+              borderColor: "var(--w-border-strong)",
+              color: "var(--w-fg)",
+              backgroundColor: "var(--w-overlay)",
+            }
+      }
     >
       <Icon size={12} strokeWidth={1.8} aria-hidden />
       {label}

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -363,8 +363,8 @@ export function WorldViewer({
   if (!mapboxToken) {
     return (
       <main
-        className="flex h-[100dvh] w-full items-center justify-center p-8 text-center text-sm text-white"
-        style={{ backgroundColor: bg }}
+        className="flex w-full items-center justify-center p-8 text-center text-sm text-white"
+        style={{ height: "100dvh", backgroundColor: bg }}
       >
         Map is unavailable.
       </main>
@@ -373,10 +373,19 @@ export function WorldViewer({
 
   return (
     <main
-      className="relative h-[100dvh] w-full overflow-hidden"
-      style={{ backgroundColor: bg }}
+      className="relative w-full overflow-hidden"
+      // Inline `height` so the layout doesn't depend on Tailwind's
+      // arbitrary-value JIT picking up `h-[100dvh]` for this route.
+      // Mapbox needs a measurable container before init, and any
+      // height-purge causes the canvas to collapse to 0 — symptom is
+      // a blank screen with the html/body background showing through.
+      style={{ height: "100dvh", backgroundColor: bg }}
     >
-      <div ref={mapEl} className="absolute inset-0" />
+      <div
+        ref={mapEl}
+        className="absolute inset-0"
+        style={{ width: "100%", height: "100%" }}
+      />
 
       {/* World title — top-left card. Kept compact so it doesn't
           dominate the map; the install prompt + drawer live elsewhere. */}

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -70,6 +70,67 @@ function pickHex(value: unknown, fallback: string): string {
   return fallback;
 }
 
+/** Expand `#rgb` → `#rrggbb` so the channel reads below stay uniform. */
+function expandHex(hex: string): string {
+  if (hex.length === 7) return hex;
+  const body = hex.slice(1);
+  return `#${body[0]}${body[0]}${body[1]}${body[1]}${body[2]}${body[2]}`;
+}
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function hexToRgb(hex: string): RGB {
+  const h = expandHex(hex).slice(1);
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function rgba({ r, g, b }: RGB, a: number): string {
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+/** Perceived brightness — drives the fg/border choice so the operator
+ *  can paint a world bright or dark and the chrome reads either way. */
+function isLight({ r, g, b }: RGB): boolean {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.55;
+}
+
+/**
+ * Derive every chrome colour from the operator's two picks. Returned
+ * as a flat record of CSS custom properties so the viewer can drop
+ * them onto a single style block on `<main>` and every descendant
+ * info-box / button reads them via `var(--w-*)` instead of hard-coded
+ * `text-white` / `bg-black` classes that fight a bright theme.
+ */
+function deriveWorldPalette(bg: string, primary: string): Record<string, string> {
+  const bgRgb = hexToRgb(bg);
+  const primaryRgb = hexToRgb(primary);
+  const light = isLight(bgRgb);
+  const fgBase: RGB = light ? { r: 11, g: 18, b: 32 } : { r: 245, g: 247, b: 250 };
+  const accentContrast: RGB = isLight(primaryRgb)
+    ? { r: 11, g: 18, b: 32 }
+    : { r: 255, g: 255, b: 255 };
+  return {
+    "--w-bg": bg,
+    "--w-fg": rgba(fgBase, 0.95),
+    "--w-fg-soft": rgba(fgBase, 0.72),
+    "--w-fg-muted": rgba(fgBase, 0.5),
+    "--w-border": rgba(fgBase, light ? 0.14 : 0.16),
+    "--w-border-strong": rgba(fgBase, light ? 0.22 : 0.28),
+    "--w-overlay": rgba(fgBase, light ? 0.06 : 0.08),
+    "--w-accent": primary,
+    "--w-accent-soft": rgba(primaryRgb, 0.18),
+    "--w-accent-contrast": rgba(accentContrast, 1),
+  };
+}
+
 function fitToDevices(map: MapboxMap, devices: PublicWorldDevice[]): void {
   const located = devices.filter(
     (d): d is PublicWorldDevice & { lat: number; lng: number } =>
@@ -203,6 +264,10 @@ export function WorldViewer({
   const bg = pickHex(theme.backgroundColor, DEFAULT_BG);
   const logoUrl = typeof theme.logoUrl === "string" ? theme.logoUrl : null;
   const tagline = typeof theme.tagline === "string" ? theme.tagline : null;
+  /** Operator-driven palette as CSS variables. Set once on `<main>`
+   *  so every info box can read `var(--w-fg)` etc. instead of fighting
+   *  hard-coded text-white / bg-black classes. */
+  const paletteStyle = useMemo(() => deriveWorldPalette(bg, primary), [bg, primary]);
 
   const mapEl = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapboxMap | null>(null);
@@ -363,8 +428,13 @@ export function WorldViewer({
   if (!mapboxToken) {
     return (
       <main
-        className="flex w-full items-center justify-center p-8 text-center text-sm text-white"
-        style={{ height: "100dvh", backgroundColor: bg }}
+        className="flex w-full items-center justify-center p-8 text-center text-sm"
+        style={{
+          height: "100dvh",
+          backgroundColor: bg,
+          color: "var(--w-fg)",
+          ...paletteStyle,
+        }}
       >
         Map is unavailable.
       </main>
@@ -379,7 +449,10 @@ export function WorldViewer({
       // Mapbox needs a measurable container before init, and any
       // height-purge causes the canvas to collapse to 0 — symptom is
       // a blank screen with the html/body background showing through.
-      style={{ height: "100dvh", backgroundColor: bg }}
+      //
+      // The `--w-*` palette is plumbed once here so every floating
+      // info box can theme off it without hard-coded colours.
+      style={{ height: "100dvh", backgroundColor: bg, ...paletteStyle }}
     >
       <div
         ref={mapEl}
@@ -388,10 +461,16 @@ export function WorldViewer({
       />
 
       {/* World title — top-left card. Kept compact so it doesn't
-          dominate the map; the install prompt + drawer live elsewhere. */}
+          dominate the map; the install prompt + drawer live elsewhere.
+          All colours read from the `--w-*` palette so a light theme
+          renders dark text on a bright card and vice versa. */}
       <header
-        className="pointer-events-none absolute left-4 top-4 max-w-[min(86%,360px)] rounded-2xl border border-white/10 bg-[var(--world-bg)]/85 px-4 py-3 text-white shadow-lg backdrop-blur"
-        style={{ ["--world-bg" as string]: bg }}
+        className="pointer-events-none absolute left-4 top-4 max-w-[min(86%,360px)] rounded-2xl border px-4 py-3 shadow-lg backdrop-blur"
+        style={{
+          borderColor: "var(--w-border)",
+          backgroundColor: "color-mix(in srgb, var(--w-bg) 85%, transparent)",
+          color: "var(--w-fg)",
+        }}
       >
         <div className="flex items-center gap-2">
           {logoUrl ? (
@@ -405,17 +484,23 @@ export function WorldViewer({
               className="h-7 w-7 shrink-0 rounded-md object-cover"
             />
           ) : null}
-          <p className="text-[10px] font-medium uppercase tracking-[0.22em] text-white/60">
+          <p
+            className="text-[10px] font-medium uppercase tracking-[0.22em]"
+            style={{ color: "var(--w-fg-muted)" }}
+          >
             Klorad Mobility
           </p>
         </div>
         <h1 className="mt-1 text-base font-semibold">{name}</h1>
         {tagline || description ? (
-          <p className="mt-1 line-clamp-2 text-xs text-white/70">
+          <p
+            className="mt-1 line-clamp-2 text-xs"
+            style={{ color: "var(--w-fg-soft)" }}
+          >
             {tagline || description}
           </p>
         ) : null}
-        <p className="mt-1.5 text-[11px] text-white/50">
+        <p className="mt-1.5 text-[11px]" style={{ color: "var(--w-fg-muted)" }}>
           <span style={{ color: primary }}>{devices.length}</span> devices ·{" "}
           <code className="font-mono">/w/{slug}</code>
         </p>
@@ -435,7 +520,6 @@ export function WorldViewer({
       <DeviceDrawer
         device={selected}
         primary={primary}
-        bg={bg}
         onClose={() => setSelectedId(null)}
       />
     </main>
@@ -472,8 +556,14 @@ function MapSettingsButton({
         onClick={() => onOpenChange(!open)}
         aria-expanded={open}
         aria-label="Map settings"
-        className="pointer-events-auto inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-black/60 text-white shadow-lg backdrop-blur transition-colors hover:bg-black/75"
-        style={open ? { borderColor: primary, color: primary } : undefined}
+        className="pointer-events-auto inline-flex h-11 w-11 items-center justify-center rounded-full border shadow-lg backdrop-blur transition-colors"
+        style={{
+          borderColor: open ? primary : "var(--w-border-strong)",
+          backgroundColor: open
+            ? "var(--w-accent-soft)"
+            : "color-mix(in srgb, var(--w-bg) 78%, transparent)",
+          color: open ? primary : "var(--w-fg)",
+        }}
         title={`Style: ${styleDef.label}`}
       >
         <Settings size={16} strokeWidth={1.8} aria-hidden />
@@ -493,9 +583,20 @@ function MapSettingsPanel({
 }) {
   const activeStyle = MAP_STYLES[settings.mapStyle];
   return (
-    <div className="pointer-events-auto w-[280px] rounded-2xl border border-white/15 bg-[#0b1220]/95 p-4 text-xs text-white shadow-2xl backdrop-blur">
+    <div
+      className="pointer-events-auto w-[280px] rounded-2xl border p-4 text-xs shadow-2xl backdrop-blur"
+      style={{
+        borderColor: "var(--w-border-strong)",
+        backgroundColor:
+          "color-mix(in srgb, var(--w-bg) 92%, transparent)",
+        color: "var(--w-fg)",
+      }}
+    >
       {/* Style */}
-      <p className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.22em] text-white/60">
+      <p
+        className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.22em]"
+        style={{ color: "var(--w-fg-muted)" }}
+      >
         <LayersIcon size={11} strokeWidth={1.8} aria-hidden />
         Style
       </p>
@@ -508,15 +609,29 @@ function MapSettingsPanel({
               type="button"
               aria-pressed={active}
               onClick={() => onChange({ ...settings, mapStyle: key })}
-              className="rounded-md px-1.5 py-2 text-[10px] font-medium text-white/80 transition-colors hover:bg-white/10"
+              className="rounded-md px-1.5 py-2 text-[10px] font-medium transition-colors"
               style={
                 active
-                  ? { backgroundColor: primary, color: "#0b1220" }
-                  : undefined
+                  ? {
+                      backgroundColor: primary,
+                      color: "var(--w-accent-contrast)",
+                    }
+                  : {
+                      color: "var(--w-fg-soft)",
+                      backgroundColor: "transparent",
+                    }
               }
             >
               <span className="block">{def.label}</span>
-              <span className="mt-0.5 block text-[9px] font-normal opacity-70">
+              <span
+                className="mt-0.5 block text-[9px] font-normal"
+                style={{
+                  color: active
+                    ? "var(--w-accent-contrast)"
+                    : "var(--w-fg-muted)",
+                  opacity: active ? 0.85 : 1,
+                }}
+              >
                 {def.description}
               </span>
             </button>
@@ -526,14 +641,21 @@ function MapSettingsPanel({
 
       {/* Light */}
       <p
-        className={`mt-4 mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.22em] ${
-          activeStyle.supportsLightPreset ? "text-white/60" : "text-white/30"
-        }`}
+        className="mt-4 mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.22em]"
+        style={{
+          color: activeStyle.supportsLightPreset
+            ? "var(--w-fg-muted)"
+            : "var(--w-fg-muted)",
+          opacity: activeStyle.supportsLightPreset ? 1 : 0.55,
+        }}
       >
         <Sun size={11} strokeWidth={1.8} aria-hidden />
         Light
         {!activeStyle.supportsLightPreset ? (
-          <span className="ml-1 text-[8px] font-normal normal-case tracking-normal text-white/40">
+          <span
+            className="ml-1 text-[8px] font-normal normal-case tracking-normal"
+            style={{ color: "var(--w-fg-muted)", opacity: 0.75 }}
+          >
             (Standard / Satellite only)
           </span>
         ) : null}
@@ -556,11 +678,17 @@ function MapSettingsPanel({
               aria-pressed={active}
               disabled={disabled}
               onClick={() => onChange({ ...settings, lightPreset: value })}
-              className="flex flex-col items-center justify-center gap-0.5 rounded-md px-1.5 py-2 text-[10px] font-medium text-white/80 transition-colors enabled:hover:bg-white/10 disabled:opacity-40"
+              className="flex flex-col items-center justify-center gap-0.5 rounded-md px-1.5 py-2 text-[10px] font-medium transition-colors disabled:opacity-40"
               style={
                 active && !disabled
-                  ? { backgroundColor: primary, color: "#0b1220" }
-                  : undefined
+                  ? {
+                      backgroundColor: primary,
+                      color: "var(--w-accent-contrast)",
+                    }
+                  : {
+                      color: "var(--w-fg-soft)",
+                      backgroundColor: "transparent",
+                    }
               }
             >
               <Icon size={13} strokeWidth={1.8} aria-hidden />
@@ -595,7 +723,11 @@ function MapSettingsPanel({
       <button
         type="button"
         onClick={() => onChange(DEFAULT_SETTINGS)}
-        className="mt-3 w-full rounded-md border border-white/15 px-3 py-1.5 text-[11px] font-medium text-white/60 transition-colors hover:border-white/30 hover:text-white/85"
+        className="mt-3 w-full rounded-md border px-3 py-1.5 text-[11px] font-medium transition-colors"
+        style={{
+          borderColor: "var(--w-border)",
+          color: "var(--w-fg-muted)",
+        }}
       >
         Reset to defaults
       </button>
@@ -623,14 +755,22 @@ function PanelToggle({
   return (
     <label
       className={`flex items-center justify-between rounded-md px-2 py-1.5 transition-colors ${
-        disabled ? "opacity-40" : "cursor-pointer hover:bg-white/5"
+        disabled ? "opacity-40" : "cursor-pointer"
       }`}
     >
-      <span className="inline-flex items-center gap-2 text-white/90">
+      <span
+        className="inline-flex items-center gap-2"
+        style={{ color: "var(--w-fg)" }}
+      >
         <Icon size={12} strokeWidth={1.8} aria-hidden />
         {label}
         {disabled && disabledHint ? (
-          <span className="text-[9px] text-white/40">({disabledHint})</span>
+          <span
+            className="text-[9px]"
+            style={{ color: "var(--w-fg-muted)" }}
+          >
+            ({disabledHint})
+          </span>
         ) : null}
       </span>
       <button
@@ -639,16 +779,25 @@ function PanelToggle({
         aria-checked={checked}
         disabled={disabled}
         onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-          checked ? "" : "border border-white/25 bg-transparent"
-        }`}
-        style={checked && !disabled ? { backgroundColor: primary } : undefined}
+        className="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors"
+        style={{
+          backgroundColor:
+            checked && !disabled ? primary : "transparent",
+          borderColor:
+            checked && !disabled ? primary : "var(--w-border-strong)",
+        }}
       >
         <span
           aria-hidden
-          className={`h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+          className={`h-4 w-4 rounded-full shadow-sm transition-transform ${
             checked ? "translate-x-4" : "translate-x-0.5"
           }`}
+          style={{
+            backgroundColor:
+              checked && !disabled
+                ? "var(--w-accent-contrast)"
+                : "var(--w-fg-soft)",
+          }}
         />
       </button>
     </label>
@@ -660,12 +809,10 @@ function PanelToggle({
 function DeviceDrawer({
   device,
   primary,
-  bg,
   onClose,
 }: {
   device: PublicWorldDevice | null;
   primary: string;
-  bg: string;
   onClose: () => void;
 }) {
   if (!device) return null;
@@ -678,18 +825,25 @@ function DeviceDrawer({
 
   return (
     <aside
-      className="absolute bottom-0 left-0 right-0 z-10 mx-auto max-w-[640px] rounded-t-2xl border border-white/10 bg-[var(--world-bg)]/95 p-5 text-white shadow-2xl backdrop-blur md:bottom-4 md:left-4 md:right-auto md:w-[360px] md:rounded-2xl"
-      style={{ ["--world-bg" as string]: bg }}
+      className="absolute bottom-0 left-0 right-0 z-10 mx-auto max-w-[640px] rounded-t-2xl border p-5 shadow-2xl backdrop-blur md:bottom-4 md:left-4 md:right-auto md:w-[360px] md:rounded-2xl"
+      style={{
+        borderColor: "var(--w-border)",
+        backgroundColor: "color-mix(in srgb, var(--w-bg) 94%, transparent)",
+        color: "var(--w-fg)",
+      }}
     >
       <div className="flex items-start gap-3">
         <span
           className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full"
-          style={{ backgroundColor: `${primary}33`, color: primary }}
+          style={{ backgroundColor: "var(--w-accent-soft)", color: primary }}
         >
           <Icon size={16} strokeWidth={1.8} aria-hidden />
         </span>
         <div className="flex-1 min-w-0">
-          <p className="text-[10px] font-medium uppercase tracking-[0.22em] text-white/50">
+          <p
+            className="text-[10px] font-medium uppercase tracking-[0.22em]"
+            style={{ color: "var(--w-fg-muted)" }}
+          >
             {device.subsystem.toUpperCase()}
           </p>
           <h2 className="mt-0.5 truncate text-sm font-semibold">{device.name}</h2>
@@ -698,7 +852,8 @@ function DeviceDrawer({
           type="button"
           onClick={onClose}
           aria-label="Close"
-          className="rounded-full p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+          className="rounded-full p-1 transition-colors"
+          style={{ color: "var(--w-fg-muted)" }}
         >
           <ArrowLeft size={14} strokeWidth={1.8} aria-hidden />
         </button>
@@ -733,8 +888,10 @@ function DeviceDrawer({
 function Row({ label, value }: { label: React.ReactNode; value: string }) {
   return (
     <div className="flex items-center justify-between gap-3">
-      <dt className="text-white/50">{label}</dt>
-      <dd className="truncate font-medium text-white/90">{value}</dd>
+      <dt style={{ color: "var(--w-fg-muted)" }}>{label}</dt>
+      <dd className="truncate font-medium" style={{ color: "var(--w-fg)" }}>
+        {value}
+      </dd>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three polish fixes on top of the merged Worlds arc (#218). All three landed after the merge so they were stranded on the dead branch.

- **Operator console overlays** — Legend + Sources/Console chips now read as proper Klorad surfaces (\`surface-1/95\` over \`backdrop-blur-xl\`, \`border-line-strong\`, deeper drop-shadow), with \`accent-soft\` hover/open states and an accent-tinted header on the Legend.
- **World viewer height** — \`<main>\` and the map container switch to inline \`height: 100dvh\` / \`width: 100%\` instead of Tailwind arbitrary values. Defensive against any content-scan glob edge case (route groups, bracketed dynamic segments) — the symptom was a blank white screen where the map collapsed to 0.
- **Theme palette plumbing** — Every floating element in the public world viewer now reads from \`--w-*\` CSS custom properties derived from the operator's chosen \`primaryColor\` + \`backgroundColor\`. Foreground tier flips dark/light based on perceived brightness of the background, so a bright theme paints dark text on the cards and a dark theme paints light text. Surfaces fixed: world header card, map-settings gear + popover + chips + toggles + reset, device drawer + rows, push opt-in pill.

## Test plan

- [ ] Operator console: Legend + chips read clearly over Standard, Satellite, and Minimal styles
- [ ] Public world (\`/w/<slug>\`): map fills the viewport — no collapsed-to-0 blank screen
- [ ] Operator theme: set primary to a light colour + background to white — cards in the public viewer render with dark text + visible borders
- [ ] Operator theme: keep the default dark theme — cards render with white text on dark cards (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)