### PR TITLE
feat(editor): expose clamp-to-ground toggle for KML/GeoJSON in the properties panel

### DIFF
--- a/apps/editor/app/components/Builder/properties/CesiumIonAssetPropertiesSection.tsx
+++ b/apps/editor/app/components/Builder/properties/CesiumIonAssetPropertiesSection.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import { Box, FormControlLabel, Switch, Typography } from "@mui/material";
+import { SettingContainer, SettingLabel } from "@klorad/ui";
+import { useSceneStore } from "@klorad/core";
+
+interface CesiumIonAssetPropertiesSectionProps {
+  /** Cesium Ion asset id (the numeric string stored on the model /
+   *  scene-store CesiumIonAsset row). Used to find the matching
+   *  `CesiumIonAsset` in the store so we can flip fields on it. */
+  cesiumAssetId?: string;
+  /** Fallback matcher used when the selected model doesn't carry
+   *  `cesiumAssetId` (older rows persisted before that field was
+   *  populated). Same fallback the parent's fly-to handler uses. */
+  selectedObjectName?: string;
+}
+
+const VECTOR_TYPES = new Set(["KML", "GEOJSON", "CZML"]);
+
+/** Poll `viewer.dataSources` for a change token so the panel
+ *  re-renders when a vector data source is added/removed. Cesium's
+ *  collections aren't React-reactive, so we listen to their events
+ *  and bump a counter. */
+function useDataSourcesVersion(cesiumViewer: any): number {
+  const [version, setVersion] = React.useState(0);
+  React.useEffect(() => {
+    const dataSources = cesiumViewer?.dataSources;
+    if (!dataSources) return;
+    const bump = () => setVersion((v) => v + 1);
+    const removeAdded = dataSources.dataSourceAdded?.addEventListener?.(bump);
+    const removeRemoved =
+      dataSources.dataSourceRemoved?.addEventListener?.(bump);
+    // Kick once in case a data source was already present when we
+    // mounted — the events won't fire retroactively.
+    bump();
+    return () => {
+      try {
+        removeAdded?.();
+        removeRemoved?.();
+      } catch {
+        /* teardown race */
+      }
+    };
+  }, [cesiumViewer]);
+  return version;
+}
+
+/**
+ * Right-panel section for properties that only apply to Cesium Ion
+ * assets. Today: the "Clamp to ground" toggle for KML / GeoJSON.
+ *
+ * Detects the vector type at runtime from `viewer.dataSources` — we
+ * tag each loaded data source with `_kloradIonType`, so the toggle
+ * surfaces for any KML/GeoJSON currently rendered, even when the
+ * persisted scene doc predates the `CesiumIonAsset.type` field.
+ */
+export const CesiumIonAssetPropertiesSection: React.FC<
+  CesiumIonAssetPropertiesSectionProps
+> = ({ cesiumAssetId, selectedObjectName }) => {
+  const cesiumIonAssets = useSceneStore((s) => s.cesiumIonAssets);
+  const updateCesiumIonAsset = useSceneStore((s) => s.updateCesiumIonAsset);
+  const cesiumViewer = useSceneStore((s) => s.cesiumViewer);
+  const dataSourcesVersion = useDataSourcesVersion(cesiumViewer);
+
+  const asset = React.useMemo(() => {
+    if (cesiumAssetId) {
+      const byId = cesiumIonAssets.find(
+        (a) => String(a.assetId) === String(cesiumAssetId)
+      );
+      if (byId) return byId;
+    }
+    if (selectedObjectName) {
+      return cesiumIonAssets.find((a) => a.name === selectedObjectName);
+    }
+    return undefined;
+  }, [cesiumIonAssets, cesiumAssetId, selectedObjectName]);
+
+  // Once we know the asset, use ITS assetId for the runtime scan —
+  // even when the parent didn't pass `cesiumAssetId`, we can still
+  // find the matching data source via the asset row's own id.
+  const effectiveAssetId = asset?.assetId ?? cesiumAssetId;
+
+  // Runtime Ion-type resolution — walk `viewer.dataSources` for a
+  // match on our tagged asset id, then infer the type from either
+  // the tag we stamped at load time (fresh loads) or the data
+  // source's constructor name (works even for data sources loaded
+  // by a previous build that didn't stamp the tag). Falls back to
+  // `asset.type` on the persisted store row if no data source is
+  // present yet.
+  const runtimeIonType = React.useMemo<string | undefined>(() => {
+    if (!effectiveAssetId || !cesiumViewer?.dataSources) return undefined;
+    void dataSourcesVersion; // recompute when collection changes
+    const collection = cesiumViewer.dataSources;
+    for (let i = 0; i < collection.length; i++) {
+      const ds = collection.get(i);
+      if (String(ds?._kloradAssetId) !== String(effectiveAssetId)) continue;
+
+      const tagged = ds?._kloradIonType;
+      if (typeof tagged === "string") return tagged.toUpperCase();
+
+      const ctor = ds?.constructor?.name;
+      if (typeof ctor === "string") {
+        if (ctor.startsWith("Kml")) return "KML";
+        if (ctor.startsWith("GeoJson")) return "GEOJSON";
+        if (ctor.startsWith("Czml")) return "CZML";
+      }
+      // Data source is here but unrecognised — safest to treat it as
+      // KML so the operator still gets the toggle; KML is the common
+      // case that motivated this fix.
+      return "KML";
+    }
+    return undefined;
+  }, [cesiumViewer, effectiveAssetId, dataSourcesVersion]);
+
+  const ionType =
+    runtimeIonType || (asset?.type ? asset.type.toUpperCase() : undefined);
+
+  if (!asset || !ionType) return null;
+  if (!VECTOR_TYPES.has(ionType)) return null;
+
+  // CZML sets altitude modes per-entity in the source packet, so
+  // the load-time clamp option is a no-op. Rendering the switch would
+  // just mislead the operator.
+  if (ionType === "CZML") return null;
+
+  const clampToGround = asset.clampToGround !== false;
+
+  const handleToggle = (next: boolean) => {
+    updateCesiumIonAsset(asset.id, { clampToGround: next });
+  };
+
+  return (
+    <SettingContainer>
+      <SettingLabel>{ionType} Options</SettingLabel>
+      <Box
+        sx={(theme) => ({
+          borderRadius: "8px",
+          border: `1px solid ${theme.palette.divider}`,
+          overflow: "hidden",
+        })}
+      >
+        <FormControlLabel
+          control={
+            <Switch
+              id={`clamp-to-ground-${asset.id}`}
+              name={`clamp-to-ground-${asset.id}`}
+              checked={clampToGround}
+              onChange={(e) => handleToggle(e.target.checked)}
+              sx={(theme) => ({
+                "& .MuiSwitch-switchBase.Mui-checked": {
+                  color: theme.palette.primary.main,
+                },
+                "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                  backgroundColor: theme.palette.primary.main,
+                },
+              })}
+            />
+          }
+          label="Clamp to ground"
+          sx={(theme) => ({
+            margin: 0,
+            padding: "8.5px 14px",
+            width: "100%",
+            display: "flex",
+            justifyContent: "space-between",
+            "& .MuiFormControlLabel-label": {
+              fontSize: "0.75rem",
+              fontWeight: 400,
+              color: theme.palette.text.secondary,
+              flex: 1,
+            },
+          })}
+          labelPlacement="start"
+        />
+      </Box>
+      <Typography
+        variant="caption"
+        sx={(theme) => ({
+          display: "block",
+          mt: 1,
+          px: 0.5,
+          color: theme.palette.text.disabled,
+          fontSize: "0.7rem",
+          lineHeight: 1.4,
+        })}
+      >
+        Drapes features onto the terrain surface. Turn off if the {ionType}{" "}
+        already has real altitudes (e.g. flight paths) and you want them
+        preserved.
+      </Typography>
+    </SettingContainer>
+  );
+};
+
+export default CesiumIonAssetPropertiesSection;

