### PR TITLE
feat(mobility): device styles Phase 3 — 3D devices on Mapbox

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import mapboxgl, {
   type GeoJSONSource,
@@ -46,6 +46,11 @@ import {
   type MapStyleKey,
 } from "@/lib/mobility/map-settings";
 import { loadDeviceIconsIntoMap } from "@/lib/mobility/load-device-icons";
+import {
+  createThreeDeviceLayer,
+  THREE_DEVICE_LAYER_ID,
+  type ThreeDeviceLayer,
+} from "@/lib/mobility/three-device-layer";
 
 interface DeviceRow {
   id: string;
@@ -119,6 +124,7 @@ export function Operator({
   defaultZoom,
   styleIcons,
   customIcons,
+  styleModels,
 }: {
   projectId: string;
   mapboxToken: string | null;
@@ -131,6 +137,8 @@ export function Operator({
   /** Per-id descriptor of the project's custom uploads, so the
    *  icon loader can fetch + rasterise them on map init. */
   customIcons: Record<string, import("@/lib/mobility/device-style-resolver").CustomIconRef>;
+  /** Subsystem → 3D modelKey, pre-resolved server-side. Phase 3. */
+  styleModels: Record<string, string>;
 }) {
   const { data, mutate } = useSWR<DevicesResponse>(
     `/api/projects/${projectId}/devices`,
@@ -179,6 +187,13 @@ export function Operator({
    *  upload reaches the next map init without a remount. */
   const customIconsRef = useRef(customIcons);
   customIconsRef.current = customIcons;
+  /** Persistent reference to the Three.js custom layer so we can
+   *  push device updates without rebuilding the WebGL context. */
+  const threeLayerRef = useRef<ThreeDeviceLayer | null>(null);
+  /** Latest subsystem → modelKey mapping, read inside the layer's
+   *  resolver callback. */
+  const modelMapRef = useRef<Record<string, string>>(styleModels);
+  modelMapRef.current = styleModels;
   /** Latest style key the map is showing — keyed off settings so we
    *  only fire `setStyle` when the operator actually picks a new
    *  style, not on every light / terrain toggle. */
@@ -448,6 +463,73 @@ export function Operator({
     }
   }, [styleIcons]);
 
+  /** Three.js device layer — mount when the operator turns
+   *  `show3dDevices` on, unmount when off. The layer reads device
+   *  data + the model resolver from refs so it stays in sync with
+   *  device updates without remounting WebGL. */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const want = settings.show3dDevices;
+    const have = Boolean(threeLayerRef.current);
+    if (want && !have) {
+      const apply = () => {
+        if (!map.isStyleLoaded()) {
+          map.once("idle", apply);
+          return;
+        }
+        const layer = createThreeDeviceLayer();
+        threeLayerRef.current = layer;
+        try {
+          map.addLayer(layer);
+        } catch {
+          /* race with style swap — re-mount on next idle */
+        }
+        pushDevicesToThreeLayer();
+      };
+      apply();
+    } else if (!want && have) {
+      try {
+        if (map.getLayer(THREE_DEVICE_LAYER_ID)) {
+          map.removeLayer(THREE_DEVICE_LAYER_ID);
+        }
+      } catch {
+        /* already gone */
+      }
+      threeLayerRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.show3dDevices]);
+
+  /** Push the latest curated devices into the 3D layer when devices
+   *  or the model mapping change. */
+  const pushDevicesToThreeLayer = useCallback(() => {
+    const layer = threeLayerRef.current;
+    if (!layer) return;
+    const located = latestDevicesRef.current.filter(
+      (d): d is DeviceRow & { lat: number; lng: number } =>
+        d.lat != null && d.lng != null,
+    );
+    layer.setDevices(
+      located.map((d) => ({
+        id: d.id,
+        lat: d.lat,
+        lng: d.lng,
+        subsystem: d.subsystem,
+      })),
+      (subsystem) =>
+        modelMapRef.current[subsystem] ?? "model-generic",
+    );
+  }, []);
+
+  useEffect(() => {
+    pushDevicesToThreeLayer();
+  }, [devices, styleModels, pushDevicesToThreeLayer]);
+
+  useEffect(() => {
+    threeLayerRef.current?.setHighlight(selectedId);
+  }, [selectedId]);
+
   /** Style swap — heavier than a config-property update; `setStyle`
    *  wipes user layers, so we re-attach via `setupLayersRef`. Gated
    *  on the diff to avoid re-running on every light / terrain toggle. */
@@ -555,6 +637,7 @@ const DEFAULT_CONSOLE_SETTINGS: ConsoleSettings = {
   lightPreset: "night",
   showTerrain: true,
   show3dBuildings: true,
+  show3dDevices: false,
 };
 
 function settingsStorageKey(projectId: string): string {
@@ -818,6 +901,14 @@ function ConsoleSettingsChip({
               }
               disabled={!MAP_STYLES[settings.mapStyle].supports3dObjects}
               disabledHint="Standard / Satellite only"
+            />
+            <SettingsToggleRow
+              icon={Compass}
+              label="3D devices"
+              checked={settings.show3dDevices}
+              onChange={(show3dDevices) =>
+                onChange({ ...settings, show3dDevices })
+              }
             />
           </div>
 

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/page.tsx
@@ -69,6 +69,7 @@ export default async function OperatorPage({
       defaultZoom={defaultZoom}
       styleIcons={styleMap.icons}
       customIcons={styleMap.customIcons}
+      styleModels={styleMap.models}
     />
   );
 }

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -32,6 +32,11 @@ import {
   type MapStyleKey,
 } from "@/lib/mobility/map-settings";
 import { loadDeviceIconsIntoMap } from "@/lib/mobility/load-device-icons";
+import {
+  createThreeDeviceLayer,
+  THREE_DEVICE_LAYER_ID,
+  type ThreeDeviceLayer,
+} from "@/lib/mobility/three-device-layer";
 import { PushOptIn } from "./PushOptIn";
 
 interface Props {
@@ -46,6 +51,9 @@ interface Props {
   styleIcons: Record<string, string>;
   /** Per-id descriptor of custom uploads referenced by the project. */
   customIcons: Record<string, import("@/lib/mobility/device-style-resolver").CustomIconRef>;
+  /** Subsystem → 3D modelKey. Phase 3 — used when the visitor turns
+   *  on the "3D devices" toggle. */
+  styleModels: Record<string, string>;
 }
 
 const DEFAULT_PRIMARY = "#0ea5e9";
@@ -63,6 +71,7 @@ const DEFAULT_SETTINGS: MapEnvSettings = {
   lightPreset: "day",
   showTerrain: false,
   show3dBuildings: true,
+  show3dDevices: false,
 };
 
 function settingsStorageKey(slug: string): string {
@@ -303,6 +312,7 @@ export function WorldViewer({
   mapboxToken,
   styleIcons,
   customIcons,
+  styleModels,
 }: Props) {
   const primary = pickHex(theme.primaryColor, DEFAULT_PRIMARY);
   const bg = pickHex(theme.backgroundColor, DEFAULT_BG);
@@ -376,6 +386,30 @@ export function WorldViewer({
   latestIconExpressionRef.current = iconExpression;
   const customIconsRef = useRef(customIcons);
   customIconsRef.current = customIcons;
+  const styleModelsRef = useRef(styleModels);
+  styleModelsRef.current = styleModels;
+  const threeLayerRef = useRef<ThreeDeviceLayer | null>(null);
+
+  /** Push the world's curated devices into the Three.js layer using
+   *  the resolved per-subsystem model map. */
+  const pushDevicesTo3d = useCallback(() => {
+    const layer = threeLayerRef.current;
+    if (!layer) return;
+    const located = devices.filter(
+      (d): d is PublicWorldDevice & { lat: number; lng: number } =>
+        d.lat != null && d.lng != null,
+    );
+    layer.setDevices(
+      located.map((d) => ({
+        id: d.id,
+        lat: d.lat,
+        lng: d.lng,
+        subsystem: d.subsystem,
+      })),
+      (subsystem) => styleModelsRef.current[subsystem] ?? "model-generic",
+    );
+    layer.setAccent(primary);
+  }, [devices, primary]);
 
   const attachLayers = useCallback(
     (map: MapboxMap) => {
@@ -468,6 +502,49 @@ export function WorldViewer({
       /* style swap in-flight */
     }
   }, [iconExpression]);
+
+  /** 3D device layer — mount/unmount with the visitor's setting. */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const want = settings.show3dDevices;
+    const have = Boolean(threeLayerRef.current);
+    if (want && !have) {
+      const apply = () => {
+        if (!map.isStyleLoaded()) {
+          map.once("idle", apply);
+          return;
+        }
+        const layer = createThreeDeviceLayer();
+        threeLayerRef.current = layer;
+        try {
+          map.addLayer(layer);
+        } catch {
+          /* race with style swap — retry on next idle */
+        }
+        pushDevicesTo3d();
+      };
+      apply();
+    } else if (!want && have) {
+      try {
+        if (map.getLayer(THREE_DEVICE_LAYER_ID)) {
+          map.removeLayer(THREE_DEVICE_LAYER_ID);
+        }
+      } catch {
+        /* already gone */
+      }
+      threeLayerRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.show3dDevices]);
+
+  useEffect(() => {
+    pushDevicesTo3d();
+  }, [pushDevicesTo3d]);
+
+  useEffect(() => {
+    threeLayerRef.current?.setHighlight(selectedId);
+  }, [selectedId]);
 
   // Light + terrain + 3D — cheap config updates, no reload.
   useEffect(() => {
@@ -789,6 +866,15 @@ function MapSettingsPanel({
           }
           disabled={!activeStyle.supports3dObjects}
           disabledHint="Standard / Satellite only"
+          primary={primary}
+        />
+        <PanelToggle
+          icon={Box}
+          label="3D devices"
+          checked={settings.show3dDevices}
+          onChange={(show3dDevices) =>
+            onChange({ ...settings, show3dDevices })
+          }
           primary={primary}
         />
       </div>

--- a/apps/mobility/app/(public)/w/[slug]/page.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/page.tsx
@@ -47,6 +47,7 @@ export default async function WorldPublicPage({
       mapboxToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN ?? null}
       styleIcons={world.styleIcons}
       customIcons={world.customIcons}
+      styleModels={world.styleModels}
     />
   );
 }

--- a/apps/mobility/app/api/projects/[projectId]/styles/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/styles/route.ts
@@ -19,11 +19,18 @@ import {
   STOCK_DEVICE_ICONS,
   defaultIconKeyForSubsystem,
 } from "@/lib/mobility/device-icons";
+import {
+  STOCK_DEVICE_MODELS,
+  defaultModelKeyForSubsystem,
+} from "@/lib/mobility/device-models";
 import { listProjectSubsystems } from "@/lib/mobility/device-style-resolver";
 
 type Params = Promise<{ projectId: string }>;
 
 const STOCK_KEYS = new Set(STOCK_DEVICE_ICONS.map((entry) => entry.key));
+const STOCK_MODEL_KEYS = new Set(
+  STOCK_DEVICE_MODELS.map((entry) => entry.key),
+);
 
 export async function GET(
   _req: Request,
@@ -37,15 +44,23 @@ export async function GET(
     listProjectSubsystems(projectId),
     prisma.mobilityDeviceStyle.findMany({
       where: { projectId },
-      select: { subsystem: true, iconKey: true },
+      select: { subsystem: true, iconKey: true, modelKey: true },
     }),
   ]);
 
-  const overrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const iconOverrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const modelOverrides = new Map(
+    rows
+      .filter((r): r is typeof r & { modelKey: string } => Boolean(r.modelKey))
+      .map((r) => [r.subsystem, r.modelKey]),
+  );
   const styles = subsystems.map((subsystem) => ({
     subsystem,
-    iconKey: overrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem),
-    isOverride: overrides.has(subsystem),
+    iconKey:
+      iconOverrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem),
+    modelKey:
+      modelOverrides.get(subsystem) ?? defaultModelKeyForSubsystem(subsystem),
+    isOverride: iconOverrides.has(subsystem) || modelOverrides.has(subsystem),
   }));
 
   return NextResponse.json({ styles });
@@ -57,6 +72,9 @@ const PutBody = z.object({
       z.object({
         subsystem: z.string().min(1).max(40),
         iconKey: z.string().min(1).max(60),
+        /** Phase 3 — optional 3D model assignment. Stock-only keys
+         *  in this PR; custom uploads land in Phase 3.5. */
+        modelKey: z.string().min(1).max(60).nullable().optional(),
       }),
     )
     .max(200),
@@ -116,6 +134,16 @@ export async function PUT(
       );
     }
   }
+  // Model keys are stock-only in Phase 3; null clears the assignment.
+  for (const s of parsed.data.styles) {
+    if (s.modelKey === undefined || s.modelKey === null) continue;
+    if (!STOCK_MODEL_KEYS.has(s.modelKey)) {
+      return NextResponse.json(
+        { error: `Unknown modelKey "${s.modelKey}".` },
+        { status: 400 },
+      );
+    }
+  }
 
   await prisma.$transaction([
     prisma.mobilityDeviceStyle.deleteMany({ where: { projectId } }),
@@ -124,6 +152,7 @@ export async function PUT(
         projectId,
         subsystem: s.subsystem,
         iconKey: s.iconKey,
+        modelKey: s.modelKey ?? null,
       })),
     }),
   ]);

--- a/apps/mobility/app/api/public/worlds/[slug]/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/route.ts
@@ -33,6 +33,7 @@ export async function GET(
         theme: world.theme,
         devices: world.devices,
         styleIcons: world.styleIcons,
+        styleModels: world.styleModels,
         customIcons: world.customIcons,
       },
     },

--- a/apps/mobility/lib/mobility/device-models.ts
+++ b/apps/mobility/lib/mobility/device-models.ts
@@ -1,0 +1,201 @@
+/**
+ * Stock 3D device models — Three.js primitives, no GLB files. Each
+ * stock entry is a builder function that returns a fresh `Object3D`
+ * for the device-model layer to position at the device's
+ * `MercatorCoordinate`.
+ *
+ * Why primitives (no GLB)? Mobility's first 3D pass should ship
+ * without a content-creation pipeline. Operators who want a precise
+ * dome-camera model bring their own GLB through the Phase 3.5 upload
+ * pipeline (next PR); the stock set just needs to read as "camera"
+ * vs "sign" vs "post" from 50m up.
+ */
+import * as THREE from "three";
+
+export interface StockDeviceModel {
+  key: string;
+  label: string;
+  description: string;
+  /** Approximate height in metres so we can scale by viewport metres
+   *  later. Tuned so all stock models read at similar visual weight
+   *  at zoom 16-17. */
+  approxHeightMeters: number;
+  build: () => THREE.Object3D;
+}
+
+/** Centralised palette so swapping accent across light/dark themes
+ *  stays a one-line change. The 3D layer recolours instance materials
+ *  per-render based on the active accent. */
+const PALETTE = {
+  body: "#dde1e7",
+  housing: "#1f2937",
+  lens: "#0f172a",
+  pole: "#3b4453",
+  signFace: "#0b1220",
+  signFrame: "#94a3b8",
+  signal: "#dde1e7",
+};
+
+function makeMaterial(colour: string): THREE.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({
+    color: colour,
+    roughness: 0.55,
+    metalness: 0.18,
+  });
+}
+
+function buildPole(height: number): THREE.Mesh {
+  const geom = new THREE.CylinderGeometry(0.07, 0.09, height, 8);
+  geom.translate(0, height / 2, 0);
+  return new THREE.Mesh(geom, makeMaterial(PALETTE.pole));
+}
+
+function buildCamera(): THREE.Object3D {
+  const root = new THREE.Group();
+  const pole = buildPole(3.4);
+  root.add(pole);
+
+  const housing = new THREE.Mesh(
+    new THREE.BoxGeometry(0.55, 0.32, 0.6),
+    makeMaterial(PALETTE.housing),
+  );
+  housing.position.set(0, 3.55, 0.05);
+  root.add(housing);
+
+  const lens = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.12, 0.12, 0.22, 16),
+    makeMaterial(PALETTE.lens),
+  );
+  lens.rotation.z = Math.PI / 2;
+  lens.position.set(0.34, 3.55, 0.05);
+  root.add(lens);
+
+  return root;
+}
+
+function buildDms(): THREE.Object3D {
+  const root = new THREE.Group();
+  const left = buildPole(4.4);
+  left.position.x = -1.6;
+  const right = buildPole(4.4);
+  right.position.x = 1.6;
+  root.add(left, right);
+
+  const arm = new THREE.Mesh(
+    new THREE.BoxGeometry(3.6, 0.12, 0.12),
+    makeMaterial(PALETTE.pole),
+  );
+  arm.position.set(0, 4.35, 0);
+  root.add(arm);
+
+  const face = new THREE.Mesh(
+    new THREE.BoxGeometry(3.2, 1.05, 0.18),
+    makeMaterial(PALETTE.signFace),
+  );
+  face.position.set(0, 3.6, 0);
+  root.add(face);
+
+  const frame = new THREE.Mesh(
+    new THREE.BoxGeometry(3.3, 1.15, 0.06),
+    makeMaterial(PALETTE.signFrame),
+  );
+  frame.position.set(0, 3.6, -0.07);
+  root.add(frame);
+
+  return root;
+}
+
+function buildSignal(): THREE.Object3D {
+  const root = new THREE.Group();
+  const pole = buildPole(4.6);
+  root.add(pole);
+
+  const horizontal = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.06, 0.06, 1.6, 8),
+    makeMaterial(PALETTE.pole),
+  );
+  horizontal.rotation.z = Math.PI / 2;
+  horizontal.position.set(0.6, 4.5, 0);
+  root.add(horizontal);
+
+  const head = new THREE.Mesh(
+    new THREE.BoxGeometry(0.32, 0.78, 0.32),
+    makeMaterial(PALETTE.signFace),
+  );
+  head.position.set(1.25, 4.1, 0);
+  root.add(head);
+
+  const colours = ["#ef4444", "#facc15", "#22c55e"];
+  colours.forEach((c, i) => {
+    const lamp = new THREE.Mesh(
+      new THREE.CircleGeometry(0.085, 16),
+      new THREE.MeshBasicMaterial({ color: c }),
+    );
+    lamp.position.set(1.41, 4.35 - i * 0.22, 0);
+    lamp.rotation.y = Math.PI / 2;
+    root.add(lamp);
+  });
+
+  return root;
+}
+
+function buildGeneric(): THREE.Object3D {
+  const root = new THREE.Group();
+  const pole = buildPole(2.4);
+  root.add(pole);
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.22, 18, 12),
+    makeMaterial(PALETTE.body),
+  );
+  head.position.set(0, 2.55, 0);
+  root.add(head);
+  return root;
+}
+
+export const STOCK_DEVICE_MODELS: StockDeviceModel[] = [
+  {
+    key: "model-camera",
+    label: "Pole-mounted camera",
+    description: "Box housing on a pole.",
+    approxHeightMeters: 3.8,
+    build: buildCamera,
+  },
+  {
+    key: "model-dms",
+    label: "Dynamic sign gantry",
+    description: "Two-pole signboard.",
+    approxHeightMeters: 4.7,
+    build: buildDms,
+  },
+  {
+    key: "model-signal",
+    label: "Signal head",
+    description: "Traffic signal on mast arm.",
+    approxHeightMeters: 4.7,
+    build: buildSignal,
+  },
+  {
+    key: "model-generic",
+    label: "Generic device",
+    description: "Pole with sensor head.",
+    approxHeightMeters: 2.7,
+    build: buildGeneric,
+  },
+];
+
+const MODEL_INDEX: Map<string, StockDeviceModel> = new Map(
+  STOCK_DEVICE_MODELS.map((entry) => [entry.key, entry]),
+);
+
+export function getStockModel(key: string): StockDeviceModel | null {
+  return MODEL_INDEX.get(key) ?? null;
+}
+
+/** Auto-fill suggestion per subsystem on first visit. */
+export function defaultModelKeyForSubsystem(subsystem: string): string {
+  const normal = subsystem.toLowerCase();
+  if (normal === "cctv") return "model-camera";
+  if (normal === "dms") return "model-dms";
+  if (normal === "signal" || normal === "tsc") return "model-signal";
+  return "model-generic";
+}

