### PR TITLE
feat(editor): support KML / GeoJSON / CZML Cesium Ion assets end-to-end

### DIFF
--- a/apps/editor/app/(protected)/org/[orgId]/library/geospatial/components/UploadToIonDrawer.tsx
+++ b/apps/editor/app/(protected)/org/[orgId]/library/geospatial/components/UploadToIonDrawer.tsx
@@ -113,6 +113,19 @@ export const UploadToIonDrawer: React.FC<UploadToIonDrawerProps> = ({
         }
       } else if (uploadSourceType) {
         ionOptions.sourceType = uploadSourceType;
+      } else if (
+        sourceType === "KML" ||
+        sourceType === "GEOJSON" ||
+        sourceType === "CZML"
+      ) {
+        // Vector formats hosted as-is (no tiling), but Ion still
+        // requires `options.sourceType`. Matching the type is the
+        // pattern that works (same as IMAGERY → sourceType: "IMAGERY").
+        // Without it Ion 409s: `options.sourceType must be a valid
+        // source type`. The shared `mapSourceType` in @klorad/engine-cesium
+        // also has a matching branch, but this app-level fallback
+        // means the fix takes effect without rebuilding the package.
+        ionOptions.sourceType = sourceType;
       }
 
       // position: object shape { longitude, latitude, height }

