### PR TITLE
fix(storage): add editor + mobility origins to Spaces CORS default

### DIFF
--- a/packages/storage/scripts/set-cors.ts
+++ b/packages/storage/scripts/set-cors.ts
@@ -40,9 +40,19 @@ import {
 } from "@aws-sdk/client-s3";
 import { storageConfigFromEnv } from "../src/server";
 
+// Every Klorad app that reads or writes to Spaces from the browser
+// needs its Origin listed here — direct-upload PUT, presigned GET,
+// and (in the editor) Cesium's cross-origin glTF fetch all need
+// `Access-Control-Allow-Origin` on the response, which DO Spaces
+// only sets when an incoming Origin matches one of these rules.
+// Localhost ports match each app's `next dev -p …` script.
 const DEFAULT_ORIGINS = [
   "https://campus.klorad.com",
+  "https://platform.klorad.com",
+  "https://mobility.klorad.com",
+  "http://localhost:3001",
   "http://localhost:3003",
+  "http://localhost:3004",
 ];
 
 function parseOrigins(): string[] {
@@ -83,7 +93,11 @@ async function main() {
     AllowedOrigins: origins,
     AllowedMethods: ["PUT", "GET", "HEAD"],
     AllowedHeaders: ["*"],
-    ExposeHeaders: ["ETag"],
+    // Cesium's glTF loader in the editor reads `Content-Length` for
+    // load-progress UI and `Accept-Ranges` to decide whether it can
+    // stream big `.glb` files — without them exposed the browser
+    // treats every byte as unknown. ETag stays for cache validation.
+    ExposeHeaders: ["ETag", "Content-Length", "Accept-Ranges"],
     MaxAgeSeconds: 300,
   };
 


### PR DESCRIPTION
## Summary
- Users of the deprecated **platform.klorad.com** editor report Cesium can't load their uploaded `.glb` models: the Space returns `200 OK`, but the browser blocks the fetch because there's no `Access-Control-Allow-Origin` header.
- Root cause: `packages/storage/scripts/set-cors.ts` only lists `campus.klorad.com` + `localhost:3003` in `DEFAULT_ORIGINS`. The editor (`platform.klorad.com`) and mobility (`mobility.klorad.com`) origins were never added, so DO Spaces refuses to attach ACAO for either.
- This extends the default list to every Klorad app origin — deployed + local `next dev` ports — and exposes `Content-Length` / `Accept-Ranges` so Cesium can render load progress and stream big glTFs.

## Why now, on a deprecated editor
Nothing in the editor changed — the world around it did. Newer DO Spaces enforcement + past CORS rewrites narrowed the allowed origin list without the editor's origin ever being included. Same class of thing as PR #190's DO Spaces regression.

## Rollout
After merge, run once from repo root:
```
pnpm spaces:set-cors
```
(sources creds from `apps/campus/.env` like today). To verify:
```
pnpm spaces:get-cors
curl -I -H "Origin: https://platform.klorad.com" \
  https://fra1.digitaloceanspaces.com/prieston-prod/models/<any-file>.glb
```
Expected: `access-control-allow-origin: https://platform.klorad.com`.

## Test plan
- [ ] Merge, run `pnpm spaces:set-cors`, confirm ACAO present via curl for platform + mobility origins.
- [ ] Load a Space-hosted `.glb` in the editor's Cesium viewer — model renders instead of CORS-erroring in devtools.
- [ ] Confirm campus upload flow (unchanged path — campus.klorad.com still in origins) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)