### PR TITLE
fix(mobility): unblock the Sync button so #227's recovery can fire

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
@@ -148,6 +148,16 @@ function SourceRowItem({
 }) {
   const [busy, setBusy] = useState(false);
   const isRunning = row.syncStatus === "running";
+  /** Mirrors `STALE_SYNC_AFTER_MS` on the server. After 10 minutes
+   *  we treat a `running` row as a casualty of Vercel's `after()`
+   *  budget and let the operator restart instead of greying out the
+   *  Sync button forever. The server-side recovery in `/sync` does
+   *  the actual reset; we just unblock the click. */
+  const STALE_SYNC_AFTER_MS = 10 * 60 * 1000;
+  const isStale =
+    isRunning &&
+    !!row.syncStartedAt &&
+    Date.now() - new Date(row.syncStartedAt).getTime() > STALE_SYNC_AFTER_MS;
 
   const test = async () => {
     setBusy(true);
@@ -255,11 +265,20 @@ function SourceRowItem({
           </button>
           <button
             type="button"
-            disabled={busy || isRunning}
+            disabled={busy || (isRunning && !isStale)}
             onClick={sync}
+            title={
+              isStale
+                ? "Previous run looks stuck — click to reset and start fresh."
+                : undefined
+            }
             className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover disabled:opacity-50"
           >
-            {isRunning ? "Syncing…" : "Sync now"}
+            {isStale
+              ? "Restart sync"
+              : isRunning
+                ? "Syncing…"
+                : "Sync now"}
           </button>
           <button
             type="button"


### PR DESCRIPTION
## What's still broken

#227 added \`recoverStaleSync\` on the server so a click on Sync after a Vercel \`after()\`-budget kill would auto-reset the row and start fresh. That logic is correct — but it never runs in production because the operator UI gates the Sync button on \`syncStatus === "running"\`. The button greys out the moment a row enters running, so the operator can't click the very action that would trigger recovery. The fix shipped, but it's dead code in practice.

## The fix

Compute the same 10-min staleness check on the client. When a row's been \`running\` longer than that, flip the button from disabled "Syncing…" to enabled **"Restart sync"** with a tooltip explaining what the click does. The click still POSTs to \`/api/sources/<id>/sync\`, which now actually runs \`recoverStaleSync\` and starts a fresh run.

No new endpoint. No server change. Just the missing piece on the client.

## Test plan

- [ ] Operator with the currently-stuck source (elapsed \`1395m\`) reloads → button now reads "Restart sync".
- [ ] Click → POST returns \`{ started: true }\` → progress card resets to seconds elapsed → fresh run walks CCTV and DMS.
- [ ] A row that's only been \`running\` for 30 seconds keeps showing the disabled "Syncing…" (no regression on healthy runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)