--- a/apps/mobility/lib/mobility/device-style-resolver.ts
+++ b/apps/mobility/lib/mobility/device-style-resolver.ts
@@ -13,6 +13,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import { defaultIconKeyForSubsystem } from "./device-icons";
+import { defaultModelKeyForSubsystem } from "./device-models";
 
 export interface CustomIconRef {
   id: string;
@@ -24,6 +25,8 @@ export interface CustomIconRef {
 export interface DeviceStyleMap {
   /** Lowercased subsystem → resolved iconKey. */
   icons: Record<string, string>;
+  /** Lowercased subsystem → resolved 3D modelKey. Phase 3. */
+  models: Record<string, string>;
   /** Per-id descriptor of every custom icon currently referenced.
    *  The client loader resolves `custom:<id>` keys against this. */
   customIcons: Record<string, CustomIconRef>;
@@ -53,14 +56,22 @@ export async function resolveDeviceStyles(
     listProjectSubsystems(projectId),
     prisma.mobilityDeviceStyle.findMany({
       where: { projectId },
-      select: { subsystem: true, iconKey: true },
+      select: { subsystem: true, iconKey: true, modelKey: true },
     }),
   ]);
-  const overrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const iconOverrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const modelOverrides = new Map(
+    rows
+      .filter((r): r is typeof r & { modelKey: string } => Boolean(r.modelKey))
+      .map((r) => [r.subsystem, r.modelKey]),
+  );
   const icons: Record<string, string> = {};
+  const models: Record<string, string> = {};
   for (const subsystem of subsystems) {
     icons[subsystem] =
-      overrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem);
+      iconOverrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem);
+    models[subsystem] =
+      modelOverrides.get(subsystem) ?? defaultModelKeyForSubsystem(subsystem);
   }
 
   const customIds = Array.from(
@@ -88,5 +99,5 @@ export async function resolveDeviceStyles(
     }
   }
 
