### PR TITLE
fix(editor): opt out of AWS SDK auto-checksum on Spaces uploads

### DIFF
--- a/apps/editor/app/api/models/route.ts
+++ b/apps/editor/app/api/models/route.ts
@@ -124,6 +124,14 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Missing file data" }, { status: 400 });
     }
     // Configure the S3 client for DigitalOcean Spaces.
+    //
+    // `requestChecksumCalculation: "WHEN_REQUIRED"` — @aws-sdk/client-s3
+    // ≥ 3.729 defaults to `WHEN_SUPPORTED`, which bakes a CRC32 of an
+    // *empty* body into the presigned PUT URL (checksum computed at
+    // sign time, before the browser has the file). DO Spaces then 403s
+    // when the real body's checksum doesn't match. Same fix that
+    // shipped in `@klorad/storage`'s server; kept inline here because
+    // the editor isn't on `@klorad/storage` yet.
     const s3 = new S3Client({
       region: serverEnv.DO_SPACES_REGION,
       endpoint: serverEnv.DO_SPACES_ENDPOINT,
@@ -131,6 +139,8 @@ export async function PATCH(request: NextRequest) {
         accessKeyId: serverEnv.DO_SPACES_KEY,
         secretAccessKey: serverEnv.DO_SPACES_SECRET,
       },
+      requestChecksumCalculation: "WHEN_REQUIRED",
+      responseChecksumValidation: "WHEN_REQUIRED",
     });
     const bucketName = serverEnv.DO_SPACES_BUCKET;
     // Use provided prefix (e.g., "supportive-data") or default to "models"
@@ -464,7 +474,8 @@ export async function DELETE(request: NextRequest) {
       // Only delete from Spaces if it's not a Cesium Ion placeholder URL
       if (!fileUrl.startsWith("cesium-ion://")) {
         const key = fileUrl.replace(`${endpoint}/${bucketName}/`, "");
-        // Setup S3 client.
+        // Setup S3 client. See PATCH handler for the checksum flag
+        // rationale — same issue applies to signed DELETE requests.
         const s3 = new S3Client({
           region: serverEnv.DO_SPACES_REGION,
           endpoint: endpoint,
@@ -472,6 +483,8 @@ export async function DELETE(request: NextRequest) {
             accessKeyId: serverEnv.DO_SPACES_KEY,
             secretAccessKey: serverEnv.DO_SPACES_SECRET,
           },
+          requestChecksumCalculation: "WHEN_REQUIRED",
+          responseChecksumValidation: "WHEN_REQUIRED",
         });
         // Delete the object from Spaces.
         const deleteCommand = new DeleteObjectCommand({


### PR DESCRIPTION
## Summary
- Editor model uploads to DO Spaces are failing with 403 + CORS. The signed PUT URL carries
  `x-amz-checksum-crc32=AAAAAA%3D%3D&x-amz-sdk-checksum-algorithm=CRC32`.
- `AAAAAA==` is the CRC32 of **zero bytes** — `@aws-sdk/client-s3` ≥ 3.729 defaults to
  `requestChecksumCalculation: "WHEN_SUPPORTED"` and computes the checksum at sign time,
  before the browser has the file. DO Spaces then 403s when the real body's checksum
  doesn't match.
- `@klorad/storage`'s `server.ts` already fixed this centrally with
  `requestChecksumCalculation: "WHEN_REQUIRED"` + `responseChecksumValidation: "WHEN_REQUIRED"`.
  The editor never migrated onto `@klorad/storage`, so both `S3Client` constructions in
  `apps/editor/app/api/models/route.ts` still had the broken default.
- This applies the same two lines inline to both clients (PATCH → presign, DELETE → object cleanup).

## Companion PR
- PR #230 (`fix/storage-cors-editor-mobility-origins`) fixes the **GET** side — cross-origin
  CORS on Cesium's model fetch. Together these two + running `pnpm spaces:set-cors` fully
  unblock the editor's 3D model flow.

## Follow-up
- Migrate `apps/editor/app/api/models/route.ts` to `@klorad/storage` so the checksum flag,
  URL-shape, and env-var reading only live in one place. Out of scope for this hotfix.

## Test plan
- [ ] Deploy preview: upload a `.glb` via the editor. Inspect the signed URL — it should
      no longer contain `x-amz-checksum-*` or `x-amz-sdk-checksum-algorithm` query params.
- [ ] File uploads to `prieston-prod` succeed (200 on PUT).
- [ ] Delete an asset via the editor — Spaces object gets removed (no 403 in server logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)