### PR TITLE
fix(campus): align News admin page shape with Events

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
@@ -4,7 +4,6 @@ import { prisma } from "@/lib/prisma";
 import { listNewsForAdmin } from "@/lib/news";
 import { NewsAdminClient } from "./NewsAdminClient";
 import { PageHeader } from "@/app/(dashboard)/components/PageHeader";
-import { PhonePreview } from "@/app/(dashboard)/components/PhonePreview";
 import { OpenPublicAction } from "@/app/(dashboard)/components/OpenPublicAction";
 
 type Params = Promise<{ orgId: string; mapId: string }>;
@@ -15,10 +14,10 @@ type Params = Promise<{ orgId: string; mapId: string }>;
  * so this page no longer needs an inline back link; `PageHeader` is
  * the consistent chrome across every rail destination.
  *
- * The phone preview on the right is the Phase 4b pilot of the
- * preview pattern — see `PhonePreview`. The pane loads the public
- * news route; the rector hits Refresh after Save to see the new
- * post land.
+ * Width + layout match the Events page so the rector's eye lands in
+ * the same place across every Public surface tab. The PhonePreview
+ * pattern lived here as the Phase 4b pilot but was breaking out of
+ * the rail at 1400px and crowding the form — pulled out.
  */
 export default async function NewsAdminPage({
   params,
@@ -52,7 +51,7 @@ export default async function NewsAdminPage({
   const posts = await listNewsForAdmin(mapId);
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] px-6 py-8 md:px-10">
+    <div className="mx-auto w-full max-w-[1280px] px-6 py-8 md:px-10">
       <PageHeader
         eyebrow="Public surface"
         title="News"
@@ -60,21 +59,11 @@ export default async function NewsAdminPage({
         actions={<OpenPublicAction href={`/campus/${mapId}/news`} />}
       />
 
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px]">
-        <div className="min-w-0">
-          <NewsAdminClient
-            mapId={mapId}
-            initialPosts={posts}
-            indoorMapId={indoorMapId}
-          />
-        </div>
-        <aside className="hidden lg:block">
-          <PhonePreview
-            src={`/campus/${mapId}/news`}
-            title="Public news preview"
-          />
-        </aside>
-      </div>
+      <NewsAdminClient
+        mapId={mapId}
+        initialPosts={posts}
+        indoorMapId={indoorMapId}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What was wrong

Two intentional divergences on the News admin page that didn't match the rest of the backoffice:

1. **Width** — News used \`max-w-[1400px]\`; Events and every other rail destination use \`max-w-[1280px]\`. That extra 120px pushed past the rail and made the form overflow.
2. **Phone preview** — News was the only page that wrapped its form in a 2-column grid (\`1fr_340px\`) with a \`<PhonePreview>\` on the right. The mobile-preview pattern crowded the form, and at 1400px both columns competed for space.

The comment said the PhonePreview was the Phase 4b pilot; in practice it stayed in News alone and broke layout consistency. The \`OpenPublicAction\` link in the header is enough when the rector wants to verify on the public surface.

## What changes

- News page width → \`max-w-[1280px]\` (matches Events / Members / Settings / every other admin page).
- Drop the PhonePreview column + grid wrapper. \`NewsAdminClient\` now lives directly in the page like \`EventsAdminClient\` does.
- \`PhonePreview\` component stays — Identity still uses it; no other consumers besides News had it.

## Test plan

- [ ] Open \`/org/<orgId>/maps/<mapId>/news\` → page width matches Events, form no longer overflows the rail.
- [ ] \`Open public\` button in the header still works.
- [ ] Identity page (\`/org/<orgId>/maps/<mapId>/identity\`) still shows its phone preview — no regression elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)