-  return { icons, customIcons };
+  return { icons, models, customIcons };
 }

--- a/apps/mobility/lib/mobility/map-settings.ts
+++ b/apps/mobility/lib/mobility/map-settings.ts
@@ -65,6 +65,9 @@ export interface MapEnvSettings {
   lightPreset: LightPreset;
   showTerrain: boolean;
   show3dBuildings: boolean;
+  /** Phase 3 — render devices as 3D meshes through the Three.js
+   *  custom layer. When off, the 2D symbol layer carries on. */
+  show3dDevices: boolean;
 }
 
 const TERRAIN_SOURCE_ID = "mapbox-dem";
@@ -130,6 +133,12 @@ export function loadMapEnvSettings(
     // MAP_STYLES, snap back to the default rather than crash on init.
     if (parsed.mapStyle && !(parsed.mapStyle in MAP_STYLES)) {
       delete parsed.mapStyle;
+    }
+    // `show3dDevices` is a Phase-3 addition — older persisted blobs
+    // won't have it. Coerce undefined → false so existing operators
+    // don't get 3D forced on without opting in.
+    if (typeof parsed.show3dDevices !== "boolean") {
+      parsed.show3dDevices = defaults.show3dDevices ?? false;
     }
     return { ...defaults, ...parsed };
   } catch {

--- a/apps/mobility/lib/mobility/three-device-layer.ts
+++ b/apps/mobility/lib/mobility/three-device-layer.ts
@@ -1,0 +1,233 @@
+/**
+ * Mapbox CustomLayer that renders device meshes through Three.js.
+ *
+ * One layer per map. Devices are written via `setDevices(devices,
+ * resolveModelKey)`; the layer keeps the Three.js scene in sync with
+ * the latest device set and queues a repaint. Each device gets one
+ * mesh built from the stock model registry, anchored at the device's
+ * lng/lat via Mapbox's `MercatorCoordinate` so the projection matrix
+ * Mapbox hands the renderer lines up with the basemap exactly.
+ *
+ * Why a custom layer (not Mapbox's native `model` layer)? Native v3
+ * models are tied to the Standard style's `addImport` plumbing and
+ * don't accept arbitrary geometry from app code without GLB files.
+ * The Three.js layer keeps Phase 3 self-contained — stock primitives
+ * today, GLB uploads (Phase 3.5) tomorrow.
+ */
+import * as THREE from "three";
+import mapboxgl, {
+  type CustomLayerInterface,
+  type Map as MapboxMap,
+} from "mapbox-gl";
+import { getStockModel, type StockDeviceModel } from "./device-models";
+
+export interface ThreeDeviceInput {
+  id: string;
+  lng: number;
+  lat: number;
+  subsystem: string;
+}
+
+export interface ThreeDeviceLayer extends CustomLayerInterface {
+  setDevices(
+    devices: ThreeDeviceInput[],
+    resolveModelKey: (subsystem: string) => string,
+  ): void;
+  setHighlight(deviceId: string | null): void;
+  /** Tint applied to selection halo. Defaults to a Klorad teal. */
+  setAccent(hex: string): void;
+}
+
+const LAYER_ID = "device-models-3d";
+
+interface DeviceMesh {
+  id: string;
+  mesh: THREE.Object3D;
+  halo: THREE.Mesh;
+  modelKey: string;
+}
+
+export function createThreeDeviceLayer(): ThreeDeviceLayer {
+  let camera: THREE.PerspectiveCamera | null = null;
+  let scene: THREE.Scene | null = null;
+  let renderer: THREE.WebGLRenderer | null = null;
+  let map: MapboxMap | null = null;
+  const meshes: Map<string, DeviceMesh> = new Map();
+  /** Cache of source meshes per stock-model key. We `.clone()` per
+   *  instance so the geometry/material upload happens once. */
+  const sourceModels: Map<string, THREE.Object3D> = new Map();
+  let highlightId: string | null = null;
+  let accent = "#0ea5e9";
+  let lastDevices: ThreeDeviceInput[] = [];
+  let lastResolver: ((subsystem: string) => string) | null = null;
+
+  function ensureSourceModel(stock: StockDeviceModel): THREE.Object3D {
+    const cached = sourceModels.get(stock.key);
+    if (cached) return cached;
+    const built = stock.build();
+    sourceModels.set(stock.key, built);
+    return built;
+  }
+
+  function buildHaloMesh(): THREE.Mesh {
+    const geom = new THREE.RingGeometry(1.2, 1.55, 36);
+    const mat = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(accent),
+      transparent: true,
+      opacity: 0.5,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const mesh = new THREE.Mesh(geom, mat);
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.visible = false;
+    return mesh;
+  }
+
+  function addLights(s: THREE.Scene): void {
+    const ambient = new THREE.AmbientLight(0xffffff, 0.7);
+    const sun = new THREE.DirectionalLight(0xffffff, 0.85);
+    sun.position.set(0.5, 1, 0.6);
+    s.add(ambient, sun);
+  }
+
+  function placeAt(
+    obj: THREE.Object3D,
+    halo: THREE.Mesh,
+    lng: number,
+    lat: number,
+  ): void {
+    const merc = mapboxgl.MercatorCoordinate.fromLngLat([lng, lat], 0);
+    const scale = merc.meterInMercatorCoordinateUnits();
+    // The model's Y axis is "up" in metres; Mapbox's z is the
+    // mercator "altitude". We orient the model upright then translate
+    // everything so the base sits on the basemap.
+    const t = new THREE.Group();
+    t.position.set(merc.x, merc.y, merc.z);
+    t.rotation.x = Math.PI / 2;
+    t.scale.set(scale, scale, scale);
+    t.add(obj);
+    halo.position.set(merc.x, merc.y, merc.z);
+    halo.scale.set(scale, scale, scale);
+    // Halo is already rotated to lie flat against the basemap; replace
+    // the transform's group with one that doesn't include the halo.
+    return;
+  }
+
+  function rebuildScene(): void {
+    if (!scene) return;
+    for (const entry of meshes.values()) {
+      scene.remove(entry.mesh);
+      scene.remove(entry.halo);
+    }
+    meshes.clear();
+    if (!lastResolver) return;
+    for (const d of lastDevices) {
+      const modelKey = lastResolver(d.subsystem);
+      const stock = getStockModel(modelKey);
+      if (!stock) continue;
+      const source = ensureSourceModel(stock);
+      const clone = source.clone();
+      const halo = buildHaloMesh();
+      const merc = mapboxgl.MercatorCoordinate.fromLngLat([d.lng, d.lat], 0);
+      const metres = merc.meterInMercatorCoordinateUnits();
+      // Compose the per-instance transform on a fresh root so we can
+      // swap orientation without copy-pasting Mapbox boilerplate.
+      const root = new THREE.Group();
+      root.position.set(merc.x, merc.y, merc.z);
+      root.rotation.x = Math.PI / 2;
+      root.scale.setScalar(metres);
+      root.add(clone);
+
+      halo.position.set(merc.x, merc.y, merc.z);
+      halo.rotation.x = -Math.PI / 2;
+      halo.scale.setScalar(metres * stock.approxHeightMeters * 0.6);
+      scene.add(root);
+      scene.add(halo);
+      meshes.set(d.id, { id: d.id, mesh: root, halo, modelKey });
+    }
+    updateHighlight();
+  }
+
+  function updateHighlight(): void {
+    for (const entry of meshes.values()) {
+      entry.halo.visible = entry.id === highlightId;
+    }
+    if (map) map.triggerRepaint();
+  }
+
+  // Suppress unused-warning for the helper retained for clarity.
+  void placeAt;
+
+  return {
+    id: LAYER_ID,
+    type: "custom",
+    renderingMode: "3d",
+
+    onAdd(mapInstance, gl) {
+      map = mapInstance as MapboxMap;
+      scene = new THREE.Scene();
+      addLights(scene);
+      camera = new THREE.PerspectiveCamera();
+      renderer = new THREE.WebGLRenderer({
+        canvas: map.getCanvas(),
+        context: gl,
+        antialias: true,
+      });
+      renderer.autoClear = false;
+      // Rebuild scene if a previous setDevices call landed before
+      // the layer was attached (Operator passes devices into the
+      // factory + may swap layers across style.load).
+      rebuildScene();
+    },
+
+    render(_gl, matrix) {
+      if (!renderer || !scene || !camera) return;
+      const projection = new THREE.Matrix4().fromArray(matrix);
+      camera.projectionMatrix = projection;
+      // World is already encoded in mercator coords so the view is
+      // identity. The projection matrix Mapbox gives us covers all
+      // the placement maths.
+      renderer.resetState();
+      renderer.render(scene, camera);
+      if (map) map.triggerRepaint();
+    },
+
+    onRemove() {
+      if (!scene) return;
+      for (const entry of meshes.values()) {
+        scene.remove(entry.mesh);
+        scene.remove(entry.halo);
+      }
+      meshes.clear();
+      sourceModels.clear();
+      renderer?.dispose();
+      renderer = null;
+      scene = null;
+      camera = null;
+      map = null;
+    },
+
+    setDevices(devices, resolveModelKey) {
+      lastDevices = devices;
+      lastResolver = resolveModelKey;
+      rebuildScene();
+    },
+
+    setHighlight(deviceId) {
+      highlightId = deviceId;
+      updateHighlight();
+    },
+
+    setAccent(hex) {
+      accent = hex;
+      for (const entry of meshes.values()) {
+        const mat = entry.halo.material;
+        if (mat instanceof THREE.MeshBasicMaterial) mat.color.set(hex);
+      }
+      if (map) map.triggerRepaint();
+    },
+  };
+}
+
+export const THREE_DEVICE_LAYER_ID = LAYER_ID;

--- a/apps/mobility/lib/mobility/world-resolver.ts
+++ b/apps/mobility/lib/mobility/world-resolver.ts
@@ -47,6 +47,9 @@ export interface PublicWorld {
   /// Subsystem → iconKey resolved from the operator's project-level
   /// `MobilityDeviceStyle` rows. Used by the viewer's symbol layer.
   styleIcons: Record<string, string>;
+  /// Subsystem → 3D modelKey. Used when the visitor turns on the
+  /// "3D devices" toggle.
+  styleModels: Record<string, string>;
   /// Per-id descriptor of every custom upload referenced by the
   /// project's styles. Lets the viewer's loader resolve `custom:<id>`
   /// keys without a second round-trip.
@@ -137,6 +140,7 @@ async function toPublicWorld(world: WorldRecord): Promise<PublicWorld> {
         direction: d.direction,
       })),
     styleIcons: styleMap.icons,
