### PR TITLE
feat(campus): send push notification switch on news + event create

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/EventsAdminClient.tsx
@@ -27,6 +27,9 @@ interface Props {
   initialEvents: EventPost[];
   /** MappedIn venue id — when set, the anchor input becomes a picker. */
   indoorMapId?: string | null;
+  /** True when VAPID keys are configured on the server. Drives whether
+   *  the "Send push notification" switch is interactive. */
+  pushEnabled?: boolean;
 }
 
 const EMPTY_ANCHOR: AnchorValue = { refName: "", refId: "" };
@@ -63,6 +66,7 @@ export function EventsAdminClient({
   mapId,
   initialEvents,
   indoorMapId,
+  pushEnabled = false,
 }: Props) {
   const [events, setEvents] = useState<EventPost[]>(initialEvents);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -80,6 +84,9 @@ export function EventsAdminClient({
   const [expectedAttendance, setExpectedAttendance] = useState("");
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  /** Only meaningful on Create — see NewsAdminClient for the same
+   *  no-resend-on-edit rationale. */
+  const [notify, setNotify] = useState(false);
 
   const reset = () => {
     setEditingId(null);
@@ -96,6 +103,7 @@ export function EventsAdminClient({
     setOrganizer("");
     setExpectedAttendance("");
     setImageUrl(null);
+    setNotify(false);
   };
 
   /** `<input type="datetime-local">` value from an ISO string in local TZ. */
@@ -175,18 +183,32 @@ export function EventsAdminClient({
                 },
               ]
             : [],
+          // See NewsAdminClient — Create only. Edit relies on the
+          // Reach form for explicit resends.
+          notify: editingId ? undefined : notify,
         }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err.error ?? "Failed to save");
       }
+      const json = await res.json().catch(() => ({}));
       const list = await fetch(`/api/maps/${mapId}/events`).then((r) =>
         r.json(),
       );
       setEvents(list.events ?? []);
       reset();
       toast.success(editingId ? "Updated" : "Event published");
+      const b = json?.broadcast;
+      if (b?.requested) {
+        if (b.ok) {
+          toast.success(
+            `Sent to ${b.attempted} subscriber(s) · ${b.delivered} delivered.`,
+          );
+        } else {
+          toast.warn(`Push skipped: ${b.reason}`);
+        }
+      }
     } catch (e) {
       console.error(e);
       toast.error(e instanceof Error ? e.message : "Failed to save");
@@ -432,6 +454,37 @@ export function EventsAdminClient({
               defaultCategory="events"
             />
           </Field>
+
+          {/* Push notification toggle — Create only. See
+              NewsAdminClient for the same reasoning. */}
+          {!editingId && (
+            <label
+              className={`flex cursor-pointer items-start gap-3 rounded-lg border border-solid p-3 transition-colors ${
+                pushEnabled
+                  ? "border-line-soft hover:border-accent/40"
+                  : "cursor-not-allowed border-line-soft bg-surface-2/60 opacity-70"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={pushEnabled && notify}
+                onChange={(e) => setNotify(e.target.checked)}
+                disabled={!pushEnabled || submitting}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+                aria-label="Send push notification when publishing"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium text-text-primary">
+                  Send push notification
+                </span>
+                <span className="mt-0.5 block text-xs text-text-tertiary">
+                  {pushEnabled
+                    ? "Notify everyone who tapped “Get notifications” on this campus. Tapping the notification opens this event."
+                    : "Disabled — set VAPID_* env vars to enable."}
+                </span>
+              </span>
+            </label>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/events/page.tsx
@@ -63,6 +63,7 @@ export default async function EventsAdminPage({
           mapId={mapId}
           initialEvents={events}
           indoorMapId={indoorMapId}
+          pushEnabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}
         />
         <IcsFeedsManager mapId={mapId} initialFeeds={initialFeeds} />
         <NotifyForm

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/NewsAdminClient.tsx
@@ -26,6 +26,10 @@ interface Props {
   initialPosts: NewsPost[];
   /** MappedIn venue id — when set, the anchor input becomes a picker. */
   indoorMapId?: string | null;
+  /** True when VAPID keys are configured on the server. Drives whether
+   *  the "Send push notification" switch is interactive. Falls to
+   *  `false` if the parent page doesn't pass it — safe default. */
+  pushEnabled?: boolean;
 }
 
 const EMPTY_ANCHOR: AnchorValue = { refName: "", refId: "" };
@@ -52,6 +56,7 @@ export function NewsAdminClient({
   mapId,
   initialPosts,
   indoorMapId,
+  pushEnabled = false,
 }: Props) {
   const [posts, setPosts] = useState<NewsPost[]>(initialPosts);
   /** Non-null when the form is editing an existing post. */
@@ -65,6 +70,10 @@ export function NewsAdminClient({
   const [anchor, setAnchor] = useState<AnchorValue>(EMPTY_ANCHOR);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  /** Only meaningful on Create (not Edit) — sends a push to every
+   *  subscriber the moment the post lands, with a deep-link to the
+   *  new article's public page. */
+  const [notify, setNotify] = useState(false);
 
   const reset = () => {
     setEditingId(null);
@@ -76,6 +85,7 @@ export function NewsAdminClient({
     setPublishedAt(todayISODate());
     setAnchor(EMPTY_ANCHOR);
     setImageUrl(null);
+    setNotify(false);
   };
 
   /** Populate the form with a post's current values for editing. */
@@ -133,12 +143,18 @@ export function NewsAdminClient({
                 },
               ]
             : [],
+          // Only ask for a push on Create — resending on every Edit
+          // would spam subscribers with duplicates whenever a rector
+          // fixes a typo. Reach form covers the "resend on update"
+          // case explicitly.
+          notify: editingId ? undefined : notify,
         }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err.error ?? "Failed to save");
       }
+      const json = await res.json().catch(() => ({}));
       // Optimistic refresh — re-fetch the list so the post updates.
       const list = await fetch(`/api/maps/${mapId}/news`).then((r) =>
         r.json(),
@@ -146,6 +162,20 @@ export function NewsAdminClient({
       setPosts(list.posts ?? []);
       reset();
       toast.success(editingId ? "Updated" : "Published");
+      // Broadcast toast — success shows the delivery counts, failure
+      // still shows the post was published but surfaces why the push
+      // was skipped so the rector can decide whether to retry via
+      // the Reach form.
+      const b = json?.broadcast;
+      if (b?.requested) {
+        if (b.ok) {
+          toast.success(
+            `Sent to ${b.attempted} subscriber(s) · ${b.delivered} delivered.`,
+          );
+        } else {
+          toast.warn(`Push skipped: ${b.reason}`);
+        }
+      }
     } catch (e) {
       console.error(e);
       toast.error(e instanceof Error ? e.message : "Failed to save");
@@ -338,6 +368,38 @@ export function NewsAdminClient({
               defaultCategory="news"
             />
           </Field>
+
+          {/* Push notification toggle — Create only. On Edit we hide
+              it because sending the same push again on every typo
+              edit would be a subscriber-experience footgun. */}
+          {!editingId && (
+            <label
+              className={`flex cursor-pointer items-start gap-3 rounded-lg border border-solid p-3 transition-colors ${
+                pushEnabled
+                  ? "border-line-soft hover:border-accent/40"
+                  : "cursor-not-allowed border-line-soft bg-surface-2/60 opacity-70"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={pushEnabled && notify}
+                onChange={(e) => setNotify(e.target.checked)}
+                disabled={!pushEnabled || submitting}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+                aria-label="Send push notification when publishing"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium text-text-primary">
+                  Send push notification
+                </span>
+                <span className="mt-0.5 block text-xs text-text-tertiary">
+                  {pushEnabled
+                    ? "Notify everyone who tapped “Get notifications” on this campus. Tapping the notification opens this article."
+                    : "Disabled — set VAPID_* env vars to enable."}
+                </span>
+              </span>
+            </label>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button

--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/news/page.tsx
@@ -63,6 +63,7 @@ export default async function NewsAdminPage({
         mapId={mapId}
         initialPosts={posts}
         indoorMapId={indoorMapId}
+        pushEnabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}
       />
     </div>
   );

--- a/apps/campus/app/api/maps/[mapId]/events/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/events/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/events-db";
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
+import { createBroadcastAndSend, eventDeepLinkUrl } from "@/lib/broadcast";
 
 type Params = Promise<{ mapId: string }>;
 
@@ -161,5 +162,55 @@ export async function POST(req: Request, { params }: { params: Params }) {
     metadata: { startsAt: startsAt.toISOString() },
   });
 
-  return NextResponse.json({ id: created.id });
+  // Optional on-publish push — see the news route for the reasoning
+  // behind the shape of this response and the try/catch that keeps
+  // event creation safe from downstream broadcast errors.
+  let broadcast:
+    | { requested: false }
+    | { requested: true; ok: true; broadcastId: string; delivered: number; attempted: number }
+    | { requested: true; ok: false; reason: string } = { requested: false };
+  if (body.notify === true) {
+    try {
+      const result = await createBroadcastAndSend({
+        mapId,
+        organizationId: project.organizationId,
+        title:
+          typeof body.notifyTitle === "string" && body.notifyTitle.trim().length > 0
+            ? body.notifyTitle.trim()
+            : title,
+        body:
+          typeof body.notifyBody === "string" && body.notifyBody.trim().length > 0
+            ? body.notifyBody.trim()
+            : description,
+        url: eventDeepLinkUrl(mapId, created.id),
+        senderId: (session?.user?.id as string | undefined) ?? null,
+      });
+      if (result.ok) {
+        broadcast = {
+          requested: true,
+          ok: true,
+          broadcastId: result.broadcastId,
+          delivered: result.delivered,
+          attempted: result.attempted,
+        };
+      } else if ("skipped" in result) {
+        broadcast = {
+          requested: true,
+          ok: false,
+          reason: result.skipped,
+        };
+      } else {
+        broadcast = { requested: true, ok: false, reason: result.error };
+      }
+    } catch (err) {
+      console.error("[events] broadcast failed", err);
+      broadcast = {
+        requested: true,
+        ok: false,
+        reason: err instanceof Error ? err.message : "Broadcast failed",
+      };
+    }
+  }
+
+  return NextResponse.json({ id: created.id, broadcast });
 }

--- a/apps/campus/app/api/maps/[mapId]/events/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/events/route.ts
@@ -185,7 +185,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
         url: eventDeepLinkUrl(mapId, created.id),
         senderId: (session?.user?.id as string | undefined) ?? null,
       });
-      if (result.ok) {
+      if (result.status === "sent") {
         broadcast = {
           requested: true,
           ok: true,
@@ -193,12 +193,8 @@ export async function POST(req: Request, { params }: { params: Params }) {
           delivered: result.delivered,
           attempted: result.attempted,
         };
-      } else if ("skipped" in result) {
-        broadcast = {
-          requested: true,
-          ok: false,
-          reason: result.skipped,
-        };
+      } else if (result.status === "skipped") {
+        broadcast = { requested: true, ok: false, reason: result.reason };
       } else {
         broadcast = { requested: true, ok: false, reason: result.error };
       }

--- a/apps/campus/app/api/maps/[mapId]/news/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/news/route.ts
@@ -169,7 +169,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
         url: newsDeepLinkUrl(mapId, created.id),
         senderId: session.user.id as string,
       });
-      if (result.ok) {
+      if (result.status === "sent") {
         broadcast = {
           requested: true,
           ok: true,
@@ -177,12 +177,8 @@ export async function POST(req: Request, { params }: { params: Params }) {
           delivered: result.delivered,
           attempted: result.attempted,
         };
-      } else if ("skipped" in result) {
-        broadcast = {
-          requested: true,
-          ok: false,
-          reason: result.skipped,
-        };
+      } else if (result.status === "skipped") {
+        broadcast = { requested: true, ok: false, reason: result.reason };
       } else {
         broadcast = { requested: true, ok: false, reason: result.error };
       }

--- a/apps/campus/app/api/maps/[mapId]/news/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/news/route.ts
@@ -10,6 +10,7 @@ import {
 import { revalidateTag } from "next/cache";
 import { publicCampusTag } from "@/lib/public-campus";
 import { Prisma, type NewsCategory } from "@prisma/client";
+import { createBroadcastAndSend, newsDeepLinkUrl } from "@/lib/broadcast";
 
 type Params = Promise<{ mapId: string }>;
 
@@ -142,5 +143,58 @@ export async function POST(req: Request, { params }: { params: Params }) {
     metadata: { category, title },
   });
 
-  return NextResponse.json({ id: created.id });
+  // Optional on-publish push. The Reach form still exists for
+  // one-off announcements; this is the "publish + notify at once"
+  // shortcut on the news composer. Wrapped in try/catch so a push
+  // failure never fails the news creation itself — the row is
+  // already in the DB and the rector shouldn't see a 500 for a
+  // downstream problem.
+  let broadcast:
+    | { requested: false }
+    | { requested: true; ok: true; broadcastId: string; delivered: number; attempted: number }
+    | { requested: true; ok: false; reason: string } = { requested: false };
+  if (body.notify === true) {
+    try {
+      const result = await createBroadcastAndSend({
+        mapId,
+        organizationId: project.organizationId,
+        title:
+          typeof body.notifyTitle === "string" && body.notifyTitle.trim().length > 0
+            ? body.notifyTitle.trim()
+            : title,
+        body:
+          typeof body.notifyBody === "string" && body.notifyBody.trim().length > 0
+            ? body.notifyBody.trim()
+            : post,
+        url: newsDeepLinkUrl(mapId, created.id),
+        senderId: session.user.id as string,
+      });
+      if (result.ok) {
+        broadcast = {
+          requested: true,
+          ok: true,
+          broadcastId: result.broadcastId,
+          delivered: result.delivered,
+          attempted: result.attempted,
+        };
+      } else if ("skipped" in result) {
+        broadcast = {
+          requested: true,
+          ok: false,
+          reason: result.skipped,
+        };
+      } else {
+        broadcast = { requested: true, ok: false, reason: result.error };
+      }
+    } catch (err) {
+      console.error("[news] broadcast failed", err);
+      broadcast = {
+        requested: true,
+        ok: false,
+        reason: err instanceof Error ? err.message : "Broadcast failed",
+      };
+    }
+  }
+
+  return NextResponse.json({ id: created.id, broadcast });
 }

--- a/apps/campus/app/api/maps/[mapId]/notify/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/notify/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from "next/server";
-import { randomBytes } from "node:crypto";
 import { auth } from "@/auth";
 import { requireCampusAccess } from "@/lib/authz";
-import { recordAudit } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
-import { pushEnabled, sendPushToProject } from "@/lib/push";
+import { pushEnabled } from "@/lib/push";
+import { createBroadcastAndSend } from "@/lib/broadcast";
 
 type Params = Promise<{ mapId: string }>;
 
@@ -56,103 +55,42 @@ export async function POST(req: Request, { params }: { params: Params }) {
   const url = typeof body.url === "string" ? body.url : undefined;
   const icon = typeof body.icon === "string" ? body.icon : undefined;
 
-  // Pre-allocate the broadcast row so the push payload can carry its
-  // id. If anything fails before the send, the row is left with
-  // `attempted: 0` which the Reach UI renders as a "0/0 · queued"
-  // line — surfacing the failed send instead of hiding it.
-  const clickToken = randomBytes(12).toString("base64url");
   const session = await auth();
-  const broadcast = await prisma.broadcast.create({
-    data: {
-      projectId: mapId,
-      title,
-      body: message,
-      targetPath: extractCampusRelativePath(url, mapId),
-      senderId: (session?.user?.id as string | undefined) ?? null,
-      clickToken,
-    },
-    select: { id: true },
+  const project = await prisma.project.findUnique({
+    where: { id: mapId },
+    select: { organizationId: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Campus not found" }, { status: 404 });
+  }
+
+  const outcome = await createBroadcastAndSend({
+    mapId,
+    organizationId: project.organizationId,
+    title,
+    body: message,
+    url,
+    icon,
+    senderId: (session?.user?.id as string | undefined) ?? null,
   });
 
-  try {
-    const result = await sendPushToProject(mapId, {
-      title,
-      body: message,
-      url,
-      icon,
-      broadcastId: broadcast.id,
-      clickToken,
+  if (outcome.ok) {
+    return NextResponse.json({
+      ok: true,
+      result: {
+        attempted: outcome.attempted,
+        delivered: outcome.delivered,
+        pruned: outcome.pruned,
+      },
     });
-
-    await prisma.broadcast
-      .update({
-        where: { id: broadcast.id },
-        data: {
-          attempted: result.attempted,
-          delivered: result.delivered,
-          pruned: result.pruned,
-        },
-      })
-      .catch((err) => {
-        console.error("[notify] count update failed", err);
-      });
-
-    // Audit row: piggybacks on the project lookup the authz helper
-    // already did. We do an extra `findUnique` to get the org id —
-    // tiny cost vs. accurate attribution on the "What Changed" feed.
-    const project = await prisma.project.findUnique({
-      where: { id: mapId },
-      select: { organizationId: true },
-    });
-    if (project) {
-      await recordAudit({
-        organizationId: project.organizationId,
-        projectId: mapId,
-        actorId: (session?.user?.id as string | undefined) ?? null,
-        entityType: "BROADCAST",
-        entityId: broadcast.id,
-        action: "CREATED",
-        message: `Broadcast "${title}" — sent to ${result.delivered} of ${result.attempted}`,
-        metadata: {
-          attempted: result.attempted,
-          delivered: result.delivered,
-          pruned: result.pruned,
-        },
-      });
-    }
-
-    return NextResponse.json({ ok: true, result });
-  } catch (err) {
-    console.error("[notify]", err);
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Push failed" },
-      { status: 500 },
-    );
   }
-}
 
-/**
- * The Reach composer sends an absolute-or-campus-prefixed URL like
- * `/campus/<mapId>/events`. We store the campus-relative tail so
- * future history rows stay valid if the public URL scheme moves
- * (e.g. custom domains). Returns `null` when the URL doesn't look
- * like a campus link.
- */
-function extractCampusRelativePath(
-  url: string | undefined,
-  mapId: string,
-): string | null {
-  if (!url) return null;
-  let path = url;
-  try {
-    if (url.startsWith("http://") || url.startsWith("https://")) {
-      path = new URL(url).pathname;
-    }
-  } catch {
-    return null;
-  }
-  const prefix = `/campus/${mapId}`;
-  if (!path.startsWith(prefix)) return null;
-  const tail = path.slice(prefix.length);
-  return tail || "/";
+  const status = "skipped" in outcome && outcome.skipped === "push-disabled" ? 503 : 500;
+  const errorMessage =
+    "skipped" in outcome
+      ? outcome.skipped === "push-disabled"
+        ? "Push isn't configured on this server."
+        : "Broadcast skipped."
+      : outcome.error;
+  return NextResponse.json({ error: errorMessage }, { status });
 }

--- a/apps/campus/app/api/maps/[mapId]/notify/route.ts
+++ b/apps/campus/app/api/maps/[mapId]/notify/route.ts
@@ -74,7 +74,7 @@ export async function POST(req: Request, { params }: { params: Params }) {
     senderId: (session?.user?.id as string | undefined) ?? null,
   });
 
-  if (outcome.ok) {
+  if (outcome.status === "sent") {
     return NextResponse.json({
       ok: true,
       result: {
@@ -85,10 +85,13 @@ export async function POST(req: Request, { params }: { params: Params }) {
     });
   }
 
-  const status = "skipped" in outcome && outcome.skipped === "push-disabled" ? 503 : 500;
+  const status =
+    outcome.status === "skipped" && outcome.reason === "push-disabled"
+      ? 503
+      : 500;
   const errorMessage =
-    "skipped" in outcome
-      ? outcome.skipped === "push-disabled"
+    outcome.status === "skipped"
+      ? outcome.reason === "push-disabled"
         ? "Push isn't configured on this server."
         : "Broadcast skipped."
       : outcome.error;

--- a/apps/campus/lib/broadcast.ts
+++ b/apps/campus/lib/broadcast.ts
@@ -1,0 +1,179 @@
+/**
+ * Shared "compose a broadcast, send the push, count the deliveries,
+ * audit the send" helper. Extracted from `POST /api/maps/[mapId]/notify`
+ * so the news / event create routes can fire an on-publish push
+ * without duplicating the ~40 lines of pre-allocate + send + counter
+ * update + audit boilerplate.
+ *
+ * Design notes:
+ *   - The Broadcast row is pre-allocated so the push payload can
+ *     carry `broadcastId` + `clickToken`. If the push send throws,
+ *     the row stays at `attempted: 0` and the Reach screen shows it
+ *     as "0/0 · queued" — a visible signal instead of a silent drop.
+ *   - Every push failure per subscription is swallowed by
+ *     `sendPushToProject`; the helper only rethrows when *nothing*
+ *     could be sent at all (VAPID not configured).
+ *   - Deep-link URLs are stored as campus-relative tails on the
+ *     Broadcast row so the analytics survives a future URL-scheme
+ *     change.
+ */
+import { randomBytes } from "node:crypto";
+import { prisma } from "@/lib/prisma";
+import { pushEnabled, sendPushToProject } from "@/lib/push";
+import { recordAudit } from "@/lib/audit";
+
+export interface CreateBroadcastInput {
+  mapId: string;
+  organizationId: string;
+  title: string;
+  body: string;
+  /** Absolute or campus-prefixed click-through URL. */
+  url?: string;
+  icon?: string;
+  senderId?: string | null;
+}
+
+export type CreateBroadcastResult =
+  | {
+      ok: true;
+      broadcastId: string;
+      attempted: number;
+      delivered: number;
+      pruned: number;
+    }
+  | { ok: false; skipped: "push-disabled" | "no-subscribers"; broadcastId?: string }
+  | { ok: false; error: string; broadcastId?: string };
+
+/**
+ * Send a push to every subscriber on `mapId` and persist the audit
+ * trail. Non-throwing — inspect the result's `ok` flag. On success
+ * the return also carries per-run counters for the caller (currently
+ * unused but handy for a future toast on the admin).
+ */
+export async function createBroadcastAndSend(
+  input: CreateBroadcastInput,
+): Promise<CreateBroadcastResult> {
+  if (!pushEnabled()) {
+    return { ok: false, skipped: "push-disabled" };
+  }
+
+  const {
+    mapId,
+    organizationId,
+    title,
+    body,
+    url,
+    icon,
+    senderId,
+  } = input;
+
+  const clickToken = randomBytes(12).toString("base64url");
+
+  const broadcast = await prisma.broadcast.create({
+    data: {
+      projectId: mapId,
+      title,
+      body,
+      targetPath: extractCampusRelativePath(url, mapId),
+      senderId: senderId ?? null,
+      clickToken,
+    },
+    select: { id: true },
+  });
+
+  try {
+    const result = await sendPushToProject(mapId, {
+      title,
+      body,
+      url,
+      icon,
+      broadcastId: broadcast.id,
+      clickToken,
+    });
+
+    await prisma.broadcast
+      .update({
+        where: { id: broadcast.id },
+        data: {
+          attempted: result.attempted,
+          delivered: result.delivered,
+          pruned: result.pruned,
+        },
+      })
+      .catch((err) => {
+        console.error("[broadcast] count update failed", err);
+      });
+
+    await recordAudit({
+      organizationId,
+      projectId: mapId,
+      actorId: senderId ?? null,
+      entityType: "BROADCAST",
+      entityId: broadcast.id,
+      action: "CREATED",
+      message: `Broadcast "${title}" — sent to ${result.delivered} of ${result.attempted}`,
+      metadata: {
+        attempted: result.attempted,
+        delivered: result.delivered,
+        pruned: result.pruned,
+      },
+    }).catch((err) => {
+      console.error("[broadcast] audit failed", err);
+    });
+
+    return {
+      ok: true,
+      broadcastId: broadcast.id,
+      attempted: result.attempted,
+      delivered: result.delivered,
+      pruned: result.pruned,
+    };
+  } catch (err) {
+    console.error("[broadcast] send failed", err);
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Push failed",
+      broadcastId: broadcast.id,
+    };
+  }
+}
+
+/**
+ * A composer-provided URL might be absolute, campus-prefixed, or a
+ * bare `/news/<id>` shorthand from a create-route caller. Store the
+ * campus-relative tail on the Broadcast row so the history stays
+ * valid if the public URL scheme changes (e.g. custom domains).
+ */
+function extractCampusRelativePath(
+  url: string | undefined,
+  mapId: string,
+): string | null {
+  if (!url) return null;
+  let path = url;
+  try {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      path = new URL(url).pathname;
+    }
+  } catch {
+    return null;
+  }
+  const prefix = `/campus/${mapId}`;
+  if (path.startsWith(prefix)) {
+    const tail = path.slice(prefix.length);
+    return tail || "/";
+  }
+  // Callers from the news / event routes pass a bare `/news/<id>`
+  // shorthand — keep it as-is; it's already campus-relative.
+  if (path.startsWith("/")) return path;
+  return null;
+}
+
+/** Compose the campus-scoped public URL for a news post. */
+export function newsDeepLinkUrl(mapId: string, newsId: string): string {
+  return `/campus/${mapId}/news/${newsId}`;
+}
+
+/** Compose the campus-scoped public URL for an event. */
+export function eventDeepLinkUrl(mapId: string, eventId: string): string {
+  return `/campus/${mapId}/events/${eventId}`;
+}

--- a/apps/campus/lib/broadcast.ts
+++ b/apps/campus/lib/broadcast.ts
@@ -33,16 +33,27 @@ export interface CreateBroadcastInput {
   senderId?: string | null;
 }
 
+/** Single tagged discriminant so callers can switch/if-else cleanly.
+ *  TypeScript's `"skipped" in result` narrowing gave up on the shape
+ *  where two non-ok variants both had `ok: false`; a nominal
+ *  `status` field is unambiguous. */
 export type CreateBroadcastResult =
   | {
-      ok: true;
+      status: "sent";
       broadcastId: string;
       attempted: number;
       delivered: number;
       pruned: number;
     }
-  | { ok: false; skipped: "push-disabled" | "no-subscribers"; broadcastId?: string }
-  | { ok: false; error: string; broadcastId?: string };
+  | {
+      status: "skipped";
+      reason: "push-disabled" | "no-subscribers";
+    }
+  | {
+      status: "error";
+      error: string;
+      broadcastId?: string;
+    };
 
 /**
  * Send a push to every subscriber on `mapId` and persist the audit
@@ -54,7 +65,7 @@ export async function createBroadcastAndSend(
   input: CreateBroadcastInput,
 ): Promise<CreateBroadcastResult> {
   if (!pushEnabled()) {
-    return { ok: false, skipped: "push-disabled" };
+    return { status: "skipped", reason: "push-disabled" };
   }
 
   const {
@@ -122,7 +133,7 @@ export async function createBroadcastAndSend(
     });
 
     return {
-      ok: true,
+      status: "sent",
       broadcastId: broadcast.id,
       attempted: result.attempted,
       delivered: result.delivered,
@@ -131,7 +142,7 @@ export async function createBroadcastAndSend(
   } catch (err) {
     console.error("[broadcast] send failed", err);
     return {
-      ok: false,
+      status: "error",
       error: err instanceof Error ? err.message : "Push failed",
       broadcastId: broadcast.id,
     };


### PR DESCRIPTION
## Summary
Adds a "Send push notification" toggle to the news and event **create** forms in the campus admin. When toggled on, publishing the post fires a push to every subscriber with a deep-link that opens the article/event inside the campus app.

Previously the only way to notify subscribers was the standalone Reach composer at the bottom of the events page — easy to forget after publishing the actual news.

## What's new

- **`lib/broadcast.ts`** — new shared helper that extracts the "pre-allocate `Broadcast` row + `sendPushToProject` + counter update + audit" pattern out of `/api/maps/[mapId]/notify` so the news + event routes can call it in one line. Also exports `newsDeepLinkUrl` / `eventDeepLinkUrl` so the URL scheme lives in one place.
- **News POST route** — accepts optional `notify: boolean` plus `notifyTitle` / `notifyBody` overrides (default to the post's own title/body). Returns a `broadcast` block the client renders as a toast.
- **Events POST route** — same shape.
- **`/api/maps/[mapId]/notify`** — refactored to reuse the helper (~40 lines lighter).
- **`NewsAdminClient` + `EventsAdminClient`** — new switch tile below the image picker, only visible on Create (not on Edit — a typo fix shouldn't blast subscribers with a duplicate; Reach form still covers deliberate resends). Disabled with a clear "VAPID_* env vars" hint when push isn't configured.
- **Parent pages** — pass `pushEnabled={Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)}` through, matching the existing `NotifyForm` gating.

Deep-link is served by the SW's existing `notificationclick` handler (`/public/sw.js` opens the payload's `url`), so no client-side SW changes were needed.

## Try it
1. Set `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` on the server.
2. Subscribe to notifications from the public campus (tap "Get notifications" in the PWA).
3. In `/org/…/maps/…/news`, publish a post with the switch on. You should get a push on the subscribed device with the title/body; tapping it opens `/campus/<mapId>/news/<id>`.
4. Same flow on `/events`.

## Test plan
- [x] Create news with switch off → no push sent, no `broadcast` toast.
- [x] Create news with switch on → push received; toast shows delivery counts.
- [x] Edit existing news → switch tile hidden (no accidental resends).
- [x] Broadcast failure → post still saved, warn toast surfaces the reason.
- [x] `pushEnabled=false` (VAPID unset) → switch shown but disabled + hinted.
- [x] Tap notification → opens the article inside the app (SW handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)