### PR TITLE
feat(mobility): device styles Phase 2 + Phase 3 (custom uploads + 3D devices)

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -118,6 +118,7 @@ export function Operator({
   defaultCentre,
   defaultZoom,
   styleIcons,
+  customIcons,
 }: {
   projectId: string;
   mapboxToken: string | null;
@@ -127,6 +128,9 @@ export function Operator({
   /** Subsystem → iconKey, pre-resolved server-side so the symbol
    *  layer's `icon-image` expression is ready before first paint. */
   styleIcons: Record<string, string>;
+  /** Per-id descriptor of the project's custom uploads, so the
+   *  icon loader can fetch + rasterise them on map init. */
+  customIcons: Record<string, import("@/lib/mobility/device-style-resolver").CustomIconRef>;
 }) {
   const { data, mutate } = useSWR<DevicesResponse>(
     `/api/projects/${projectId}/devices`,
@@ -171,6 +175,10 @@ export function Operator({
     () => buildIconExpression(styleIcons),
     [styleIcons],
   );
+  /** Custom-icon manifest — read inside async loaders so a fresh
+   *  upload reaches the next map init without a remount. */
+  const customIconsRef = useRef(customIcons);
+  customIconsRef.current = customIcons;
   /** Latest style key the map is showing — keyed off settings so we
    *  only fire `setStyle` when the operator actually picks a new
    *  style, not on every light / terrain toggle. */
@@ -376,11 +384,13 @@ export function Operator({
     setupLayersRef.current = setupLayers;
 
     /** Initial style ready hook — apply env settings, register the
-     *  stock icon images, then bring up the device layers. Subsequent
-     *  style swaps go through the effect below. */
+     *  stock + custom icon images, then bring up the device layers.
+     *  Subsequent style swaps go through the effect below. */
     const onLoad = () => {
       applyConsoleSettings(map, latestSettingsRef.current);
-      void loadDeviceIconsIntoMap(map).then(() => setupLayers());
+      void loadDeviceIconsIntoMap(map, customIconsRef.current).then(() =>
+        setupLayers(),
+      );
     };
 
     if (map.isStyleLoaded()) {
@@ -450,7 +460,9 @@ export function Operator({
     map.setStyle(MAP_STYLES[settings.mapStyle].url);
     map.once("style.load", () => {
       applyConsoleSettings(map, latestSettingsRef.current);
-      void loadDeviceIconsIntoMap(map).then(() => setupLayersRef.current?.());
+      void loadDeviceIconsIntoMap(map, customIconsRef.current).then(() =>
+        setupLayersRef.current?.(),
+      );
     });
   }, [settings.mapStyle]);
 

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import mapboxgl, {
   type GeoJSONSource,
@@ -46,6 +46,11 @@ import {
   type MapStyleKey,
 } from "@/lib/mobility/map-settings";
 import { loadDeviceIconsIntoMap } from "@/lib/mobility/load-device-icons";
+import {
+  createThreeDeviceLayer,
+  THREE_DEVICE_LAYER_ID,
+  type ThreeDeviceLayer,
+} from "@/lib/mobility/three-device-layer";
 
 interface DeviceRow {
   id: string;
@@ -119,6 +124,7 @@ export function Operator({
   defaultZoom,
   styleIcons,
   customIcons,
+  styleModels,
 }: {
   projectId: string;
   mapboxToken: string | null;
@@ -131,6 +137,8 @@ export function Operator({
   /** Per-id descriptor of the project's custom uploads, so the
    *  icon loader can fetch + rasterise them on map init. */
   customIcons: Record<string, import("@/lib/mobility/device-style-resolver").CustomIconRef>;
+  /** Subsystem → 3D modelKey, pre-resolved server-side. Phase 3. */
+  styleModels: Record<string, string>;
 }) {
   const { data, mutate } = useSWR<DevicesResponse>(
     `/api/projects/${projectId}/devices`,
@@ -179,6 +187,13 @@ export function Operator({
    *  upload reaches the next map init without a remount. */
   const customIconsRef = useRef(customIcons);
   customIconsRef.current = customIcons;
+  /** Persistent reference to the Three.js custom layer so we can
+   *  push device updates without rebuilding the WebGL context. */
+  const threeLayerRef = useRef<ThreeDeviceLayer | null>(null);
+  /** Latest subsystem → modelKey mapping, read inside the layer's
+   *  resolver callback. */
+  const modelMapRef = useRef<Record<string, string>>(styleModels);
+  modelMapRef.current = styleModels;
   /** Latest style key the map is showing — keyed off settings so we
    *  only fire `setStyle` when the operator actually picks a new
    *  style, not on every light / terrain toggle. */
@@ -448,6 +463,73 @@ export function Operator({
     }
   }, [styleIcons]);
 
+  /** Three.js device layer — mount when the operator turns
+   *  `show3dDevices` on, unmount when off. The layer reads device
+   *  data + the model resolver from refs so it stays in sync with
+   *  device updates without remounting WebGL. */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const want = settings.show3dDevices;
+    const have = Boolean(threeLayerRef.current);
+    if (want && !have) {
+      const apply = () => {
+        if (!map.isStyleLoaded()) {
+          map.once("idle", apply);
+          return;
+        }
+        const layer = createThreeDeviceLayer();
+        threeLayerRef.current = layer;
+        try {
+          map.addLayer(layer);
+        } catch {
+          /* race with style swap — re-mount on next idle */
+        }
+        pushDevicesToThreeLayer();
+      };
+      apply();
+    } else if (!want && have) {
+      try {
+        if (map.getLayer(THREE_DEVICE_LAYER_ID)) {
+          map.removeLayer(THREE_DEVICE_LAYER_ID);
+        }
+      } catch {
+        /* already gone */
+      }
+      threeLayerRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.show3dDevices]);
+
+  /** Push the latest curated devices into the 3D layer when devices
+   *  or the model mapping change. */
+  const pushDevicesToThreeLayer = useCallback(() => {
+    const layer = threeLayerRef.current;
+    if (!layer) return;
+    const located = latestDevicesRef.current.filter(
+      (d): d is DeviceRow & { lat: number; lng: number } =>
+        d.lat != null && d.lng != null,
+    );
+    layer.setDevices(
+      located.map((d) => ({
+        id: d.id,
+        lat: d.lat,
+        lng: d.lng,
+        subsystem: d.subsystem,
+      })),
+      (subsystem) =>
+        modelMapRef.current[subsystem] ?? "model-generic",
+    );
+  }, []);
+
+  useEffect(() => {
+    pushDevicesToThreeLayer();
+  }, [devices, styleModels, pushDevicesToThreeLayer]);
+
+  useEffect(() => {
+    threeLayerRef.current?.setHighlight(selectedId);
+  }, [selectedId]);
+
   /** Style swap — heavier than a config-property update; `setStyle`
    *  wipes user layers, so we re-attach via `setupLayersRef`. Gated
    *  on the diff to avoid re-running on every light / terrain toggle. */
@@ -555,6 +637,7 @@ const DEFAULT_CONSOLE_SETTINGS: ConsoleSettings = {
   lightPreset: "night",
   showTerrain: true,
   show3dBuildings: true,
+  show3dDevices: false,
 };
 
 function settingsStorageKey(projectId: string): string {
@@ -818,6 +901,14 @@ function ConsoleSettingsChip({
               }
               disabled={!MAP_STYLES[settings.mapStyle].supports3dObjects}
               disabledHint="Standard / Satellite only"
+            />
+            <SettingsToggleRow
+              icon={Compass}
+              label="3D devices"
+              checked={settings.show3dDevices}
+              onChange={(show3dDevices) =>
+                onChange({ ...settings, show3dDevices })
+              }
             />
           </div>
 

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/page.tsx
@@ -69,6 +69,7 @@ export default async function OperatorPage({
       defaultZoom={defaultZoom}
       styleIcons={styleMap.icons}
       customIcons={styleMap.customIcons}
+      styleModels={styleMap.models}
     />
   );
 }

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/page.tsx
@@ -68,6 +68,7 @@ export default async function OperatorPage({
       defaultCentre={defaultCentre}
       defaultZoom={defaultZoom}
       styleIcons={styleMap.icons}
+      customIcons={styleMap.customIcons}
     />
   );
 }

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/styles/StylesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/styles/StylesClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import { toast } from "react-toastify";
-import { Brush, Check } from "lucide-react";
+import { Brush, Check, Trash2, Upload } from "lucide-react";
 import { getStockIcon } from "@/lib/mobility/device-icons";
 
 interface StyleRow {
@@ -18,11 +18,28 @@ interface IconChoice {
   description: string;
 }
 
+interface CustomIcon {
+  id: string;
+  label: string;
+  url: string;
+  contentType: string;
+  bytes: number;
+  createdAt: string;
+}
+
+interface PresignResponse {
+  signedUrl: string;
+  publicUrl: string;
+  key: string;
+}
+
 interface Props {
   projectId: string;
   projectTitle: string;
   initialStyles: StyleRow[];
   iconLibrary: IconChoice[];
+  initialCustomIcons: CustomIcon[];
+  uploadsEnabled: boolean;
 }
 
 const fetcher = (url: string) =>
@@ -31,11 +48,21 @@ const fetcher = (url: string) =>
     return r.json();
   });
 
+const MAX_BYTES = 256 * 1024;
+const ALLOWED_TYPES = new Set([
+  "image/svg+xml",
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);
+
 export function StylesClient({
   projectId,
   projectTitle,
   initialStyles,
   iconLibrary,
+  initialCustomIcons,
+  uploadsEnabled,
 }: Props) {
   const { data, mutate } = useSWR<{ styles: StyleRow[] }>(
     `/api/projects/${projectId}/styles`,
@@ -44,17 +71,21 @@ export function StylesClient({
   );
   const baseline = data?.styles ?? initialStyles;
 
+  const { data: iconsData, mutate: mutateIcons } = useSWR<{
+    icons: CustomIcon[];
+  }>(`/api/projects/${projectId}/styles/icons`, fetcher, {
+    fallbackData: { icons: initialCustomIcons },
+  });
+  const customIcons = iconsData?.icons ?? initialCustomIcons;
+
   const [draft, setDraft] = useState<Map<string, string>>(
     () => new Map(baseline.map((s) => [s.subsystem, s.iconKey])),
   );
   const [saving, setSaving] = useState(false);
 
-  // Re-sync the draft when the server data shifts under us (after a
-  // save mutate, for instance). Keep the operator's in-progress edits
-  // if any draft key already differs.
-  const hash = baseline
-    .map((s) => `${s.subsystem}:${s.iconKey}`)
-    .join("|");
+  // Sync the draft when the server data shifts under us. Keep
+  // in-progress edits where the operator has already typed.
+  const hash = baseline.map((s) => `${s.subsystem}:${s.iconKey}`).join("|");
   useMemo(() => {
     setDraft((prev) => {
       const next = new Map(prev);
@@ -111,7 +142,8 @@ export function StylesClient({
           <p className="mt-2 max-w-[640px] text-sm text-text-secondary">
             Pick an icon for each device class so the map reads at a
             glance — cameras, signs, weather stations, sensors are all
-            recognisable from a single zoom-out.
+            recognisable from a single zoom-out. Upload your own to
+            mirror real-world hardware.
           </p>
         </div>
         <button
@@ -124,6 +156,16 @@ export function StylesClient({
         </button>
       </header>
 
+      <CustomLibrary
+        projectId={projectId}
+        customIcons={customIcons}
+        uploadsEnabled={uploadsEnabled}
+        onChanged={() => void mutateIcons()}
+        anyAssignments={Array.from(draft.values()).some((k) =>
+          k.startsWith("custom:"),
+        )}
+      />
+
       {baseline.length === 0 ? (
         <EmptyState />
       ) : (
@@ -135,6 +177,7 @@ export function StylesClient({
                 value={draft.get(row.subsystem) ?? row.iconKey}
                 isOverride={row.isOverride}
                 iconLibrary={iconLibrary}
+                customIcons={customIcons}
                 onChange={(next) =>
                   setDraft((prev) => {
                     const map = new Map(prev);
@@ -148,6 +191,211 @@ export function StylesClient({
         </ul>
       )}
     </main>
+  );
+}
+
+/* ─── Custom-icon library ──────────────────────────────────────── */
+
+function CustomLibrary({
+  projectId,
+  customIcons,
+  uploadsEnabled,
+  onChanged,
+  anyAssignments,
+}: {
+  projectId: string;
+  customIcons: CustomIcon[];
+  uploadsEnabled: boolean;
+  onChanged: () => void;
+  anyAssignments: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleFile(file: File) {
+    if (!ALLOWED_TYPES.has(file.type)) {
+      toast.error("Use SVG, PNG, JPEG, or WebP.");
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      toast.error(`Icons must be under ${Math.round(MAX_BYTES / 1024)} KB.`);
+      return;
+    }
+    setUploading(true);
+    try {
+      // 1. Presign the PUT.
+      const presignRes = await fetch(`/api/uploads`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          fileName: file.name,
+          fileType: file.type,
+          prefix: "mobility-device-icons",
+        }),
+      });
+      if (!presignRes.ok) {
+        const body = (await presignRes.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? "Failed to presign upload");
+      }
+      const { signedUrl, publicUrl } = (await presignRes.json()) as PresignResponse;
+
+      // 2. Upload directly to Spaces.
+      const putRes = await fetch(signedUrl, {
+        method: "PUT",
+        headers: { "content-type": file.type },
+        body: file,
+      });
+      if (!putRes.ok) throw new Error("Spaces rejected the upload");
+
+      // 3. Register the row.
+      const label = file.name.replace(/\.[^./]+$/, "").slice(0, 60);
+      const registerRes = await fetch(
+        `/api/projects/${projectId}/styles/icons`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            url: publicUrl,
+            contentType: file.type,
+            bytes: file.size,
+            label,
+          }),
+        },
+      );
+      if (!registerRes.ok) {
+        const body = (await registerRes.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? "Failed to register icon");
+      }
+      toast.success(`Uploaded ${label}`);
+      onChanged();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  async function deleteIcon(icon: CustomIcon) {
+    if (
+      !confirm(
+        `Delete "${icon.label}"? Any subsystems using this icon will revert to the stock default.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/styles/icons/${icon.id}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) throw new Error("Delete failed");
+      toast.success(`Removed ${icon.label}`);
+      onChanged();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Delete failed");
+    }
+  }
+
+  return (
+    <section className="mb-6 rounded-2xl border border-line-soft bg-surface-1/40 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-text-primary">
+            Custom library
+          </h2>
+          <p className="mt-1 text-xs text-text-secondary">
+            SVG uploads tint with the active accent. PNG / JPEG / WebP
+            keep their original colours. Max{" "}
+            {Math.round(MAX_BYTES / 1024)} KB.
+          </p>
+        </div>
+        {uploadsEnabled ? (
+          <>
+            <input
+              ref={inputRef}
+              type="file"
+              accept=".svg,.png,.jpg,.jpeg,.webp"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void handleFile(f);
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => inputRef.current?.click()}
+              disabled={uploading}
+              className="inline-flex items-center gap-1.5 rounded-md border border-line-strong bg-bg px-3 py-1.5 text-xs font-medium text-text-primary transition-colors enabled:hover:border-accent enabled:hover:text-accent disabled:opacity-50"
+            >
+              <Upload size={12} strokeWidth={1.8} aria-hidden />
+              {uploading ? "Uploading…" : "Upload icon"}
+            </button>
+          </>
+        ) : (
+          <span className="text-[11px] text-text-tertiary">
+            Uploads disabled (storage not configured)
+          </span>
+        )}
+      </div>
+
+      {customIcons.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-dashed border-line-soft px-3 py-5 text-center text-xs text-text-tertiary">
+          No custom icons yet. Drop an SVG or PNG to give a subsystem its
+          own look.
+        </p>
+      ) : (
+        <ul className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+          {customIcons.map((icon) => (
+            <li
+              key={icon.id}
+              className="flex items-center gap-3 rounded-lg border border-line-soft bg-bg px-3 py-2"
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-md bg-surface-2">
+                {/* Operator-uploaded asset on DO Spaces — eslint
+                    next/no-img-element is fine here because the
+                    remote-pattern allowlist already covers this host
+                    and we need to render arbitrary contentType. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={icon.url}
+                  alt={icon.label}
+                  className="h-8 w-8 object-contain"
+                />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block truncate text-xs font-semibold text-text-primary">
+                  {icon.label}
+                </span>
+                <span className="block truncate text-[10px] text-text-tertiary">
+                  {icon.contentType === "image/svg+xml"
+                    ? "SVG · tinted"
+                    : icon.contentType.replace("image/", "").toUpperCase()}
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => void deleteIcon(icon)}
+                aria-label={`Delete ${icon.label}`}
+                className="rounded-md p-1 text-text-tertiary transition-colors hover:bg-rose-500/10 hover:text-rose-500"
+              >
+                <Trash2 size={12} strokeWidth={1.8} aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {anyAssignments ? (
+        <p className="mt-3 text-[10px] text-text-tertiary">
+          Some subsystems use custom icons. Deleting an icon reverts
+          those subsystems to the stock default.
+        </p>
+      ) : null}
+    </section>
   );
 }
 
@@ -172,24 +420,37 @@ function SubsystemCard({
   value,
   isOverride,
   iconLibrary,
+  customIcons,
   onChange,
 }: {
   subsystem: string;
   value: string;
   isOverride: boolean;
   iconLibrary: IconChoice[];
+  customIcons: CustomIcon[];
   onChange: (next: string) => void;
 }) {
-  const selected = getStockIcon(value);
+  const customId = value.startsWith("custom:") ? value.slice(7) : null;
+  const customSelected = customId
+    ? customIcons.find((i) => i.id === customId)
+    : null;
+  const stockSelected = !customId ? getStockIcon(value) : null;
   return (
     <article className="rounded-2xl border border-line-soft bg-surface-1/40 p-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          {selected ? (
-            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-soft text-accent">
-              <selected.Icon size={20} strokeWidth={1.6} aria-hidden />
-            </span>
-          ) : null}
+          <span className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-lg bg-accent-soft text-accent">
+            {customSelected ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={customSelected.url}
+                alt=""
+                className="h-7 w-7 object-contain"
+              />
+            ) : stockSelected ? (
+              <stockSelected.Icon size={20} strokeWidth={1.6} aria-hidden />
+            ) : null}
+          </span>
           <div>
             <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-text-tertiary">
               Subsystem
@@ -217,7 +478,7 @@ function SubsystemCard({
               type="button"
               aria-pressed={active}
               onClick={() => onChange(choice.key)}
-              className={`group flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+              className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
                 active
                   ? "border-accent bg-accent-soft"
                   : "border-line-soft bg-bg hover:border-line-strong"
@@ -225,21 +486,65 @@ function SubsystemCard({
             >
               <span
                 className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-md ${
-                  active ? "bg-accent text-accent-contrast" : "bg-surface-2 text-text-secondary"
+                  active
+                    ? "bg-accent text-accent-contrast"
+                    : "bg-surface-2 text-text-secondary"
                 }`}
               >
                 <stock.Icon size={16} strokeWidth={1.6} aria-hidden />
               </span>
               <span className="flex-1 min-w-0">
-                <span
-                  className={`block truncate text-xs font-semibold ${
-                    active ? "text-text-primary" : "text-text-primary"
-                  }`}
-                >
+                <span className="block truncate text-xs font-semibold text-text-primary">
                   {choice.label}
                 </span>
                 <span className="block truncate text-[10px] text-text-tertiary">
                   {choice.description}
+                </span>
+              </span>
+              {active ? (
+                <Check
+                  size={14}
+                  strokeWidth={2.2}
+                  className="shrink-0 text-accent"
+                  aria-hidden
+                />
+              ) : null}
+            </button>
+          );
+        })}
+        {customIcons.map((icon) => {
+          const key = `custom:${icon.id}`;
+          const active = value === key;
+          return (
+            <button
+              key={icon.id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange(key)}
+              className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                active
+                  ? "border-accent bg-accent-soft"
+                  : "border-line-soft bg-bg hover:border-line-strong"
+              }`}
+            >
+              <span
+                className={`flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md ${
+                  active ? "bg-accent/10" : "bg-surface-2"
+                }`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={icon.url}
+                  alt=""
+                  className="h-6 w-6 object-contain"
+                />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block truncate text-xs font-semibold text-text-primary">
+                  {icon.label}
+                </span>
+                <span className="block truncate text-[10px] text-text-tertiary">
+                  Custom
                 </span>
               </span>
               {active ? (

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/styles/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/styles/page.tsx
@@ -6,6 +6,7 @@ import {
   defaultIconKeyForSubsystem,
 } from "@/lib/mobility/device-icons";
 import { listProjectSubsystems } from "@/lib/mobility/device-style-resolver";
+import { features } from "@/lib/env";
 import { StylesClient } from "./StylesClient";
 
 type Params = Promise<{ orgId: string; projectId: string }>;
@@ -42,11 +43,23 @@ export default async function StylesPage({ params }: { params: Params }) {
   });
   if (!project) notFound();
 
-  const [subsystems, rows] = await Promise.all([
+  const [subsystems, rows, customRows] = await Promise.all([
     listProjectSubsystems(projectId),
     prisma.mobilityDeviceStyle.findMany({
       where: { projectId },
       select: { subsystem: true, iconKey: true },
+    }),
+    prisma.mobilityCustomIcon.findMany({
+      where: { projectId },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        label: true,
+        url: true,
+        contentType: true,
+        bytes: true,
+        createdAt: true,
+      },
     }),
   ]);
   const overrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
@@ -66,6 +79,11 @@ export default async function StylesPage({ params }: { params: Params }) {
         label: entry.label,
         description: entry.description,
       }))}
+      initialCustomIcons={customRows.map((r) => ({
+        ...r,
+        createdAt: r.createdAt.toISOString(),
+      }))}
+      uploadsEnabled={features.uploads}
     />
   );
 }

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -32,6 +32,11 @@ import {
   type MapStyleKey,
 } from "@/lib/mobility/map-settings";
 import { loadDeviceIconsIntoMap } from "@/lib/mobility/load-device-icons";
+import {
+  createThreeDeviceLayer,
+  THREE_DEVICE_LAYER_ID,
+  type ThreeDeviceLayer,
+} from "@/lib/mobility/three-device-layer";
 import { PushOptIn } from "./PushOptIn";
 
 interface Props {
@@ -46,6 +51,9 @@ interface Props {
   styleIcons: Record<string, string>;
   /** Per-id descriptor of custom uploads referenced by the project. */
   customIcons: Record<string, import("@/lib/mobility/device-style-resolver").CustomIconRef>;
+  /** Subsystem → 3D modelKey. Phase 3 — used when the visitor turns
+   *  on the "3D devices" toggle. */
+  styleModels: Record<string, string>;
 }
 
 const DEFAULT_PRIMARY = "#0ea5e9";
@@ -63,6 +71,7 @@ const DEFAULT_SETTINGS: MapEnvSettings = {
   lightPreset: "day",
   showTerrain: false,
   show3dBuildings: true,
+  show3dDevices: false,
 };
 
 function settingsStorageKey(slug: string): string {
@@ -303,6 +312,7 @@ export function WorldViewer({
   mapboxToken,
   styleIcons,
   customIcons,
+  styleModels,
 }: Props) {
   const primary = pickHex(theme.primaryColor, DEFAULT_PRIMARY);
   const bg = pickHex(theme.backgroundColor, DEFAULT_BG);
@@ -376,6 +386,30 @@ export function WorldViewer({
   latestIconExpressionRef.current = iconExpression;
   const customIconsRef = useRef(customIcons);
   customIconsRef.current = customIcons;
+  const styleModelsRef = useRef(styleModels);
+  styleModelsRef.current = styleModels;
+  const threeLayerRef = useRef<ThreeDeviceLayer | null>(null);
+
+  /** Push the world's curated devices into the Three.js layer using
+   *  the resolved per-subsystem model map. */
+  const pushDevicesTo3d = useCallback(() => {
+    const layer = threeLayerRef.current;
+    if (!layer) return;
+    const located = devices.filter(
+      (d): d is PublicWorldDevice & { lat: number; lng: number } =>
+        d.lat != null && d.lng != null,
+    );
+    layer.setDevices(
+      located.map((d) => ({
+        id: d.id,
+        lat: d.lat,
+        lng: d.lng,
+        subsystem: d.subsystem,
+      })),
+      (subsystem) => styleModelsRef.current[subsystem] ?? "model-generic",
+    );
+    layer.setAccent(primary);
+  }, [devices, primary]);
 
   const attachLayers = useCallback(
     (map: MapboxMap) => {
@@ -468,6 +502,49 @@ export function WorldViewer({
       /* style swap in-flight */
     }
   }, [iconExpression]);
+
+  /** 3D device layer — mount/unmount with the visitor's setting. */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const want = settings.show3dDevices;
+    const have = Boolean(threeLayerRef.current);
+    if (want && !have) {
+      const apply = () => {
+        if (!map.isStyleLoaded()) {
+          map.once("idle", apply);
+          return;
+        }
+        const layer = createThreeDeviceLayer();
+        threeLayerRef.current = layer;
+        try {
+          map.addLayer(layer);
+        } catch {
+          /* race with style swap — retry on next idle */
+        }
+        pushDevicesTo3d();
+      };
+      apply();
+    } else if (!want && have) {
+      try {
+        if (map.getLayer(THREE_DEVICE_LAYER_ID)) {
+          map.removeLayer(THREE_DEVICE_LAYER_ID);
+        }
+      } catch {
+        /* already gone */
+      }
+      threeLayerRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.show3dDevices]);
+
+  useEffect(() => {
+    pushDevicesTo3d();
+  }, [pushDevicesTo3d]);
+
+  useEffect(() => {
+    threeLayerRef.current?.setHighlight(selectedId);
+  }, [selectedId]);
 
   // Light + terrain + 3D — cheap config updates, no reload.
   useEffect(() => {
@@ -789,6 +866,15 @@ function MapSettingsPanel({
           }
           disabled={!activeStyle.supports3dObjects}
           disabledHint="Standard / Satellite only"
+          primary={primary}
+        />
+        <PanelToggle
+          icon={Box}
+          label="3D devices"
+          checked={settings.show3dDevices}
+          onChange={(show3dDevices) =>
+            onChange({ ...settings, show3dDevices })
+          }
           primary={primary}
         />
       </div>

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -44,6 +44,8 @@ interface Props {
   /** Subsystem → iconKey, resolved server-side from the operator's
    *  project-level styles. */
   styleIcons: Record<string, string>;
+  /** Per-id descriptor of custom uploads referenced by the project. */
+  customIcons: Record<string, import("@/lib/mobility/device-style-resolver").CustomIconRef>;
 }
 
 const DEFAULT_PRIMARY = "#0ea5e9";
@@ -300,6 +302,7 @@ export function WorldViewer({
   theme,
   mapboxToken,
   styleIcons,
+  customIcons,
 }: Props) {
   const primary = pickHex(theme.primaryColor, DEFAULT_PRIMARY);
   const bg = pickHex(theme.backgroundColor, DEFAULT_BG);
@@ -371,6 +374,8 @@ export function WorldViewer({
   );
   const latestIconExpressionRef = useRef(iconExpression);
   latestIconExpressionRef.current = iconExpression;
+  const customIconsRef = useRef(customIcons);
+  customIconsRef.current = customIcons;
 
   const attachLayers = useCallback(
     (map: MapboxMap) => {
@@ -416,7 +421,7 @@ export function WorldViewer({
 
     map.on("load", () => {
       applyMapEnvSettings(map, latestSettingsRef.current);
-      void loadDeviceIconsIntoMap(map).then(() => {
+      void loadDeviceIconsIntoMap(map, customIconsRef.current).then(() => {
         attachLayers(map);
         fitToDevices(map, devices);
       });
@@ -443,7 +448,9 @@ export function WorldViewer({
     map.setStyle(MAP_STYLES[settings.mapStyle].url);
     map.once("style.load", () => {
       applyMapEnvSettings(map, latestSettingsRef.current);
-      void loadDeviceIconsIntoMap(map).then(() => attachLayers(map));
+      void loadDeviceIconsIntoMap(map, customIconsRef.current).then(() =>
+        attachLayers(map),
+      );
     });
   }, [settings.mapStyle, attachLayers]);
 

--- a/apps/mobility/app/(public)/w/[slug]/page.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/page.tsx
@@ -47,6 +47,7 @@ export default async function WorldPublicPage({
       mapboxToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN ?? null}
       styleIcons={world.styleIcons}
       customIcons={world.customIcons}
+      styleModels={world.styleModels}
     />
   );
 }

--- a/apps/mobility/app/(public)/w/[slug]/page.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/page.tsx
@@ -46,6 +46,7 @@ export default async function WorldPublicPage({
       theme={world.theme}
       mapboxToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN ?? null}
       styleIcons={world.styleIcons}
+      customIcons={world.customIcons}
     />
   );
 }

--- a/apps/mobility/app/api/projects/[projectId]/styles/icons/[iconId]/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/styles/icons/[iconId]/route.ts
@@ -1,0 +1,32 @@
+/**
+ * `DELETE /api/projects/[projectId]/styles/icons/[iconId]`
+ *
+ * Drop a custom icon. Any subsystem styles that still reference it
+ * via `custom:<id>` revert to the stock default — done by deleting
+ * those rows here so the resolver re-picks the default lazily.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ projectId: string; iconId: string }>;
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId, iconId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  const ref = `custom:${iconId}`;
+  await prisma.$transaction([
+    prisma.mobilityDeviceStyle.deleteMany({
+      where: { projectId, iconKey: ref },
+    }),
+    prisma.mobilityCustomIcon.deleteMany({
+      where: { id: iconId, projectId },
+    }),
+  ]);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/mobility/app/api/projects/[projectId]/styles/icons/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/styles/icons/route.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-project custom icon library.
+ *
+ *   GET  /api/projects/[projectId]/styles/icons
+ *     List the operator's uploaded icons.
+ *
+ *   POST /api/projects/[projectId]/styles/icons
+ *     Register an icon that the browser has already PUT to Spaces.
+ *     Body: { url, contentType, bytes, label }
+ *     Returns the new row so the picker can include it immediately.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ projectId: string }>;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "read");
+  if (denied) return denied;
+
+  const icons = await prisma.mobilityCustomIcon.findMany({
+    where: { projectId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      label: true,
+      url: true,
+      contentType: true,
+      bytes: true,
+      createdAt: true,
+    },
+  });
+  return NextResponse.json({
+    icons: icons.map((i) => ({
+      ...i,
+      createdAt: i.createdAt.toISOString(),
+    })),
+  });
+}
+
+const PostBody = z.object({
+  url: z.string().url(),
+  contentType: z.enum([
+    "image/svg+xml",
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+  ]),
+  bytes: z.number().int().min(1).max(512 * 1024),
+  label: z.string().min(1).max(60),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PostBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const icon = await prisma.mobilityCustomIcon.create({
+    data: {
+      projectId,
+      label: parsed.data.label,
+      url: parsed.data.url,
+      contentType: parsed.data.contentType,
+      bytes: parsed.data.bytes,
+    },
+    select: {
+      id: true,
+      label: true,
+      url: true,
+      contentType: true,
+      bytes: true,
+      createdAt: true,
+    },
+  });
+  return NextResponse.json(
+    { icon: { ...icon, createdAt: icon.createdAt.toISOString() } },
+    { status: 201 },
+  );
+}

--- a/apps/mobility/app/api/projects/[projectId]/styles/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/styles/route.ts
@@ -19,11 +19,18 @@ import {
   STOCK_DEVICE_ICONS,
   defaultIconKeyForSubsystem,
 } from "@/lib/mobility/device-icons";
+import {
+  STOCK_DEVICE_MODELS,
+  defaultModelKeyForSubsystem,
+} from "@/lib/mobility/device-models";
 import { listProjectSubsystems } from "@/lib/mobility/device-style-resolver";
 
 type Params = Promise<{ projectId: string }>;
 
 const STOCK_KEYS = new Set(STOCK_DEVICE_ICONS.map((entry) => entry.key));
+const STOCK_MODEL_KEYS = new Set(
+  STOCK_DEVICE_MODELS.map((entry) => entry.key),
+);
 
 export async function GET(
   _req: Request,
@@ -37,15 +44,23 @@ export async function GET(
     listProjectSubsystems(projectId),
     prisma.mobilityDeviceStyle.findMany({
       where: { projectId },
-      select: { subsystem: true, iconKey: true },
+      select: { subsystem: true, iconKey: true, modelKey: true },
     }),
   ]);
 
-  const overrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const iconOverrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const modelOverrides = new Map(
+    rows
+      .filter((r): r is typeof r & { modelKey: string } => Boolean(r.modelKey))
+      .map((r) => [r.subsystem, r.modelKey]),
+  );
   const styles = subsystems.map((subsystem) => ({
     subsystem,
-    iconKey: overrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem),
-    isOverride: overrides.has(subsystem),
+    iconKey:
+      iconOverrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem),
+    modelKey:
+      modelOverrides.get(subsystem) ?? defaultModelKeyForSubsystem(subsystem),
+    isOverride: iconOverrides.has(subsystem) || modelOverrides.has(subsystem),
   }));
 
   return NextResponse.json({ styles });
@@ -57,6 +72,9 @@ const PutBody = z.object({
       z.object({
         subsystem: z.string().min(1).max(40),
         iconKey: z.string().min(1).max(60),
+        /** Phase 3 — optional 3D model assignment. Stock-only keys
+         *  in this PR; custom uploads land in Phase 3.5. */
+        modelKey: z.string().min(1).max(60).nullable().optional(),
       }),
     )
     .max(200),
@@ -116,6 +134,16 @@ export async function PUT(
       );
     }
   }
+  // Model keys are stock-only in Phase 3; null clears the assignment.
+  for (const s of parsed.data.styles) {
+    if (s.modelKey === undefined || s.modelKey === null) continue;
+    if (!STOCK_MODEL_KEYS.has(s.modelKey)) {
+      return NextResponse.json(
+        { error: `Unknown modelKey "${s.modelKey}".` },
+        { status: 400 },
+      );
+    }
+  }
 
   await prisma.$transaction([
     prisma.mobilityDeviceStyle.deleteMany({ where: { projectId } }),
@@ -124,6 +152,7 @@ export async function PUT(
         projectId,
         subsystem: s.subsystem,
         iconKey: s.iconKey,
+        modelKey: s.modelKey ?? null,
       })),
     }),
   ]);

--- a/apps/mobility/app/api/projects/[projectId]/styles/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/styles/route.ts
@@ -84,10 +84,31 @@ export async function PUT(
     );
   }
 
-  // Phase 1: stock keys only. Phase 2 will widen this when custom
-  // uploads land — we'll resolve `custom:<id>` against an upload
-  // table and accept those too.
+  // Stock keys are accepted as-is. `custom:<id>` references must
+  // resolve to a MobilityCustomIcon row owned by this project — block
+  // any attempt to point at another project's icon.
+  const customRefs = parsed.data.styles
+    .filter((s) => s.iconKey.startsWith("custom:"))
+    .map((s) => s.iconKey.slice("custom:".length));
+  const validCustomIds = new Set<string>();
+  if (customRefs.length) {
+    const rows = await prisma.mobilityCustomIcon.findMany({
+      where: { projectId, id: { in: customRefs } },
+      select: { id: true },
+    });
+    for (const r of rows) validCustomIds.add(r.id);
+  }
   for (const s of parsed.data.styles) {
+    if (s.iconKey.startsWith("custom:")) {
+      const id = s.iconKey.slice("custom:".length);
+      if (!validCustomIds.has(id)) {
+        return NextResponse.json(
+          { error: `Custom icon "${id}" is not part of this project.` },
+          { status: 400 },
+        );
+      }
+      continue;
+    }
     if (!STOCK_KEYS.has(s.iconKey)) {
       return NextResponse.json(
         { error: `Unknown iconKey "${s.iconKey}".` },

--- a/apps/mobility/app/api/public/worlds/[slug]/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/route.ts
@@ -33,6 +33,7 @@ export async function GET(
         theme: world.theme,
         devices: world.devices,
         styleIcons: world.styleIcons,
+        customIcons: world.customIcons,
       },
     },
     {

--- a/apps/mobility/app/api/public/worlds/[slug]/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/route.ts
@@ -33,6 +33,7 @@ export async function GET(
         theme: world.theme,
         devices: world.devices,
         styleIcons: world.styleIcons,
+        styleModels: world.styleModels,
         customIcons: world.customIcons,
       },
     },

--- a/apps/mobility/app/api/uploads/route.ts
+++ b/apps/mobility/app/api/uploads/route.ts
@@ -1,0 +1,74 @@
+/**
+ * `POST /api/uploads` — presigned PUT URL for direct-to-Spaces upload.
+ *
+ * Mirrors the campus pattern: the browser PUTs the file straight to
+ * DigitalOcean Spaces using the returned signed URL, then registers
+ * the resulting public URL against the relevant tenant resource
+ * (device icons, world logos, …).
+ *
+ * The allowlist of `prefix` values is the single source of truth for
+ * which surfaces accept uploads — adding a new prefix here is the
+ * only place a new upload target needs to learn its bucket layout.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { presignUpload, storageConfigFromEnv } from "@klorad/storage/server";
+import type { PresignUploadInput } from "@klorad/storage/types";
+
+const ALLOWED_PREFIXES = new Set<string>([
+  "mobility-device-icons",
+]);
+
+const ALLOWED_TYPES = new Set([
+  "image/svg+xml",
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: PresignUploadInput;
+  try {
+    body = (await req.json()) as PresignUploadInput;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.fileName || !body.fileType) {
+    return NextResponse.json(
+      { error: "fileName and fileType are required" },
+      { status: 400 },
+    );
+  }
+  if (!ALLOWED_TYPES.has(body.fileType.toLowerCase())) {
+    return NextResponse.json(
+      { error: `Unsupported fileType: ${body.fileType}` },
+      { status: 415 },
+    );
+  }
+  const prefix = body.prefix ?? "mobility-device-icons";
+  if (!ALLOWED_PREFIXES.has(prefix)) {
+    return NextResponse.json(
+      { error: `Unsupported prefix: ${prefix}` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await presignUpload(storageConfigFromEnv(), {
+      ...body,
+      prefix,
+    });
+    return NextResponse.json(result);
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Failed to sign upload" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/mobility/lib/mobility/device-models.ts
+++ b/apps/mobility/lib/mobility/device-models.ts
@@ -1,0 +1,201 @@
+/**
+ * Stock 3D device models — Three.js primitives, no GLB files. Each
+ * stock entry is a builder function that returns a fresh `Object3D`
+ * for the device-model layer to position at the device's
+ * `MercatorCoordinate`.
+ *
+ * Why primitives (no GLB)? Mobility's first 3D pass should ship
+ * without a content-creation pipeline. Operators who want a precise
+ * dome-camera model bring their own GLB through the Phase 3.5 upload
+ * pipeline (next PR); the stock set just needs to read as "camera"
+ * vs "sign" vs "post" from 50m up.
+ */
+import * as THREE from "three";
+
+export interface StockDeviceModel {
+  key: string;
+  label: string;
+  description: string;
+  /** Approximate height in metres so we can scale by viewport metres
+   *  later. Tuned so all stock models read at similar visual weight
+   *  at zoom 16-17. */
+  approxHeightMeters: number;
+  build: () => THREE.Object3D;
+}
+
+/** Centralised palette so swapping accent across light/dark themes
+ *  stays a one-line change. The 3D layer recolours instance materials
+ *  per-render based on the active accent. */
+const PALETTE = {
+  body: "#dde1e7",
+  housing: "#1f2937",
+  lens: "#0f172a",
+  pole: "#3b4453",
+  signFace: "#0b1220",
+  signFrame: "#94a3b8",
+  signal: "#dde1e7",
+};
+
+function makeMaterial(colour: string): THREE.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({
+    color: colour,
+    roughness: 0.55,
+    metalness: 0.18,
+  });
+}
+
+function buildPole(height: number): THREE.Mesh {
+  const geom = new THREE.CylinderGeometry(0.07, 0.09, height, 8);
+  geom.translate(0, height / 2, 0);
+  return new THREE.Mesh(geom, makeMaterial(PALETTE.pole));
+}
+
+function buildCamera(): THREE.Object3D {
+  const root = new THREE.Group();
+  const pole = buildPole(3.4);
+  root.add(pole);
+
+  const housing = new THREE.Mesh(
+    new THREE.BoxGeometry(0.55, 0.32, 0.6),
+    makeMaterial(PALETTE.housing),
+  );
+  housing.position.set(0, 3.55, 0.05);
+  root.add(housing);
+
+  const lens = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.12, 0.12, 0.22, 16),
+    makeMaterial(PALETTE.lens),
+  );
+  lens.rotation.z = Math.PI / 2;
+  lens.position.set(0.34, 3.55, 0.05);
+  root.add(lens);
+
+  return root;
+}
+
+function buildDms(): THREE.Object3D {
+  const root = new THREE.Group();
+  const left = buildPole(4.4);
+  left.position.x = -1.6;
+  const right = buildPole(4.4);
+  right.position.x = 1.6;
+  root.add(left, right);
+
+  const arm = new THREE.Mesh(
+    new THREE.BoxGeometry(3.6, 0.12, 0.12),
+    makeMaterial(PALETTE.pole),
+  );
+  arm.position.set(0, 4.35, 0);
+  root.add(arm);
+
+  const face = new THREE.Mesh(
+    new THREE.BoxGeometry(3.2, 1.05, 0.18),
+    makeMaterial(PALETTE.signFace),
+  );
+  face.position.set(0, 3.6, 0);
+  root.add(face);
+
+  const frame = new THREE.Mesh(
+    new THREE.BoxGeometry(3.3, 1.15, 0.06),
+    makeMaterial(PALETTE.signFrame),
+  );
+  frame.position.set(0, 3.6, -0.07);
+  root.add(frame);
+
+  return root;
+}
+
+function buildSignal(): THREE.Object3D {
+  const root = new THREE.Group();
+  const pole = buildPole(4.6);
+  root.add(pole);
+
+  const horizontal = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.06, 0.06, 1.6, 8),
+    makeMaterial(PALETTE.pole),
+  );
+  horizontal.rotation.z = Math.PI / 2;
+  horizontal.position.set(0.6, 4.5, 0);
+  root.add(horizontal);
+
+  const head = new THREE.Mesh(
+    new THREE.BoxGeometry(0.32, 0.78, 0.32),
+    makeMaterial(PALETTE.signFace),
+  );
+  head.position.set(1.25, 4.1, 0);
+  root.add(head);
+
+  const colours = ["#ef4444", "#facc15", "#22c55e"];
+  colours.forEach((c, i) => {
+    const lamp = new THREE.Mesh(
+      new THREE.CircleGeometry(0.085, 16),
+      new THREE.MeshBasicMaterial({ color: c }),
+    );
+    lamp.position.set(1.41, 4.35 - i * 0.22, 0);
+    lamp.rotation.y = Math.PI / 2;
+    root.add(lamp);
+  });
+
+  return root;
+}
+
+function buildGeneric(): THREE.Object3D {
+  const root = new THREE.Group();
+  const pole = buildPole(2.4);
+  root.add(pole);
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.22, 18, 12),
+    makeMaterial(PALETTE.body),
+  );
+  head.position.set(0, 2.55, 0);
+  root.add(head);
+  return root;
+}
+
+export const STOCK_DEVICE_MODELS: StockDeviceModel[] = [
+  {
+    key: "model-camera",
+    label: "Pole-mounted camera",
+    description: "Box housing on a pole.",
+    approxHeightMeters: 3.8,
+    build: buildCamera,
+  },
+  {
+    key: "model-dms",
+    label: "Dynamic sign gantry",
+    description: "Two-pole signboard.",
+    approxHeightMeters: 4.7,
+    build: buildDms,
+  },
+  {
+    key: "model-signal",
+    label: "Signal head",
+    description: "Traffic signal on mast arm.",
+    approxHeightMeters: 4.7,
+    build: buildSignal,
+  },
+  {
+    key: "model-generic",
+    label: "Generic device",
+    description: "Pole with sensor head.",
+    approxHeightMeters: 2.7,
+    build: buildGeneric,
+  },
+];
+
+const MODEL_INDEX: Map<string, StockDeviceModel> = new Map(
+  STOCK_DEVICE_MODELS.map((entry) => [entry.key, entry]),
+);
+
+export function getStockModel(key: string): StockDeviceModel | null {
+  return MODEL_INDEX.get(key) ?? null;
+}
+
+/** Auto-fill suggestion per subsystem on first visit. */
+export function defaultModelKeyForSubsystem(subsystem: string): string {
+  const normal = subsystem.toLowerCase();
+  if (normal === "cctv") return "model-camera";
+  if (normal === "dms") return "model-dms";
+  if (normal === "signal" || normal === "tsc") return "model-signal";
+  return "model-generic";
+}

--- a/apps/mobility/lib/mobility/device-style-resolver.ts
+++ b/apps/mobility/lib/mobility/device-style-resolver.ts
@@ -14,9 +14,19 @@
 import { prisma } from "@/lib/prisma";
 import { defaultIconKeyForSubsystem } from "./device-icons";
 
+export interface CustomIconRef {
+  id: string;
+  url: string;
+  contentType: string;
+  label: string;
+}
+
 export interface DeviceStyleMap {
   /** Lowercased subsystem → resolved iconKey. */
   icons: Record<string, string>;
+  /** Per-id descriptor of every custom icon currently referenced.
+   *  The client loader resolves `custom:<id>` keys against this. */
+  customIcons: Record<string, CustomIconRef>;
 }
 
 /** Distinct subsystems used in the project, in alphabetical order. */
@@ -33,7 +43,9 @@ export async function listProjectSubsystems(
 }
 
 /** Load operator-set rows + merge them with subsystem defaults so
- *  every active subsystem maps to *some* iconKey. */
+ *  every active subsystem maps to *some* iconKey. Custom icons that
+ *  are still referenced get bundled in so the client can resolve the
+ *  `custom:<id>` keys without a second round-trip. */
 export async function resolveDeviceStyles(
   projectId: string,
 ): Promise<DeviceStyleMap> {
@@ -50,5 +62,31 @@ export async function resolveDeviceStyles(
     icons[subsystem] =
       overrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem);
   }
-  return { icons };
+
+  const customIds = Array.from(
+    new Set(
+      Object.values(icons)
+        .filter((k) => k.startsWith("custom:"))
+        .map((k) => k.slice("custom:".length)),
+    ),
+  );
+  const customIcons: Record<string, CustomIconRef> = {};
+  if (customIds.length) {
+    const rows = await prisma.mobilityCustomIcon.findMany({
+      where: { projectId, id: { in: customIds } },
+      select: { id: true, url: true, contentType: true, label: true },
+    });
+    for (const r of rows) customIcons[r.id] = r;
+    // Self-heal: if a style still points at a deleted custom icon
+    // (race between style save and icon delete), fall back to the
+    // stock default rather than leave a dangling reference.
+    for (const subsystem of subsystems) {
+      const k = icons[subsystem];
+      if (k.startsWith("custom:") && !customIcons[k.slice(7)]) {
+        icons[subsystem] = defaultIconKeyForSubsystem(subsystem);
+      }
+    }
+  }
+
+  return { icons, customIcons };
 }

--- a/apps/mobility/lib/mobility/device-style-resolver.ts
+++ b/apps/mobility/lib/mobility/device-style-resolver.ts
@@ -13,6 +13,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import { defaultIconKeyForSubsystem } from "./device-icons";
+import { defaultModelKeyForSubsystem } from "./device-models";
 
 export interface CustomIconRef {
   id: string;
@@ -24,6 +25,8 @@ export interface CustomIconRef {
 export interface DeviceStyleMap {
   /** Lowercased subsystem → resolved iconKey. */
   icons: Record<string, string>;
+  /** Lowercased subsystem → resolved 3D modelKey. Phase 3. */
+  models: Record<string, string>;
   /** Per-id descriptor of every custom icon currently referenced.
    *  The client loader resolves `custom:<id>` keys against this. */
   customIcons: Record<string, CustomIconRef>;
@@ -53,14 +56,22 @@ export async function resolveDeviceStyles(
     listProjectSubsystems(projectId),
     prisma.mobilityDeviceStyle.findMany({
       where: { projectId },
-      select: { subsystem: true, iconKey: true },
+      select: { subsystem: true, iconKey: true, modelKey: true },
     }),
   ]);
-  const overrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const iconOverrides = new Map(rows.map((r) => [r.subsystem, r.iconKey]));
+  const modelOverrides = new Map(
+    rows
+      .filter((r): r is typeof r & { modelKey: string } => Boolean(r.modelKey))
+      .map((r) => [r.subsystem, r.modelKey]),
+  );
   const icons: Record<string, string> = {};
+  const models: Record<string, string> = {};
   for (const subsystem of subsystems) {
     icons[subsystem] =
-      overrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem);
+      iconOverrides.get(subsystem) ?? defaultIconKeyForSubsystem(subsystem);
+    models[subsystem] =
+      modelOverrides.get(subsystem) ?? defaultModelKeyForSubsystem(subsystem);
   }
 
   const customIds = Array.from(
@@ -88,5 +99,5 @@ export async function resolveDeviceStyles(
     }
   }
 
-  return { icons, customIcons };
+  return { icons, models, customIcons };
 }

--- a/apps/mobility/lib/mobility/load-device-icons.tsx
+++ b/apps/mobility/lib/mobility/load-device-icons.tsx
@@ -1,34 +1,40 @@
 "use client";
 
 /**
- * Client-side helper: load every stock device icon into a Mapbox map
- * as an SDF image. Idempotent on the icon *name*, so the operator
- * console and the public world viewer can both invoke this at every
- * style swap without paying the rasterisation cost twice.
+ * Client-side helper: load every stock + custom device icon into a
+ * Mapbox map as an addressable image. Idempotent on the icon name,
+ * so the operator console and the public world viewer can both
+ * invoke this at every style swap without paying the rasterisation
+ * cost twice.
+ *
+ * Naming:
+ *   - Stock entries register under `device-<stock key>`, SDF.
+ *   - Custom entries register under `device-custom:<id>`. SVG → SDF
+ *     so Mapbox can tint them with `icon-color`. PNG/JPEG/WebP are
+ *     added non-SDF, preserving the operator's original colours.
  */
 import { createElement } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
 import { STOCK_DEVICE_ICONS } from "./device-icons";
+import type { CustomIconRef } from "./device-style-resolver";
 import { rasteriseSvg } from "./icon-rasteriser";
 
-const RASTER_CACHE = new Map<string, ImageData>();
+interface CacheEntry {
+  data: ImageData;
+  sdf: boolean;
+}
 
-/**
- * Ensure every stock icon is present on the map as an SDF image
- * named `device-<key>`. Re-adds after a `setStyle` swap because the
- * style change wipes user-added images.
- *
- * `react-dom/server` is dynamically imported so the (sizeable) server
- * renderer doesn't land in the initial client bundle — map init is
- * already async and pays its cost off the critical path.
- */
-export async function loadDeviceIconsIntoMap(map: MapboxMap): Promise<void> {
+const RASTER_CACHE = new Map<string, CacheEntry>();
+
+/** Lookups that survive style swaps — the cache is per-icon, the
+ *  `addImage` re-add is per-style. */
+async function ensureStockIcons(map: MapboxMap): Promise<void> {
   const { renderToStaticMarkup } = await import("react-dom/server");
   for (const entry of STOCK_DEVICE_ICONS) {
     const name = `device-${entry.key}`;
     if (map.hasImage(name)) continue;
-    let data = RASTER_CACHE.get(entry.key) ?? null;
-    if (!data) {
+    let cached = RASTER_CACHE.get(name);
+    if (!cached) {
       const svg = renderToStaticMarkup(
         createElement(entry.Icon, {
           size: 96,
@@ -36,14 +42,92 @@ export async function loadDeviceIconsIntoMap(map: MapboxMap): Promise<void> {
           color: "white",
         }),
       );
-      data = await rasteriseSvg(svg);
+      const data = await rasteriseSvg(svg);
       if (!data) continue;
-      RASTER_CACHE.set(entry.key, data);
+      cached = { data, sdf: true };
+      RASTER_CACHE.set(name, cached);
     }
     try {
-      map.addImage(name, data, { sdf: true });
+      map.addImage(name, cached.data, { sdf: cached.sdf });
     } catch {
-      /* image already added under this name — fine */
+      /* same name — fine */
     }
   }
+}
+
+/** Fetch a custom upload + rasterise. SVGs reuse the same path as
+ *  stock icons so they tint via SDF; raster types are decoded by the
+ *  browser and pushed as full-colour images. */
+async function rasteriseCustomIcon(
+  icon: CustomIconRef,
+): Promise<CacheEntry | null> {
+  if (icon.contentType === "image/svg+xml") {
+    const res = await fetch(icon.url);
+    if (!res.ok) return null;
+    const svg = await res.text();
+    const data = await rasteriseSvg(svg);
+    if (!data) return null;
+    return { data, sdf: true };
+  }
+  // Raster path: <img> → canvas. The image is loaded crossOrigin so
+  // the canvas pixel buffer is readable (DO Spaces is configured to
+  // return permissive CORS on public assets — same convention as
+  // campus's branding pipeline).
+  const img = await new Promise<HTMLImageElement | null>((resolve) => {
+    const el = new Image();
+    el.crossOrigin = "anonymous";
+    el.onload = () => resolve(el);
+    el.onerror = () => resolve(null);
+    el.src = icon.url;
+  });
+  if (!img) return null;
+  const size = 128;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  // Letterbox so non-square uploads don't stretch.
+  const ratio = Math.min(size / img.width, size / img.height);
+  const w = img.width * ratio;
+  const h = img.height * ratio;
+  ctx.clearRect(0, 0, size, size);
+  ctx.drawImage(img, (size - w) / 2, (size - h) / 2, w, h);
+  return { data: ctx.getImageData(0, 0, size, size), sdf: false };
+}
+
+async function ensureCustomIcons(
+  map: MapboxMap,
+  customIcons: Record<string, CustomIconRef>,
+): Promise<void> {
+  for (const icon of Object.values(customIcons)) {
+    const name = `device-custom:${icon.id}`;
+    if (map.hasImage(name)) continue;
+    let cached = RASTER_CACHE.get(name);
+    if (!cached) {
+      const data = await rasteriseCustomIcon(icon);
+      if (!data) continue;
+      cached = data;
+      RASTER_CACHE.set(name, cached);
+    }
+    try {
+      map.addImage(name, cached.data, { sdf: cached.sdf });
+    } catch {
+      /* same name — fine */
+    }
+  }
+}
+
+/**
+ * Ensure stock + custom icons are present on the map. Re-runs after
+ * a `setStyle` swap because the style change wipes user-added
+ * images. `customIcons` defaults to empty so callers that don't yet
+ * resolve a project's icons (e.g. transient previews) still work.
+ */
+export async function loadDeviceIconsIntoMap(
+  map: MapboxMap,
+  customIcons: Record<string, CustomIconRef> = {},
+): Promise<void> {
+  await ensureStockIcons(map);
+  await ensureCustomIcons(map, customIcons);
 }

--- a/apps/mobility/lib/mobility/map-settings.ts
+++ b/apps/mobility/lib/mobility/map-settings.ts
@@ -65,6 +65,9 @@ export interface MapEnvSettings {
   lightPreset: LightPreset;
   showTerrain: boolean;
   show3dBuildings: boolean;
+  /** Phase 3 — render devices as 3D meshes through the Three.js
+   *  custom layer. When off, the 2D symbol layer carries on. */
+  show3dDevices: boolean;
 }
 
 const TERRAIN_SOURCE_ID = "mapbox-dem";
@@ -130,6 +133,12 @@ export function loadMapEnvSettings(
     // MAP_STYLES, snap back to the default rather than crash on init.
     if (parsed.mapStyle && !(parsed.mapStyle in MAP_STYLES)) {
       delete parsed.mapStyle;
+    }
+    // `show3dDevices` is a Phase-3 addition — older persisted blobs
+    // won't have it. Coerce undefined → false so existing operators
+    // don't get 3D forced on without opting in.
+    if (typeof parsed.show3dDevices !== "boolean") {
+      parsed.show3dDevices = defaults.show3dDevices ?? false;
     }
     return { ...defaults, ...parsed };
   } catch {

--- a/apps/mobility/lib/mobility/three-device-layer.ts
+++ b/apps/mobility/lib/mobility/three-device-layer.ts
@@ -1,0 +1,233 @@
+/**
+ * Mapbox CustomLayer that renders device meshes through Three.js.
+ *
+ * One layer per map. Devices are written via `setDevices(devices,
+ * resolveModelKey)`; the layer keeps the Three.js scene in sync with
+ * the latest device set and queues a repaint. Each device gets one
+ * mesh built from the stock model registry, anchored at the device's
+ * lng/lat via Mapbox's `MercatorCoordinate` so the projection matrix
+ * Mapbox hands the renderer lines up with the basemap exactly.
+ *
+ * Why a custom layer (not Mapbox's native `model` layer)? Native v3
+ * models are tied to the Standard style's `addImport` plumbing and
+ * don't accept arbitrary geometry from app code without GLB files.
+ * The Three.js layer keeps Phase 3 self-contained — stock primitives
+ * today, GLB uploads (Phase 3.5) tomorrow.
+ */
+import * as THREE from "three";
+import mapboxgl, {
+  type CustomLayerInterface,
+  type Map as MapboxMap,
+} from "mapbox-gl";
+import { getStockModel, type StockDeviceModel } from "./device-models";
+
+export interface ThreeDeviceInput {
+  id: string;
+  lng: number;
+  lat: number;
+  subsystem: string;
+}
+
+export interface ThreeDeviceLayer extends CustomLayerInterface {
+  setDevices(
+    devices: ThreeDeviceInput[],
+    resolveModelKey: (subsystem: string) => string,
+  ): void;
+  setHighlight(deviceId: string | null): void;
+  /** Tint applied to selection halo. Defaults to a Klorad teal. */
+  setAccent(hex: string): void;
+}
+
+const LAYER_ID = "device-models-3d";
+
+interface DeviceMesh {
+  id: string;
+  mesh: THREE.Object3D;
+  halo: THREE.Mesh;
+  modelKey: string;
+}
+
+export function createThreeDeviceLayer(): ThreeDeviceLayer {
+  let camera: THREE.PerspectiveCamera | null = null;
+  let scene: THREE.Scene | null = null;
+  let renderer: THREE.WebGLRenderer | null = null;
+  let map: MapboxMap | null = null;
+  const meshes: Map<string, DeviceMesh> = new Map();
+  /** Cache of source meshes per stock-model key. We `.clone()` per
+   *  instance so the geometry/material upload happens once. */
+  const sourceModels: Map<string, THREE.Object3D> = new Map();
+  let highlightId: string | null = null;
+  let accent = "#0ea5e9";
+  let lastDevices: ThreeDeviceInput[] = [];
+  let lastResolver: ((subsystem: string) => string) | null = null;
+
+  function ensureSourceModel(stock: StockDeviceModel): THREE.Object3D {
+    const cached = sourceModels.get(stock.key);
+    if (cached) return cached;
+    const built = stock.build();
+    sourceModels.set(stock.key, built);
+    return built;
+  }
+
+  function buildHaloMesh(): THREE.Mesh {
+    const geom = new THREE.RingGeometry(1.2, 1.55, 36);
+    const mat = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(accent),
+      transparent: true,
+      opacity: 0.5,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const mesh = new THREE.Mesh(geom, mat);
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.visible = false;
+    return mesh;
+  }
+
+  function addLights(s: THREE.Scene): void {
+    const ambient = new THREE.AmbientLight(0xffffff, 0.7);
+    const sun = new THREE.DirectionalLight(0xffffff, 0.85);
+    sun.position.set(0.5, 1, 0.6);
+    s.add(ambient, sun);
+  }
+
+  function placeAt(
+    obj: THREE.Object3D,
+    halo: THREE.Mesh,
+    lng: number,
+    lat: number,
+  ): void {
+    const merc = mapboxgl.MercatorCoordinate.fromLngLat([lng, lat], 0);
+    const scale = merc.meterInMercatorCoordinateUnits();
+    // The model's Y axis is "up" in metres; Mapbox's z is the
+    // mercator "altitude". We orient the model upright then translate
+    // everything so the base sits on the basemap.
+    const t = new THREE.Group();
+    t.position.set(merc.x, merc.y, merc.z);
+    t.rotation.x = Math.PI / 2;
+    t.scale.set(scale, scale, scale);
+    t.add(obj);
+    halo.position.set(merc.x, merc.y, merc.z);
+    halo.scale.set(scale, scale, scale);
+    // Halo is already rotated to lie flat against the basemap; replace
+    // the transform's group with one that doesn't include the halo.
+    return;
+  }
+
+  function rebuildScene(): void {
+    if (!scene) return;
+    for (const entry of meshes.values()) {
+      scene.remove(entry.mesh);
+      scene.remove(entry.halo);
+    }
+    meshes.clear();
+    if (!lastResolver) return;
+    for (const d of lastDevices) {
+      const modelKey = lastResolver(d.subsystem);
+      const stock = getStockModel(modelKey);
+      if (!stock) continue;
+      const source = ensureSourceModel(stock);
+      const clone = source.clone();
+      const halo = buildHaloMesh();
+      const merc = mapboxgl.MercatorCoordinate.fromLngLat([d.lng, d.lat], 0);
+      const metres = merc.meterInMercatorCoordinateUnits();
+      // Compose the per-instance transform on a fresh root so we can
+      // swap orientation without copy-pasting Mapbox boilerplate.
+      const root = new THREE.Group();
+      root.position.set(merc.x, merc.y, merc.z);
+      root.rotation.x = Math.PI / 2;
+      root.scale.setScalar(metres);
+      root.add(clone);
+
+      halo.position.set(merc.x, merc.y, merc.z);
+      halo.rotation.x = -Math.PI / 2;
+      halo.scale.setScalar(metres * stock.approxHeightMeters * 0.6);
+      scene.add(root);
+      scene.add(halo);
+      meshes.set(d.id, { id: d.id, mesh: root, halo, modelKey });
+    }
+    updateHighlight();
+  }
+
+  function updateHighlight(): void {
+    for (const entry of meshes.values()) {
+      entry.halo.visible = entry.id === highlightId;
+    }
+    if (map) map.triggerRepaint();
+  }
+
+  // Suppress unused-warning for the helper retained for clarity.
+  void placeAt;
+
+  return {
+    id: LAYER_ID,
+    type: "custom",
+    renderingMode: "3d",
+
+    onAdd(mapInstance, gl) {
+      map = mapInstance as MapboxMap;
+      scene = new THREE.Scene();
+      addLights(scene);
+      camera = new THREE.PerspectiveCamera();
+      renderer = new THREE.WebGLRenderer({
+        canvas: map.getCanvas(),
+        context: gl,
+        antialias: true,
+      });
+      renderer.autoClear = false;
+      // Rebuild scene if a previous setDevices call landed before
+      // the layer was attached (Operator passes devices into the
+      // factory + may swap layers across style.load).
+      rebuildScene();
+    },
+
+    render(_gl, matrix) {
+      if (!renderer || !scene || !camera) return;
+      const projection = new THREE.Matrix4().fromArray(matrix);
+      camera.projectionMatrix = projection;
+      // World is already encoded in mercator coords so the view is
+      // identity. The projection matrix Mapbox gives us covers all
+      // the placement maths.
+      renderer.resetState();
+      renderer.render(scene, camera);
+      if (map) map.triggerRepaint();
+    },
+
+    onRemove() {
+      if (!scene) return;
+      for (const entry of meshes.values()) {
+        scene.remove(entry.mesh);
+        scene.remove(entry.halo);
+      }
+      meshes.clear();
+      sourceModels.clear();
+      renderer?.dispose();
+      renderer = null;
+      scene = null;
+      camera = null;
+      map = null;
+    },
+
+    setDevices(devices, resolveModelKey) {
+      lastDevices = devices;
+      lastResolver = resolveModelKey;
+      rebuildScene();
+    },
+
+    setHighlight(deviceId) {
+      highlightId = deviceId;
+      updateHighlight();
+    },
+
+    setAccent(hex) {
+      accent = hex;
+      for (const entry of meshes.values()) {
+        const mat = entry.halo.material;
+        if (mat instanceof THREE.MeshBasicMaterial) mat.color.set(hex);
+      }
+      if (map) map.triggerRepaint();
+    },
+  };
+}
+
+export const THREE_DEVICE_LAYER_ID = LAYER_ID;

--- a/apps/mobility/lib/mobility/world-resolver.ts
+++ b/apps/mobility/lib/mobility/world-resolver.ts
@@ -47,6 +47,10 @@ export interface PublicWorld {
   /// Subsystem → iconKey resolved from the operator's project-level
   /// `MobilityDeviceStyle` rows. Used by the viewer's symbol layer.
   styleIcons: Record<string, string>;
+  /// Per-id descriptor of every custom upload referenced by the
+  /// project's styles. Lets the viewer's loader resolve `custom:<id>`
+  /// keys without a second round-trip.
+  customIcons: Record<string, import("./device-style-resolver").CustomIconRef>;
 }
 
 /**
@@ -133,6 +137,7 @@ async function toPublicWorld(world: WorldRecord): Promise<PublicWorld> {
         direction: d.direction,
       })),
     styleIcons: styleMap.icons,
+    customIcons: styleMap.customIcons,
   };
 }
 

--- a/apps/mobility/lib/mobility/world-resolver.ts
+++ b/apps/mobility/lib/mobility/world-resolver.ts
@@ -47,6 +47,9 @@ export interface PublicWorld {
   /// Subsystem → iconKey resolved from the operator's project-level
   /// `MobilityDeviceStyle` rows. Used by the viewer's symbol layer.
   styleIcons: Record<string, string>;
+  /// Subsystem → 3D modelKey. Used when the visitor turns on the
+  /// "3D devices" toggle.
+  styleModels: Record<string, string>;
   /// Per-id descriptor of every custom upload referenced by the
   /// project's styles. Lets the viewer's loader resolve `custom:<id>`
   /// keys without a second round-trip.
@@ -137,6 +140,7 @@ async function toPublicWorld(world: WorldRecord): Promise<PublicWorld> {
         direction: d.direction,
       })),
     styleIcons: styleMap.icons,
+    styleModels: styleMap.models,
     customIcons: styleMap.customIcons,
   };
 }

--- a/apps/mobility/package.json
+++ b/apps/mobility/package.json
@@ -34,10 +34,12 @@
     "react-dom": "^19.2.1",
     "react-toastify": "^11.0.5",
     "swr": "^2.3.6",
+    "three": "^0.170.0",
     "web-push": "^3.6.7",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/three": "^0.170.0",
     "@types/web-push": "^3.6.4",
     "autoprefixer": "10.4.20",
     "eslint": "^8.56.0",

--- a/packages/prisma/migrations/20260619120000_mobility_custom_icons/migration.sql
+++ b/packages/prisma/migrations/20260619120000_mobility_custom_icons/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "MobilityCustomIcon" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "contentType" TEXT NOT NULL,
+    "bytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MobilityCustomIcon_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MobilityCustomIcon_projectId_idx" ON "MobilityCustomIcon"("projectId");
+
+-- AddForeignKey
+ALTER TABLE "MobilityCustomIcon" ADD CONSTRAINT "MobilityCustomIcon_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -203,6 +203,9 @@ model Project {
   // Per-subsystem visual styles (icons + reserved 3D fields). See
   // lib/mobility/device-style-resolver.ts.
   mobilityDeviceStyles   MobilityDeviceStyle[]
+  // Per-project library of operator-uploaded device icons (SVG/PNG).
+  // Referenced from MobilityDeviceStyle.iconKey via `custom:<id>`.
+  mobilityCustomIcons    MobilityCustomIcon[]
   // Discovered items pending rector review.
   discoveredItems        DiscoveredItem[]
 
@@ -1085,6 +1088,37 @@ enum MobilityWorldEventKind {
   push_subscribe
   push_unsubscribe
   broadcast_sent
+}
+
+/// Per-project library of operator-uploaded device icons. Phase 1
+/// only consumed the stock library; Phase 2 lets the operator drop
+/// their own SVG (rendered as SDF, tinted) or PNG (kept full-colour)
+/// into the same picker.
+///
+/// Referenced by `MobilityDeviceStyle.iconKey` via the prefix
+/// `custom:<id>`. When a custom icon is deleted, any styles that
+/// referenced it revert to the stock subsystem default; that's done
+/// in the DELETE route, not at the schema layer, so we don't need a
+/// brittle FK across a polymorphic string column.
+model MobilityCustomIcon {
+  id          String   @id @default(cuid())
+  projectId   String
+  /// Operator-facing label — derived from the upload filename, can
+  /// be renamed later.
+  label       String
+  /// Public URL on DO Spaces.
+  url         String
+  /// MIME type. `image/svg+xml` is tinted via SDF; raster types are
+  /// rendered full-colour through the symbol layer.
+  contentType String
+  /// Byte count from the upload — used for the eventual per-project
+  /// quota check.
+  bytes       Int
+  createdAt   DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
 }
 
 /// Per-project, per-subsystem device style. The operator picks an

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,6 +667,9 @@ importers:
       swr:
         specifier: ^2.3.6
         version: 2.3.6(react@19.2.1)
+      three:
+        specifier: ^0.170.0
+        version: 0.170.0
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -674,6 +677,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@types/three':
+        specifier: ^0.170.0
+        version: 0.170.0
       '@types/web-push':
         specifier: ^3.6.4
         version: 3.6.4


### PR DESCRIPTION
## Why this PR exists

#221 (Phase 1 icons) merged into main, but #222 (Phase 2 custom uploads) and #223 (Phase 3 3D devices) got merged into their *stacked base branches* instead of main — so main only has Phase 1. This PR brings both phases onto main in a single, ready-to-merge change.

Both phases were already reviewed in #222 and #223. The commits are the same; only the base changed.

## Phase 2 — Custom SVG/PNG uploads

- New \`MobilityCustomIcon\` model + migration (\`20260619120000_mobility_custom_icons\`).
- Presigned upload route at \`/api/uploads\` (DO Spaces), prefix \`mobility-device-icons\`.
- Per-project library API: \`GET/POST /api/projects/[id]/styles/icons\`, \`DELETE /api/projects/[id]/styles/icons/[iconId]\`. Deleting a custom icon transactionally drops every \`MobilityDeviceStyle\` row that referenced it via \`custom:<id>\`, reverting those subsystems to the stock default.
- Styles page gains a "Custom library" section (upload widget, grid, delete) and the subsystem picker chips now include custom icons after the stock ones. Gated by \`features.uploads\`.
- Symbol-layer loader fetches each referenced upload at map init: SVGs reuse the existing SDF rasteriser (tinted by Mapbox); raster types are decoded into 128×128 letterboxed images and added non-SDF (preserve original colour).
- PUT \`/styles\` now validates \`custom:<id>\` keys against the project's icons — blocks cross-project assignment.

## Phase 3 — 3D devices on Mapbox

- New "3D devices" toggle on the existing Console + Map-settings panel; persists in localStorage. Off by default; older blobs coerce undefined → false at load.
- Mapbox \`CustomLayerInterface\` backed by Three.js. Devices anchor at \`MercatorCoordinate\`. Selection halo + accent are imperative setters so React doesn't tear down the WebGL context on state change.
- Stock model registry: 4 primitive builders (pole-mounted camera, DMS gantry, signal head, generic pole). Pure Three.js geometry, no GLB content pipeline for v1.
- Per-subsystem \`modelKey\` plumbed through API + resolver + both viewers. Auto-assigned defaults: CCTV → camera, DMS → gantry, signal/tsc → signal, else → generic.
- Three.js (\`^0.170.0\`) added to \`apps/mobility\`. ~120 kB hit on the public \`/w/[slug]\` chunk (565 → 689 kB). Feature is opt-in.

## Deferred to Phase 3.5

- Per-subsystem **model picker UI** on the Styles page.
- Custom **GLB uploads** (same pipeline as Phase 2 custom icons, with a \`GLTFLoader\` hook in \`ensureSourceModel\`).

## Test plan

- [ ] Migrations apply on deploy.
- [ ] Styles page shows Custom library section; upload an SVG → appears as a chip; assign to a subsystem → operator console + world viewer render it tinted with the accent.
- [ ] Upload a PNG → preserved full-colour on the map.
- [ ] Delete an assigned custom icon → subsystem reverts to stock default automatically.
- [ ] Console panel shows "3D devices" toggle; flipping on swaps from the icon symbol layer to 3D primitives at the device locations.
- [ ] Selection halo highlights the picked mesh; toggle off returns to icons cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)