--- a/apps/editor/app/components/Builder/properties/PropertiesPanel/views/ObjectPropertiesView.tsx
+++ b/apps/editor/app/components/Builder/properties/PropertiesPanel/views/ObjectPropertiesView.tsx
@@ -12,6 +12,7 @@ import { flyToThreeObject } from "@klorad/engine-three/utils";
 const logger = createLogger("ObjectPropertiesView");
 import { ScrollContainer } from "../components/ScrollContainer";
 import ObjectActionsSection from "../../ObjectActionsSection";
+import { CesiumIonAssetPropertiesSection } from "../../CesiumIonAssetPropertiesSection";
 import ModelInformationSection from "../../ModelInformationSection";
 import ObservationModelSection from "../../ObservationModelSection";
 import IoTDevicePropertiesPanel from "../../IoTDevicePropertiesPanel";
@@ -236,6 +237,21 @@ export const ObjectPropertiesView: React.FC<ObjectPropertiesViewProps> = memo(
           onInteractableChange={handleInteractableChange}
           engine={engine}
         />
+
+        {/* Vector-Ion-only options (Clamp to ground for KML/GeoJSON).
+            The component early-returns null for non-vector rows so it
+            stays invisible when the selected object is a 3D tileset.
+            Pass both `cesiumAssetId` and the object name so the
+            component can fall back to name-matching for older rows
+            that were persisted without `cesiumAssetId`. */}
+        {isCesiumIonAsset && (
+          <CesiumIonAssetPropertiesSection
+            cesiumAssetId={
+              (selectedObject as { cesiumAssetId?: string })?.cesiumAssetId
+            }
+            selectedObjectName={selectedObject?.name}
+          />
+        )}
 
         {repositioning && !isCesiumIonAsset && onCancelRepositioning && (
           <Alert

--- a/packages/core/src/state/scene-store/types.ts
+++ b/packages/core/src/state/scene-store/types.ts
@@ -16,6 +16,15 @@ export interface CesiumIonAsset {
    *  Optional so pre-existing scenes (populated before this field
    *  existed) still hydrate — the renderer defaults them to 3DTILES. */
   type?: string;
+  /** Whether to drape KML / GeoJSON features onto the terrain surface
+   *  (Cesium's `clampToGround`). Only meaningful for vector types.
+   *  Default `true` — the common case is a flat KML/GeoJSON without
+   *  meaningful altitudes, which disappears under any real terrain
+   *  otherwise. Flip to `false` for KMLs with genuine 3D geometry
+   *  (flight paths, absolute-altitude features) where the source
+   *  altitudes should be respected. Editable from the object
+   *  properties panel in the builder. */
+  clampToGround?: boolean;
   transform?: {
     matrix: number[]; // 16-element array representing Matrix4
     longitude?: number;

--- a/packages/engine-cesium/src/components/CesiumMinimalViewer/hooks/useVectorDataSource.ts
+++ b/packages/engine-cesium/src/components/CesiumMinimalViewer/hooks/useVectorDataSource.ts
@@ -84,6 +84,10 @@ export function useVectorDataSource({
         if (cancelled) return;
 
         dataSource._kloradAssetId = cesiumAssetId;
+        // Tag the Ion type at runtime so panels can detect it
+        // without depending on the (optional, possibly-un-hydrated)
+        // `asset.type` field on the scene store row.
+        dataSource._kloradIonType = ionType;
 
         // Viewer could have been torn down while we awaited Ion.
         if (

--- a/packages/engine-cesium/src/helpers/CesiumIonAssetsRenderer.tsx
+++ b/packages/engine-cesium/src/helpers/CesiumIonAssetsRenderer.tsx
@@ -37,6 +37,13 @@ const CesiumIonAssetsRenderer: React.FC<CesiumIonAssetsRendererProps> = ({
   autoFlyToTileset = false,
 }) => {
   const tilesetRefs = useRef<Map<string, TilesetWrapper>>(new Map());
+  // Bumped every time the load effect re-runs. `initializeAsset`
+  // captures the run token at start and discards its loaded data
+  // source if the token has moved on — prevents a stale in-flight
+  // load from attaching to the viewer after a newer effect run has
+  // already swept and started a fresh load. Without this, toggling
+  // clamp-to-ground fast enough leaves a ghost of the previous render.
+  const runTokenRef = useRef(0);
   const cesiumIonAssets = useSceneStore((state) => state.cesiumIonAssets);
   const { cesiumViewer, cesiumInstance } = useSceneStore();
   const removeCesiumIonAsset = useSceneStore((state) => state.removeCesiumIonAsset);
@@ -48,7 +55,12 @@ const CesiumIonAssetsRenderer: React.FC<CesiumIonAssetsRendererProps> = ({
         const transformKey = asset.transform?.matrix
           ? asset.transform.matrix.slice(12, 15).join(',') // Use translation part as key
           : 'no-transform';
-        return `${asset.id}-${asset.enabled}-${transformKey}`;
+        // `clampToGround` participates so toggling it in the
+        // properties panel tears down + reloads the data source with
+        // the new option (Cesium doesn't reactively update the
+        // load-time flag once the source is added to the viewer).
+        const clampKey = asset.clampToGround === false ? 'no-clamp' : 'clamp';
+        return `${asset.id}-${asset.enabled}-${transformKey}-${clampKey}`;
       })
       .join('|');
   }, [cesiumIonAssets]);
@@ -67,19 +79,46 @@ const CesiumIonAssetsRenderer: React.FC<CesiumIonAssetsRendererProps> = ({
       return;
     }
 
+    // Dispose everything we're tracking, then also sweep any orphan
+    // data sources still attached to the viewer with a `_kloradAssetId`
+    // tag. Without the sweep, toggling a fast-changing option (e.g.
+    // clamp-to-ground) can leave a ghost of the previous render: the
+    // effect fires a fresh load before the previous `initializeAsset`
+    // finished attaching, so its data source only lands on the viewer
+    // AFTER our forEach-dispose — orphaning it forever.
     tilesetRefs.current.forEach((wrapper) => {
       wrapper.dispose();
     });
     tilesetRefs.current.clear();
 
+    try {
+      const collection = cesiumViewer.dataSources;
+      if (collection) {
+        const orphans: any[] = [];
+        for (let i = 0; i < collection.length; i++) {
+          const ds = collection.get(i);
+          if (ds?._kloradAssetId != null) {
+            orphans.push(ds);
+          }
+        }
+        for (const ds of orphans) {
+          collection.remove(ds, true);
+        }
+      }
+    } catch {
+      /* viewer torn down mid-teardown — nothing to do */
+    }
+
+    runTokenRef.current += 1;
+    const runToken = runTokenRef.current;
     cesiumIonAssets.forEach((asset) => {
       if (asset.enabled) {
-        initializeAsset(asset);
+        initializeAsset(asset, runToken);
       }
     });
   }, [assetsKey, cesiumViewer, cesiumInstance]); // Use assetsKey instead of cesiumIonAssets
 
-  const initializeAsset = async (asset: any) => {
+  const initializeAsset = async (asset: any, runToken: number) => {
     try {
       const originalToken = cesiumInstance.Ion.defaultAccessToken;
       cesiumInstance.Ion.defaultAccessToken = asset.apiKey;
@@ -95,9 +134,32 @@ const CesiumIonAssetsRenderer: React.FC<CesiumIonAssetsRendererProps> = ({
           cesiumInstance,
           asset.assetId,
           ionType as "KML" | "GEOJSON" | "CZML",
-          cesiumViewer
+          cesiumViewer,
+          {
+            // Default true — matches historic behaviour and covers the
+            // common flat-KML case. Operator flips this off from the
+            // properties panel when the source KML has real altitudes.
+            clampToGround: asset.clampToGround ?? true,
+          }
         );
+        // If a newer run started while we were awaiting Ion, drop this
+        // data source instead of attaching it — it would only be a
+        // ghost of the previous option state.
+        if (runToken !== runTokenRef.current) {
+          try {
+            dataSource.destroy?.();
+          } catch {
+            /* nothing to do */
+          }
+          cesiumInstance.Ion.defaultAccessToken = originalToken;
+          return;
+        }
         dataSource._kloradAssetId = asset.assetId;
+        // Tag the runtime Ion type so the properties panel can detect
+        // "this is a vector row" from the viewer directly, without
+        // depending on `asset.type` being present on the store row
+        // (older scenes persist without it).
+        dataSource._kloradIonType = ionType;
         await cesiumViewer.dataSources.add(dataSource);
 
         const wrapper: TilesetWrapper = {

--- a/packages/engine-cesium/src/utils/tileset-operations.ts
+++ b/packages/engine-cesium/src/utils/tileset-operations.ts
@@ -622,12 +622,21 @@ export async function loadVectorIonDataSource(
   Cesium: any,
   cesiumAssetId: string,
   ionType: "KML" | "GEOJSON" | "CZML",
-  viewer?: any
+  viewer?: any,
+  options?: {
+    /** Drape features onto terrain surface. Defaults to `true` — the
+     *  common case for KML/GeoJSON authored without meaningful
+     *  altitudes. Pass `false` to preserve the source's own altitude
+     *  data (needed for KMLs with real 3D geometry). Ignored for CZML
+     *  because altitude mode is per-entity in the packet source. */
+    clampToGround?: boolean;
+  }
 ): Promise<any> {
   const idNum = Number(cesiumAssetId);
   if (!Number.isFinite(idNum)) {
     throw new Error(`Invalid Cesium Ion asset id: ${cesiumAssetId}`);
   }
+  const clampToGround = options?.clampToGround ?? true;
   const resource = await Cesium.IonResource.fromAssetId(idNum);
   switch (ionType) {
     case "KML": {
@@ -642,7 +651,7 @@ export async function loadVectorIonDataSource(
       // `camera` + `canvas` are needed for KML network links to
       // resolve screen-space queries; passing them when we have a
       // viewer is a no-op for static KMLs.
-      const kmlOptions: Record<string, unknown> = { clampToGround: true };
+      const kmlOptions: Record<string, unknown> = { clampToGround };
       if (viewer?.camera) kmlOptions.camera = viewer.camera;
       if (viewer?.canvas) kmlOptions.canvas = viewer.canvas;
       const kmlDataSource = await Cesium.KmlDataSource.load(
@@ -666,15 +675,21 @@ export async function loadVectorIonDataSource(
       // properties together, otherwise the render loop throws every
       // frame. Geodesic is the natural choice for a line following
       // the terrain surface.
-      try {
-        for (const entity of kmlDataSource.entities.values) {
-          if (entity?.polyline) {
-            entity.polyline.clampToGround = true;
-            entity.polyline.arcType = Cesium.ArcType.GEODESIC;
+      //
+      // When the caller opts OUT of clamp (a 3D KML with real
+      // altitudes), we skip this override entirely so the source
+      // `arcType` and altitudes are respected.
+      if (clampToGround) {
+        try {
+          for (const entity of kmlDataSource.entities.values) {
+            if (entity?.polyline) {
+              entity.polyline.clampToGround = true;
+              entity.polyline.arcType = Cesium.ArcType.GEODESIC;
+            }
           }
+        } catch {
+          /* entities collection unavailable — nothing to force */
         }
-      } catch {
-        /* entities collection unavailable — nothing to force */
       }
       return kmlDataSource;
     }
@@ -684,7 +699,7 @@ export async function loadVectorIonDataSource(
       // LineString handling does NOT have the KML tessellate quirk,
       // so no post-load fix-up needed here.
       return await Cesium.GeoJsonDataSource.load(resource, {
-        clampToGround: true,
+        clampToGround,
       });
     case "CZML":
       // CZML packets specify altitude modes per-entity in the source


### PR DESCRIPTION
## Summary
Follow-up to #233. Some KMLs (flight paths, absolute-altitude features) shouldn't be draped onto terrain — but the loader was forcing `clampToGround` unconditionally. This exposes it as an operator-controlled switch in the right-panel properties for the selected KML/GeoJSON row.

## What's new

- **`CesiumIonAsset.clampToGround?`** field on the scene store (default `true` — matches historic behaviour).
- **`loadVectorIonDataSource`** threads `clampToGround` into both the load-time flag AND the per-entity polyline override. When off, the KML entity fix-up is skipped so the source's own `arcType` and altitudes survive.
- **`CesiumIonAssetsRenderer`** reads `asset.clampToGround` and includes it in `assetsKey` so toggling from the panel tears down + reloads the data source with the new option.
- **New `CesiumIonAssetPropertiesSection`** in the object properties panel. Detects vectorness at runtime by scanning `viewer.dataSources` for a matching `_kloradAssetId` — works for KMLs that were loaded before this PR, because we also fall back to the data source's constructor name (`KmlDataSource` / `GeoJsonDataSource`). Persistent `asset.type` on the store is a secondary fallback.
- **`_kloradIonType` runtime tag** stamped on each attached data source so the panel's detection has a first-class marker.

## Race fixes (discovered while wiring the toggle)

1. **Orphan sweep**: before reloading, remove every data source in the viewer tagged with `_kloradAssetId`, not just the ones tracked in `tilesetRefs`. Prior to this, toggling fast enough left a ghost of the previous render because a stale in-flight `initializeAsset` was attaching AFTER our forEach-dispose.
2. **Run token**: every effect run bumps a counter; async loads that finish after the counter has moved on destroy the loaded data source instead of attaching it. Prevents late arrivals from repopulating what the sweep just cleared.

CZML doesn't get a toggle — altitude modes are per-entity in the source packet, so a load-time flag would be misleading.

## Test plan
- [x] Select an existing KML in the scene tree. "KML Options" section appears in the right panel with the "Clamp to ground" switch.
- [x] Toggle off. Old draped render disappears cleanly; features reappear at their source altitudes.
- [x] Toggle back on. Features drape onto terrain again. No ghost trail.
- [x] Toggle rapidly (before each load completes). Final state matches the current switch position — no stale renders left behind.
- [x] 3D-Tile Ion assets: switch does not appear (only vector types show it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)