--- a/apps/editor/app/components/AppBar/BuilderActions/hooks/useAssetManager.ts
+++ b/apps/editor/app/components/AppBar/BuilderActions/hooks/useAssetManager.ts
@@ -213,12 +213,27 @@ export const useAssetManager = ({
       const metadata = (model as any).metadata as Record<string, unknown> | undefined;
       const transformToPass = extractTransformFromMetadata(metadata);
 
+      // Resolve the Ion asset type so the scene renderer knows which
+      // loader to use. `metadata.type` is set by the upload-polling
+      // path and the sync path; `fileType` is the sync fallback. If
+      // neither is present the renderer falls back to 3D Tiles, which
+      // keeps pre-vector scenes working unchanged.
+      const metaType = (metadata as { type?: unknown } | undefined)?.type;
+      const ionType =
+        typeof metaType === "string"
+          ? metaType
+          : typeof model.fileType === "string" &&
+              model.fileType.toUpperCase() !== "CESIUM-ION-TILESET"
+            ? model.fileType
+            : undefined;
+
       // For Cesium Ion assets, add to both cesiumIonAssets and objects arrays
       addCesiumIonAsset({
         name: model.name || model.originalFilename,
         apiKey: (model as any).cesiumApiKey || "",
         assetId: (model as any).cesiumAssetId,
         enabled: true,
+        type: ionType,
         transform: transformToPass,
       });
 

--- a/apps/editor/app/components/AppBar/BuilderActions/hooks/useCesiumIon.ts
+++ b/apps/editor/app/components/AppBar/BuilderActions/hooks/useCesiumIon.ts
@@ -51,6 +51,7 @@ export const useCesiumIon = () => {
 
       // Fetch the asset to get metadata/transform if it exists
       let transform: { matrix: number[]; longitude?: number; latitude?: number; height?: number } | undefined;
+      let ionType: string | undefined;
       try {
         const fetchedAsset = await getModel(newAsset.id);
         const metadata = fetchedAsset.asset?.metadata as Record<string, unknown> | undefined;
@@ -70,6 +71,14 @@ export const useCesiumIon = () => {
             height: savedTransform.height,
           };
         }
+        // Ion type (KML / GEOJSON / CZML / 3DTILES / …) is written to
+        // `metadata.type` by the upload polling path — pass it into
+        // the scene store so `CesiumIonAssetsRenderer` picks the right
+        // loader (Cesium3DTileset vs KmlDataSource et al).
+        const metaType = metadata?.type;
+        if (typeof metaType === "string") {
+          ionType = metaType;
+        }
       } catch (err) {
         // Ignore errors fetching asset metadata
       }
@@ -80,6 +89,7 @@ export const useCesiumIon = () => {
         apiKey: data.apiKey || "",
         assetId: data.assetId, // Cesium Ion asset ID for rendering
         enabled: true,
+        type: ionType,
         transform,
       });
 

--- a/packages/core/src/state/scene-store/cesium-actions.ts
+++ b/packages/core/src/state/scene-store/cesium-actions.ts
@@ -103,18 +103,39 @@ export function createCesiumActions(set: any, get: any) {
         return;
       }
 
-      // Helper function to find tileset by assetId
+      // Helper function to find tileset by assetId. First scans
+      // `scene.primitives` (3D Tiles), then falls back to
+      // `viewer.dataSources` (KML / GeoJSON / CZML — attached by
+      // `CesiumIonAssetsRenderer`'s vector branch and tagged with
+      // `_kloradAssetId`). Without the data-source pass, fly-to on a
+      // KML would spin the 20-retry loop and log "Tileset not found
+      // after 20 retries" — the primitives collection never contains
+      // it.
       const findTilesetByAssetId = (): any => {
-        const primitives = (cesiumViewer as any).scene.primitives;
-        const expectedAssetId = parseInt((asset as any).assetId);
+        const expectedAssetIdNum = parseInt((asset as any).assetId);
+        const expectedAssetIdStr = String((asset as any).assetId);
 
-        for (let i = 0; i < primitives.length; i++) {
-          const primitive = primitives.get(i);
-          const primitiveAssetId = (primitive as any)?.assetId;
-          if (primitive && primitiveAssetId === expectedAssetId) {
-            return primitive;
+        const primitives = (cesiumViewer as any).scene?.primitives;
+        if (primitives) {
+          for (let i = 0; i < primitives.length; i++) {
+            const primitive = primitives.get(i);
+            const primitiveAssetId = (primitive as any)?.assetId;
+            if (primitive && primitiveAssetId === expectedAssetIdNum) {
+              return primitive;
+            }
           }
         }
+
+        const dataSources = (cesiumViewer as any).dataSources;
+        if (dataSources) {
+          for (let i = 0; i < dataSources.length; i++) {
+            const ds = dataSources.get(i);
+            if (ds && (ds as any)._kloradAssetId === expectedAssetIdStr) {
+              return ds;
+            }
+          }
+        }
+
         return null;
       };
 

--- a/packages/core/src/state/scene-store/types.ts
+++ b/packages/core/src/state/scene-store/types.ts
@@ -8,6 +8,14 @@ export interface CesiumIonAsset {
   apiKey: string;
   assetId: string;
   enabled: boolean;
+  /** Underlying Cesium Ion asset type — "3DTILES" | "KML" | "GEOJSON" |
+   *  "CZML" | "IMAGERY" | "TERRAIN" | "GLTF". Determines which loader
+   *  the scene renderer picks: 3D Tiles → `Cesium3DTileset.fromIonAssetId`;
+   *  vector formats → `KmlDataSource.load` / `GeoJsonDataSource.load` /
+   *  `CzmlDataSource.load` on the viewer's `dataSources` collection.
+   *  Optional so pre-existing scenes (populated before this field
+   *  existed) still hydrate — the renderer defaults them to 3DTILES. */
+  type?: string;
   transform?: {
     matrix: number[]; // 16-element array representing Matrix4
     longitude?: number;

--- a/packages/engine-cesium/src/components/CesiumMinimalViewer/components/VectorDataSourceRenderer.tsx
+++ b/packages/engine-cesium/src/components/CesiumMinimalViewer/components/VectorDataSourceRenderer.tsx
@@ -1,0 +1,40 @@
+import { useVectorDataSource } from "../hooks/useVectorDataSource";
+import type { CesiumModule } from "../types";
+
+interface VectorDataSourceRendererProps {
+  viewer: any | null;
+  Cesium: CesiumModule | null;
+  cesiumAssetId: string;
+  ionType: "KML" | "GEOJSON" | "CZML";
+  /** Callback fires once the data source is loaded + added to the
+   *  viewer. Named `onReady` to sit alongside `TilesetRenderer`'s
+   *  `onTilesetReady` — screenshot/capture flows treat "something is
+   *  loaded" as a proxy for "safe to capture". */
+  onReady?: (dataSource: any) => void;
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Renders a KML / GeoJSON / CZML Cesium Ion asset as a data source,
+ * paralleling `TilesetRenderer`'s 3D-Tiles code path. Vector features
+ * are georeferenced by nature, so we don't need the transform,
+ * globe-visibility, or terrain toggling that TilesetRenderer does.
+ */
+export function VectorDataSourceRenderer({
+  viewer,
+  Cesium,
+  cesiumAssetId,
+  ionType,
+  onReady,
+  onError,
+}: VectorDataSourceRendererProps) {
+  useVectorDataSource({
+    viewer,
+    Cesium,
+    cesiumAssetId,
+    ionType,
+    onReady,
+    onError,
+  });
+  return null;
+}

--- a/packages/engine-cesium/src/components/CesiumMinimalViewer/hooks/useVectorDataSource.ts
+++ b/packages/engine-cesium/src/components/CesiumMinimalViewer/hooks/useVectorDataSource.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  findExistingVectorDataSource,
+  loadVectorIonDataSource,
+} from "../../../utils/tileset-operations";
+import type { CesiumModule } from "../types";
+
+interface UseVectorDataSourceOptions {
+  viewer: any | null;
+  Cesium: CesiumModule | null;
+  cesiumAssetId: string;
+  ionType: "KML" | "GEOJSON" | "CZML";
+  onReady?: (dataSource: any) => void;
+  onError?: (error: Error) => void;
+}
+
+interface UseVectorDataSourceReturn {
+  dataSource: any | null;
+  isReady: boolean;
+  error: Error | null;
+}
+
+/**
+ * Load a KML / GeoJSON / CZML Ion asset as a Cesium `DataSource`,
+ * attach it to `viewer.dataSources`, and clean up on unmount.
+ *
+ * Deliberately minimal — vector formats are georeferenced by nature,
+ * so we skip the transform/atmosphere/globe-visibility gymnastics
+ * that `useTileset` does. Frame the camera on the data source once
+ * it's loaded and let it be.
+ */
+export function useVectorDataSource({
+  viewer,
+  Cesium,
+  cesiumAssetId,
+  ionType,
+  onReady,
+  onError,
+}: UseVectorDataSourceOptions): UseVectorDataSourceReturn {
+  const dataSourceRef = useRef<any>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const isLoadingRef = useRef(false);
+
+  // Keep the latest callback references in refs so the load effect
+  // doesn't re-run every time the parent re-renders with fresh inline
+  // functions. Following the pattern `useTileset` established — its
+  // effect intentionally excludes `onTilesetReady`/`onError` from
+  // deps for the same reason. Without this, every parent render
+  // teared down + reloaded the data source, which manifested as the
+  // KML preview flashing on/off during any state change upstream.
+  const onReadyRef = useRef(onReady);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onReadyRef.current = onReady;
+    onErrorRef.current = onError;
+  }, [onReady, onError]);
+
+  useEffect(() => {
+    if (!viewer || !Cesium || !cesiumAssetId) return;
+    if (isLoadingRef.current) return;
+
+    // Reuse an existing data source for this asset id if the effect
+    // fires twice under React strict mode.
+    const existing = findExistingVectorDataSource(viewer, cesiumAssetId);
+    if (existing) {
+      dataSourceRef.current = existing;
+      setIsReady(true);
+      onReadyRef.current?.(existing);
+      return;
+    }
+
+    isLoadingRef.current = true;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const dataSource = await loadVectorIonDataSource(
+          Cesium,
+          cesiumAssetId,
+          ionType,
+          viewer
+        );
+        if (cancelled) return;
+
+        dataSource._kloradAssetId = cesiumAssetId;
+
+        // Viewer could have been torn down while we awaited Ion.
+        if (
+          !viewer ||
+          !viewer.dataSources ||
+          (viewer.isDestroyed && viewer.isDestroyed())
+        ) {
+          return;
+        }
+        await viewer.dataSources.add(dataSource);
+
+        // Frame the camera on the loaded features. `flyTo` handles the
+        // bounding-sphere maths for us. Swallow errors — Cesium throws
+        // if the viewer is destroyed mid-flight.
+        try {
+          await viewer.flyTo(dataSource, { duration: 0 });
+        } catch {
+          /* ignore camera-during-teardown errors */
+        }
+
+        dataSourceRef.current = dataSource;
+        setIsReady(true);
+        onReadyRef.current?.(dataSource);
+      } catch (err) {
+        if (cancelled) return;
+        const errorObj =
+          err instanceof Error ? err : new Error(String(err));
+        setError(errorObj);
+        setIsReady(false);
+        onErrorRef.current?.(errorObj);
+      } finally {
+        isLoadingRef.current = false;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      isLoadingRef.current = false;
+
+      const currentDs = dataSourceRef.current;
+      if (currentDs && viewer && !(viewer.isDestroyed && viewer.isDestroyed())) {
+        try {
+          viewer.dataSources?.remove(currentDs, true);
+        } catch {
+          /* teardown races — nothing to do */
+        }
+      }
+      dataSourceRef.current = null;
+    };
+    // Callbacks intentionally excluded — see the ref block above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewer, Cesium, cesiumAssetId, ionType]);
+
+  return {
+    dataSource: dataSourceRef.current,
+    isReady,
+    error,
+  };
+}

--- a/packages/engine-cesium/src/components/CesiumMinimalViewer/index.tsx
+++ b/packages/engine-cesium/src/components/CesiumMinimalViewer/index.tsx
@@ -7,8 +7,13 @@ import { useTerrain } from "./hooks/useTerrain";
 import { TilesetRenderer } from "./components/TilesetRenderer";
 import { ImageryRenderer } from "./components/ImageryRenderer";
 import { TerrainRenderer } from "./components/TerrainRenderer";
+import { VectorDataSourceRenderer } from "./components/VectorDataSourceRenderer";
 import { LocationClickHandler } from "./components/LocationClickHandler";
 import { CesiumLoadingScreen } from "../CesiumLoadingScreen";
+import {
+  isVectorIonType,
+  resolveIonType,
+} from "../../utils/tileset-operations";
 import type { CesiumMinimalViewerProps } from "./types";
 
 /**
@@ -75,10 +80,19 @@ export function CesiumMinimalViewer({
     return <CesiumLoadingScreen />;
   }
 
+  // Resolve the actual Ion type from the DB `fileType` + `metadata`.
+  // Direct-upload rows carry `fileType = "cesium-ion-tileset"` so we
+  // need to consult `metadata.type` (populated by the upload polling
+  // path) to distinguish 3D Tiles from KML/GeoJSON/CZML.
+  const ionType = resolveIonType(assetType, metadata);
+  const isVector = isVectorIonType(ionType);
+  const isTerrainAsset = ionType === "TERRAIN" || assetType === "TERRAIN";
+  const isImageryAsset = ionType === "IMAGERY" || assetType === "IMAGERY";
+
   return (
     <>
       {/* Render terrain for TERRAIN type assets */}
-      {cesiumAssetId && assetType === "TERRAIN" && (
+      {cesiumAssetId && isTerrainAsset && (
         <TerrainRenderer
           viewer={viewer}
           Cesium={Cesium}
@@ -92,7 +106,7 @@ export function CesiumMinimalViewer({
       )}
 
       {/* Render imagery for IMAGERY type assets */}
-      {cesiumAssetId && assetType === "IMAGERY" && (
+      {cesiumAssetId && isImageryAsset && (
         <ImageryRenderer
           viewer={viewer}
           Cesium={Cesium}
@@ -104,8 +118,24 @@ export function CesiumMinimalViewer({
         />
       )}
 
-      {/* Render tileset for 3D Tiles and other types (excluding TERRAIN and IMAGERY) */}
-      {cesiumAssetId && assetType !== "IMAGERY" && assetType !== "TERRAIN" && (
+      {/* Render KML / GeoJSON / CZML as a Cesium DataSource — Ion
+          returns raw XML/JSON for these, not tileset.json, so the
+          3D-Tiles loader would `JSON.parse` an XML document and throw
+          `Unexpected token '<', "<?xml vers"…`. */}
+      {cesiumAssetId && isVector && (
+        <VectorDataSourceRenderer
+          viewer={viewer}
+          Cesium={Cesium}
+          cesiumAssetId={cesiumAssetId}
+          ionType={ionType as "KML" | "GEOJSON" | "CZML"}
+          onReady={handleTilesetReady}
+          onError={onError}
+        />
+      )}
+
+      {/* Render tileset for everything else (3D Tiles, glTF, or
+          rows where the type isn't resolvable — historic default). */}
+      {cesiumAssetId && !isTerrainAsset && !isImageryAsset && !isVector && (
         <TilesetRenderer
           viewer={viewer}
           Cesium={Cesium}

--- a/packages/engine-cesium/src/helpers/CesiumIonAssetsRenderer.tsx
+++ b/packages/engine-cesium/src/helpers/CesiumIonAssetsRenderer.tsx
@@ -3,15 +3,23 @@
 import React, { useEffect, useRef } from "react";
 import { useSceneStore } from "@klorad/core";
 import {
+  isVectorIonType,
   loadTilesetWithTransform,
+  loadVectorIonDataSource,
   reapplyTransformAfterReady,
+  resolveIonType,
   waitForTilesetReady,
   positionCameraForTileset,
 } from "../utils/tileset-operations";
 
 interface TilesetWrapper {
   id: string;
-  tileset: any;
+  /** Set for 3D Tiles rows. */
+  tileset?: any;
+  /** Set for KML / GeoJSON / CZML rows. Kept in a separate field so
+   *  fly-to and transform code doesn't accidentally treat a data
+   *  source as a tileset. */
+  dataSource?: any;
   dispose: () => void;
 }
 
@@ -75,6 +83,46 @@ const CesiumIonAssetsRenderer: React.FC<CesiumIonAssetsRendererProps> = ({
     try {
       const originalToken = cesiumInstance.Ion.defaultAccessToken;
       cesiumInstance.Ion.defaultAccessToken = asset.apiKey;
+
+      // Branch: vector-format Ion assets (KML / GeoJSON / CZML) go
+      // through Cesium DataSources, not `Cesium3DTileset.fromIonAssetId`.
+      // Without this, the tileset loader tries to `JSON.parse` raw
+      // KML/XML and either throws or retries forever ("Tileset for
+      // asset X not found after 20 retries").
+      const ionType = resolveIonType(asset.type);
+      if (isVectorIonType(ionType)) {
+        const dataSource = await loadVectorIonDataSource(
+          cesiumInstance,
+          asset.assetId,
+          ionType as "KML" | "GEOJSON" | "CZML",
+          cesiumViewer
+        );
+        dataSource._kloradAssetId = asset.assetId;
+        await cesiumViewer.dataSources.add(dataSource);
+
+        const wrapper: TilesetWrapper = {
+          id: asset.id,
+          dataSource,
+          dispose: () => {
+            try {
+              cesiumViewer?.dataSources?.remove(dataSource, true);
+            } catch {
+              /* teardown race — nothing to do */
+            }
+          },
+        };
+        tilesetRefs.current.set(asset.id, wrapper);
+
+        if (autoFlyToTileset) {
+          try {
+            await cesiumViewer.flyTo(dataSource, { duration: 2.0 });
+          } catch {
+            /* ignore fly-to-during-teardown errors */
+          }
+        }
+        cesiumInstance.Ion.defaultAccessToken = originalToken;
+        return;
+      }
 
       // Load tileset with transform (uses shared utility function)
       // This applies transform before adding to scene

--- a/packages/engine-cesium/src/hooks/useCesiumIonUpload.ts
+++ b/packages/engine-cesium/src/hooks/useCesiumIonUpload.ts
@@ -215,6 +215,17 @@ export const useCesiumIonUpload = () => {
     } else if (sourceType === "PHOTOS_3D_RECONSTRUCTION") {
       ionType = "3DTILES";
       uploadSourceType = "RASTER_IMAGERY";
+    } else if (
+      sourceType === "KML" ||
+      sourceType === "GEOJSON" ||
+      sourceType === "CZML"
+    ) {
+      // Vector formats hosted as-is (no tiling). Ion still requires
+      // `options.sourceType` — matching the type is the pattern that
+      // works (same as IMAGERY → sourceType: "IMAGERY"). Without it
+      // Ion 409s with `options.sourceType must be a valid source type`.
+      ionType = sourceType;
+      uploadSourceType = sourceType;
     }
 
     return { ionType, uploadSourceType };

--- a/packages/engine-cesium/src/utils/tileset-operations.ts
+++ b/packages/engine-cesium/src/utils/tileset-operations.ts
@@ -275,7 +275,7 @@ export async function loadTilesetWithTransform(
   cesiumAssetId: string,
   metadata?: Record<string, unknown> | null,
   transform?: TilesetTransformData,
-  options?: {
+  _options?: {
     viewer?: any;
     log?: boolean;
   }
@@ -537,5 +537,175 @@ export function findExistingTileset(
     }
   }
 
+  return null;
+}
+
+/**
+ * Cesium Ion asset types this viewer understands. Every user-facing
+ * upload eventually maps to one of these strings on the DB Asset row.
+ */
+export type IonAssetType =
+  | "3DTILES"
+  | "GLTF"
+  | "KML"
+  | "GEOJSON"
+  | "CZML"
+  | "IMAGERY"
+  | "TERRAIN";
+
+const KNOWN_ION_TYPES: readonly IonAssetType[] = [
+  "3DTILES",
+  "GLTF",
+  "KML",
+  "GEOJSON",
+  "CZML",
+  "IMAGERY",
+  "TERRAIN",
+];
+
+/**
+ * Resolve the underlying Cesium Ion asset type from the DB Asset's
+ * `fileType` + `metadata`. Preference order:
+ *
+ *   1. `metadata.type` — populated by both the direct-upload polling
+ *      path (`useCesiumIonUpload.ts`) and the integration sync path
+ *      (`apps/editor/lib/cesium/sync.ts`).
+ *   2. `assetType` (i.e. `fileType`) if it already names a known Ion
+ *      type — sync-imported rows store the Ion type directly here.
+ *   3. `undefined` — caller should default to `"3DTILES"` (the historic
+ *      behaviour before vector types were wired up).
+ *
+ * Direct-upload rows carry `fileType = "cesium-ion-tileset"`, which is
+ * intentionally not a real Ion type — it's the marker that the row is
+ * an Ion asset at all. In that case only path (1) can succeed.
+ */
+export function resolveIonType(
+  assetType?: string,
+  metadata?: Record<string, unknown> | null
+): IonAssetType | undefined {
+  const metaType =
+    metadata && typeof metadata === "object"
+      ? (metadata as { type?: unknown }).type
+      : undefined;
+  if (typeof metaType === "string") {
+    const upper = metaType.toUpperCase();
+    if ((KNOWN_ION_TYPES as readonly string[]).includes(upper)) {
+      return upper as IonAssetType;
+    }
+  }
+  if (assetType) {
+    const upper = assetType.toUpperCase();
+    if ((KNOWN_ION_TYPES as readonly string[]).includes(upper)) {
+      return upper as IonAssetType;
+    }
+  }
+  return undefined;
+}
+
+/** KML / GeoJSON / CZML — loaded via `*DataSource.load(IonResource)`
+ *  rather than `Cesium3DTileset.fromIonAssetId`. */
+export function isVectorIonType(type: IonAssetType | undefined): boolean {
+  return type === "KML" || type === "GEOJSON" || type === "CZML";
+}
+
+/**
+ * Load a vector Ion asset (KML / GeoJSON / CZML) as a Cesium
+ * `DataSource`. Attach to `viewer.dataSources` — NOT
+ * `scene.primitives` — and dispose via `viewer.dataSources.remove()`.
+ *
+ * `KmlDataSource.load` needs `camera` + `canvas` for network-link
+ * screen-space handling; we pass the viewer's when we have one, and
+ * fall back to bare `load(resource)` otherwise (feature will still
+ * render, just without live network-link updates).
+ */
+export async function loadVectorIonDataSource(
+  Cesium: any,
+  cesiumAssetId: string,
+  ionType: "KML" | "GEOJSON" | "CZML",
+  viewer?: any
+): Promise<any> {
+  const idNum = Number(cesiumAssetId);
+  if (!Number.isFinite(idNum)) {
+    throw new Error(`Invalid Cesium Ion asset id: ${cesiumAssetId}`);
+  }
+  const resource = await Cesium.IonResource.fromAssetId(idNum);
+  switch (ionType) {
+    case "KML": {
+      // `clampToGround: true` drapes flat KML features (no altitude
+      // specified per-feature, or `altitudeMode = clampToGround`) onto
+      // the terrain surface. Without it, features render at height 0
+      // and get eaten by any non-trivial terrain — which is exactly
+      // what happens for typical POI / route KMLs authored in Google
+      // Earth. Features with `absolute` altitude in the source KML
+      // keep their real height.
+      //
+      // `camera` + `canvas` are needed for KML network links to
+      // resolve screen-space queries; passing them when we have a
+      // viewer is a no-op for static KMLs.
+      const kmlOptions: Record<string, unknown> = { clampToGround: true };
+      if (viewer?.camera) kmlOptions.camera = viewer.camera;
+      if (viewer?.canvas) kmlOptions.canvas = viewer.canvas;
+      const kmlDataSource = await Cesium.KmlDataSource.load(
+        resource,
+        kmlOptions
+      );
+      // Cesium ignores `clampToGround` for KML LineStrings unless the
+      // source KML sets `<tessellate>1</tessellate>` on each line —
+      // its console warning is "Ignoring clampToGround for KML lines
+      // without the tessellate flag". Setting `polyline.clampToGround`
+      // per-entity overrides that at the graphics level. Only touch
+      // polylines; leave polygons/points alone since load-time
+      // `clampToGround` already handles those correctly.
+      //
+      // Gotcha: KML's parser defaults line `arcType` to `NONE` (a
+      // straight 3D segment between endpoints) when `<tessellate>` is
+      // absent, but `GroundPolylineGeometry` — the geometry
+      // `clampToGround` switches Cesium into — REJECTS `ArcType.NONE`
+      // with `DeveloperError: Valid options for arcType are
+      // ArcType.GEODESIC and ArcType.RHUMB`. So we have to flip both
+      // properties together, otherwise the render loop throws every
+      // frame. Geodesic is the natural choice for a line following
+      // the terrain surface.
+      try {
+        for (const entity of kmlDataSource.entities.values) {
+          if (entity?.polyline) {
+            entity.polyline.clampToGround = true;
+            entity.polyline.arcType = Cesium.ArcType.GEODESIC;
+          }
+        }
+      } catch {
+        /* entities collection unavailable — nothing to force */
+      }
+      return kmlDataSource;
+    }
+    case "GEOJSON":
+      // Same reasoning as KML — GeoJSON features are 2D by default
+      // and disappear under any real terrain otherwise. GeoJSON's
+      // LineString handling does NOT have the KML tessellate quirk,
+      // so no post-load fix-up needed here.
+      return await Cesium.GeoJsonDataSource.load(resource, {
+        clampToGround: true,
+      });
+    case "CZML":
+      // CZML packets specify altitude modes per-entity in the source
+      // document, so there's no load-time clamp option — authors
+      // control it via `heightReference`.
+      return await Cesium.CzmlDataSource.load(resource);
+  }
+}
+
+/** Find a previously-loaded vector data source keyed by asset id. */
+export function findExistingVectorDataSource(
+  viewer: any,
+  cesiumAssetId: string
+): any | null {
+  const collection = viewer?.dataSources;
+  if (!collection) return null;
+  for (let i = 0; i < collection.length; i++) {
+    const ds = collection.get(i);
+    if (ds && ds._kloradAssetId === cesiumAssetId) {
+      return ds;
+    }
+  }
   return null;
 }


### PR DESCRIPTION
## Summary
Vector-format Cesium Ion assets (KML / GeoJSON / CZML) never worked in the editor.
Every stage of the pipeline assumed 3D Tiles. This PR wires the whole path — upload,
preview, scene render, fly-to, and terrain draping — so a customer can now upload
a KML, preview it, add it to a project, and fly to it, all without hitting a
JSON-parse-XML error.

## What was broken

- **Upload → Ion 409** (`InvalidArgument: 'options.sourceType' must be a valid
  source type`). `mapSourceType` had no KML/GEOJSON/CZML branch, so `sourceType`
  was never sent. Compounded by `geometryCompression: DRACO` (BIM-only) being
  forwarded on every upload, which tricked Ion into demanding a BIM `sourceType`
  even for vector formats.
- **Preview / render** — both `useTileset` and `CesiumIonAssetsRenderer` called
  `Cesium3DTileset.fromIonAssetId(...)` unconditionally. Ion returns a raw `.kml`
  URL for KML assets; the 3D-Tiles loader `JSON.parse`s the XML and throws
  `Unexpected token '<', "<?xml vers"…`. The scene renderer's retry masking
  showed up as `Tileset for asset X not found after 20 retries`.
- **Fly-to** silently no-op'd on KML rows because `flyToCesiumIonAsset` only
  scanned `scene.primitives`, and vector data sources live on `viewer.dataSources`.
- **Terrain** — KML polylines disappeared under terrain. Load-time
  `clampToGround` isn't enough: KML's parser needs `<tessellate>1</tessellate>`,
  and even then `GroundPolylineGeometry` rejects the default `ArcType.NONE`.

## What changed

- `mapSourceType` (both hook + app-level payload builder) — add KML / GEOJSON /
  CZML branches; gate `geometryCompression` on `BIM_CAD`.
- Shared vector loader in `tileset-operations.ts`: `resolveIonType`,
  `isVectorIonType`, `loadVectorIonDataSource`. KML loader forces per-entity
  `polyline.clampToGround = true` + `polyline.arcType = ArcType.GEODESIC`.
- New `useVectorDataSource` hook + `VectorDataSourceRenderer` component for the
  preview dialog; `CesiumMinimalViewer` dispatches KML/GEOJSON/CZML to it.
- `@klorad/core`: `CesiumIonAsset.type` field carries the Ion type through the
  scene store. Populated by `useAssetManager` + `useCesiumIon` from
  `metadata.type` / `fileType`.
- `CesiumIonAssetsRenderer` branches on `type`. Vector → data source path.
  Tileset path otherwise. Unknown types default to 3D Tiles → pre-existing
  scenes hydrate unchanged.
- `flyToCesiumIonAsset` scans `viewer.dataSources` alongside `scene.primitives`.

## Known limitation
Scenes persisted before this PR won't have `CesiumIonAsset.type` set. Removing
and re-adding the vector asset from the library repopulates it. A hydration-time
backfill (read `metadata.type` from the DB Asset row on scene load) is a
natural follow-up if this bites more than once.

## Test plan
- [x] Upload a `.kml` via the geospatial library. Ion asset creation returns
      200; tiling completes.
- [x] Preview the KML from the library. Scene loads; take-photo works.
- [x] Toggle terrain in the preview. Polylines drape onto the surface instead
      of disappearing.
- [x] Add the KML to a project scene. Renders in the builder.
- [x] Click fly-to on the asset row. Camera flies to the KML's bounding sphere.
- [ ] Regression: upload an `.ifc` with source type `3DTILES_BIM` + DRACO
      selected; `geometryCompression: "DRACO"` is still in the outgoing
      payload; asset renders as a 3D Tileset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)