### PR TITLE
fix(editor): scope Ion geometryCompression to BIM/CAD uploads

### DIFF
--- a/apps/editor/app/(protected)/org/[orgId]/library/geospatial/components/UploadToIonDrawer.tsx
+++ b/apps/editor/app/(protected)/org/[orgId]/library/geospatial/components/UploadToIonDrawer.tsx
@@ -129,8 +129,12 @@ export const UploadToIonDrawer: React.FC<UploadToIonDrawerProps> = ({
         ionOptions.inputCrs = `EPSG:${options.epsgCode}`;
       }
 
-      // geometryCompression: "MESHOPT" or "DRACO" for BIM/CAD
-      if (options?.geometricCompression) {
+      // geometryCompression: "MESHOPT" or "DRACO" for BIM/CAD.
+      // Ion 409s ("options.sourceType must be a valid source type")
+      // if this is present on non-BIM types like KML/GeoJSON/CZML —
+      // it infers a BIM tiling flow and demands a matching sourceType.
+      // Gate on `BIM_CAD` like `textureFormat` below already does.
+      if (uploadSourceType === "BIM_CAD" && options?.geometricCompression) {
         const compression = options.geometricCompression.toUpperCase();
         if (compression === "MESHOPT" || compression === "DRACO") {
           ionOptions.geometryCompression = compression;

--- a/apps/editor/app/components/AppBar/BuilderActions/hooks/useCesiumIon.ts
+++ b/apps/editor/app/components/AppBar/BuilderActions/hooks/useCesiumIon.ts
@@ -207,9 +207,12 @@ export const useCesiumIon = () => {
         ionOptions.inputCrs = `EPSG:${options.epsgCode}`;
       }
 
-      // geometryCompression: "MESHOPT" or "DRACO" for BIM/CAD (note: no "ric" in field name)
-      // Remove "NONE" option as Ion doesn't accept it
-      if (options?.geometricCompression) {
+      // geometryCompression: "MESHOPT" or "DRACO" for BIM/CAD.
+      // Ion 409s ("options.sourceType must be a valid source type")
+      // if this is present on non-BIM types like KML/GeoJSON/CZML —
+      // it infers a BIM tiling flow and demands a matching sourceType.
+      // Gate on `BIM_CAD` like `textureFormat` below already does.
+      if (uploadSourceType === "BIM_CAD" && options?.geometricCompression) {
         const compression = options.geometricCompression.toUpperCase();
         if (compression === "MESHOPT" || compression === "DRACO") {
           ionOptions.geometryCompression = compression;


### PR DESCRIPTION
## Summary
- Uploading a KML (or GeoJSON / CZML) via the Cesium Ion flow was 409ing with:
  ` InvalidArgument: 'options.sourceType' must be a valid source type`,
  even though the client never sends a `sourceType` for those types.
- **Root cause**: the form's `geometricCompression` field (DRACO/MESHOPT) was being forwarded
  into `options.geometryCompression` on **every** upload. When Ion sees `geometryCompression`
  in the payload it infers a BIM/CAD tiling flow and demands a matching `sourceType`. On
  KML the client has no `sourceType` to send, so Ion rejects.

## Fix
- `textureFormat` right below already gates on `uploadSourceType === "BIM_CAD"`. Apply the
  same guard to `geometryCompression` in both copies of the payload builder:
  - `apps/editor/app/(protected)/org/[orgId]/library/geospatial/components/UploadToIonDrawer.tsx`
  - `apps/editor/app/components/AppBar/BuilderActions/hooks/useCesiumIon.ts`

## Test plan
- [ ] Upload a `.kml` via the library drawer, picking `KML/KMZ` — Ion returns 200 (asset created),
      Ion tiling starts, and the resulting asset renders via `CesiumIonAssetsRenderer` unchanged.
- [ ] Repeat with `.geojson` / `.czml` — same expected result.
- [ ] Regression: upload an `.ifc` with source type `3DTILES_BIM` and DRACO selected —
      `geometryCompression: "DRACO"` should still be in the outgoing payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)