+    styleModels: styleMap.models,
     customIcons: styleMap.customIcons,
   };
 }

--- a/apps/mobility/package.json
+++ b/apps/mobility/package.json
@@ -34,10 +34,12 @@
     "react-dom": "^19.2.1",
     "react-toastify": "^11.0.5",
     "swr": "^2.3.6",
+    "three": "^0.170.0",
     "web-push": "^3.6.7",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/three": "^0.170.0",
     "@types/web-push": "^3.6.4",
     "autoprefixer": "10.4.20",
     "eslint": "^8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,6 +667,9 @@ importers:
       swr:
         specifier: ^2.3.6
         version: 2.3.6(react@19.2.1)
+      three:
+        specifier: ^0.170.0
+        version: 0.170.0
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -674,6 +677,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@types/three':
+        specifier: ^0.170.0
+        version: 0.170.0
       '@types/web-push':
         specifier: ^3.6.4
         version: 3.6.4


### PR DESCRIPTION
## Summary

Phase 3 of the device-styles plan — devices render as 3D meshes on the map when the operator (or world visitor) turns on the new "3D devices" toggle, falling back to the existing 2D icon symbol layer when off.

**Stacked on #222.** Base is \`feature/mobility-custom-icon-uploads\` so the diff stays scoped to Phase 3 work. GitHub auto-retargets once #221/#222 land.

