### PR TITLE
fix(mobility): world PWA install icon falls back to platform default

### DIFF
--- a/apps/mobility/app/(public)/w/[slug]/layout.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/layout.tsx
@@ -26,10 +26,30 @@ export async function generateMetadata({
   const { slug } = await params;
   const world = await loadPublicWorldBySlug(slug);
   if (!world) return { title: "Not found" };
+
+  // iOS ignores manifest icons for home-screen installs — it reads
+  // `<link rel="apple-touch-icon">` instead. Without an explicit
+  // apple entry, Next.js falls back to `app/icon.png` (the PSMdt
+  // mark) and the world's branded logo never lands. Plumb the
+  // world's logoUrl into both icon channels so Android (manifest +
+  // browser tab) and iOS (apple-touch-icon + home screen) all paint
+  // the same brand. SVG vs PNG is handled in the manifest route;
+  // the apple channel accepts either.
+  const logoUrl =
+    typeof world.theme.logoUrl === "string" ? world.theme.logoUrl : null;
+  const icons: Metadata["icons"] = logoUrl
+    ? {
+        icon: [{ url: logoUrl }],
+        shortcut: [{ url: logoUrl }],
+        apple: [{ url: logoUrl, sizes: "180x180" }],
+      }
+    : undefined;
+
   return {
     title: world.name,
     description: world.description ?? `${world.name} — live traffic + transit.`,
     manifest: `/w/${slug}/manifest.webmanifest`,
+    icons,
     appleWebApp: {
       capable: true,
       statusBarStyle: "default",

--- a/apps/mobility/app/(public)/w/[slug]/manifest.webmanifest/route.ts
+++ b/apps/mobility/app/(public)/w/[slug]/manifest.webmanifest/route.ts
@@ -19,6 +19,18 @@ function truncate(value: string, max: number): string {
   return value.length <= max ? value : value.slice(0, max - 1).trimEnd() + "…";
 }
 
+/** Strip query string / fragment and take the extension for MIME
+ *  detection. URLs from DO Spaces sometimes carry signed-URL params,
+ *  but the file extension is stable. */
+function mimeFromUrl(url: string): string | null {
+  const cleaned = url.split(/[?#]/)[0].toLowerCase();
+  if (cleaned.endsWith(".svg")) return "image/svg+xml";
+  if (cleaned.endsWith(".png")) return "image/png";
+  if (cleaned.endsWith(".jpg") || cleaned.endsWith(".jpeg")) return "image/jpeg";
+  if (cleaned.endsWith(".webp")) return "image/webp";
+  return null;
+}
+
 export async function GET(
   _req: Request,
   { params }: { params: Params },
@@ -37,20 +49,47 @@ export async function GET(
     : "#0b1220";
   const logo = typeof world.theme.logoUrl === "string" ? world.theme.logoUrl : null;
 
-  // Browsers want at least one ≥192px icon for the install prompt.
-  // The world's uploaded logo (if any) is preferred; we declare
-  // `sizes: "any"` so a non-square upload still installs. The Klorad
-  // mark stays as a fallback so installability holds before the
-  // operator uploads custom branding (theming arrives in PR4).
+  // Chrome's install checker silently drops icons that don't declare
+  // a `type` matching the file, and `sizes: "any"` is only valid for
+  // SVG. Without those, the world's uploaded logo gets skipped and
+  // the install falls through to the PSM fallback — which is exactly
+  // the regression operators have been hitting after switching from
+  // SVG to PNG uploads.
+  //
+  // We claim space-separated 192x192/512x512 on raster uploads so
+  // Chrome picks the right size for both the install prompt and the
+  // splash screen, regardless of the upload's actual pixel dims.
+  // `purpose: "any maskable"` lets Android use it as an adaptive icon
+  // (Pixel/Samsung rounded squircles) without rejecting non-square
+  // sources.
   const icons: Array<{ src: string; sizes: string; type?: string; purpose?: string }> = [];
   if (logo) {
-    icons.push({ src: logo, sizes: "any", purpose: "any" });
+    const mime = mimeFromUrl(logo);
+    if (mime === "image/svg+xml") {
+      icons.push({
+        src: logo,
+        sizes: "any",
+        type: mime,
+        purpose: "any maskable",
+      });
+    } else if (mime) {
+      icons.push({
+        src: logo,
+        sizes: "192x192 512x512",
+        type: mime,
+        purpose: "any maskable",
+      });
+    } else {
+      // Unknown extension — give the browser something to try; Chrome
+      // is forgiving when `type` is omitted on a generic entry.
+      icons.push({ src: logo, sizes: "192x192 512x512", purpose: "any" });
+    }
   }
   icons.push({
     src: "/psm-mark.png",
-    sizes: "any",
+    sizes: "192x192 512x512",
     type: "image/png",
-    purpose: "any",
+    purpose: "any maskable",
   });
 
   const manifest = {


### PR DESCRIPTION
## What was broken

Operator-uploaded world logos were being silently ignored at install time, so "Add to home screen" on both Android and iOS painted the PSMdt fallback instead of the world's brand.

Two root causes:

1. **Manifest icon spec was invalid for raster uploads.** The world's logoUrl was declared with no \`type\` and \`sizes: "any"\`. Chrome's install checker silently drops icons with mismatched/absent metadata — \`sizes: "any"\` is only valid for SVG. For PNG/JPEG/WebP it wants concrete pixel sizes (\`192x192\`, \`512x512\`, …) and a matching \`type\`. The world's logo got skipped and the install fell through to PSMdt.

2. **iOS never read the manifest icons at all.** iOS uses \`<link rel="apple-touch-icon">\` for home-screen installs, not the manifest. The world layout set \`appleWebApp.capable: true\` but never declared the icon URL, so Next.js fell back to \`app/icon.png\` (the platform mark).

## Fix

- Manifest route detects MIME from the logo URL extension (strips query strings so signed Spaces URLs still resolve), then emits a properly-typed entry: SVG → \`sizes: "any"\`; raster → \`sizes: "192x192 512x512"\`. Both get \`purpose: "any maskable"\` so Android renders them as adaptive icons (rounded squircles on Pixel/Samsung).
- Layout's \`generateMetadata\` sets \`icons.icon\`, \`icons.shortcut\`, and \`icons.apple\` pointing at the world's logoUrl when set, so Next.js auto-injects the \`<link rel="apple-touch-icon">\` tag iOS needs. When no logo is set, the existing \`app/icon.png\` PSMdt fallback still applies.

## Test plan

- [ ] Upload a PNG/JPEG world logo via the Theme card, publish, install.
- [ ] **Android**: install banner + home-screen icon paint the world's logo.
- [ ] **iOS**: tap Share → Add to Home Screen → icon is the world's logo, not the PSMdt mark.
- [ ] Worlds with no logo still install with the PSMdt fallback (no regression).
- [ ] Browser tab favicon reflects the world's logo on public route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)