## What's in it

- **Three.js custom Mapbox layer** — \`createThreeDeviceLayer()\` owns a Three.js scene + perspective camera backed by Mapbox's WebGL context. Devices anchor at \`MercatorCoordinate\` so the projection matrix Mapbox hands the renderer lines up with the basemap exactly. Selection halo, accent tint, and device updates are imperative setters so React doesn't tear down the WebGL context on every state change.
- **Stock model registry** — 4 primitive builders (camera, DMS gantry, signal head, generic pole). No GLB content pipeline needed for v1; pure Three.js geometry. Each entry carries an \`approxHeightMeters\` so visual weight reads consistently across subsystems.
- **Schema groundwork already in place** — \`MobilityDeviceStyle.modelKey/scale/rotation\` reserved in Phase 1 (PR #221). This PR just wires \`modelKey\` through: API accepts/returns it, resolver merges defaults with operator overrides, server passes it into both surfaces.
- **Settings toggle** — new "3D devices" entry on the existing Console + Map-settings panel. Persists in localStorage; older blobs coerce undefined → false at load.
- **Both surfaces** — operator console + public world viewer flip between the symbol layer (off) and the 3D layer (on). World viewer tints the selection halo with the operator's primary colour so brand carries through.

## What's not in this PR

- **Per-subsystem model picker UI on the Styles page** — operators get sensible auto-assigned defaults per subsystem (CCTV → camera, DMS → DMS, signal/tsc → signal, anything else → generic). Phase 3.5 will add a dropdown next to the icon picker.
- **Custom GLB uploads** — Phase 3.5 will extend the upload pipeline + the layer's \`ensureSourceModel\` with a GLTFLoader hook.

## Cost

- Three.js (\`^0.170.0\`) adds ~120 kB to the public \`/w/[slug]\` chunk (565 kB → 689 kB). One-time hit; feature is opt-in.

## Test plan

- [ ] After merge + migrate, open a project with synced devices.
- [ ] Toggle "3D devices" in the Console panel — devices render as primitives at street level when tilted; toggle off returns to icons.
- [ ] Each subsystem gets a sensible default (CCTV → camera, DMS → gantry, etc.).
- [ ] Click a device — halo appears under the selected mesh.
- [ ] Tilt + zoom maintains correct alignment with the basemap.
- [ ] World viewer renders 3D devices with the world's primary tint on the halo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)