### PR TITLE
fix(editor): remove Cesium Ion sidecar row when deleting a model

### DIFF
--- a/packages/core/src/state/scene-store/object-actions.ts
+++ b/packages/core/src/state/scene-store/object-actions.ts
@@ -34,9 +34,33 @@ export function createObjectActions(set: any, _get: any) {
           objects: state.objects.filter((obj: Model) => obj.id !== id),
           selectedObject:
             state.selectedObject?.id === id ? null : state.selectedObject,
+          // Match the sidecar `CesiumIonAsset` row by the Cesium Ion
+          // asset id — not the model's `assetId`, which stores the
+          // *database* asset id (`model.id`) and never matches
+          // `cesiumIonAsset.assetId` (the numeric Ion id). Without
+          // this, deleting an Ion-backed model from the scene
+          // removed it from the objects list but the tileset / data
+          // source kept rendering because `CesiumIonAssetsRenderer`
+          // still saw a live row in `cesiumIonAssets`.
+          //
+          // Falls back to a `name` match so historical rows added
+          // before we started stamping `cesiumAssetId` on the Model
+          // still delete cleanly.
           cesiumIonAssets: isCesiumIonAsset
             ? state.cesiumIonAssets.filter((asset: any) => {
-                return asset.assetId !== objectToRemove?.assetId;
+                const cesiumId = (objectToRemove as {
+                  cesiumAssetId?: string;
+                })?.cesiumAssetId;
+                if (cesiumId && String(asset.assetId) === String(cesiumId)) {
+                  return false;
+                }
+                if (
+                  objectToRemove?.name &&
+                  asset.name === objectToRemove.name
+                ) {
+                  return false;
+                }
+                return true;
               })
             : state.cesiumIonAssets,
         };


### PR DESCRIPTION
## Summary
Deleting an Ion-backed model in the editor (glTF hosted on Ion, 3D Tileset, KML/GeoJSON) removed the row from the scene tree but the tileset / data source **kept rendering on the map**. The scene renderer reads from `cesiumIonAssets`, and the `removeObject` action was leaving that sidecar row untouched.

## Root cause
`removeObject` filtered `cesiumIonAssets` with:
```ts
asset.assetId !== objectToRemove?.assetId
```
The two `assetId` fields represent **different things**:

| Field | What it is |
|---|---|
| `Model.assetId` | The **database** asset id (`= model.id`), used for metadata/supportive-data lookup |
| `CesiumIonAsset.assetId` | The **Cesium Ion** asset id (numeric id from Ion's API) |

They never match, so the filter always kept the row.

## Fix
Match by `Model.cesiumAssetId` — the Ion id we already stamp on the model row alongside the DB id when the asset is added to the scene. Falls back to a `name` match so historical rows (added before `cesiumAssetId` was populated on the Model) still delete cleanly.

## Related
Same class of bug we would have hit deleting a KML added via PR #233 (vector loader) or #234 (clamp-to-ground toggle) — the sidecar row would have survived, the data source would have kept rendering, and the operator would have had no way to remove it without a full page reload.

## Test plan
- [x] Add a Cesium Ion tileset to the scene → delete it from the scene list → tileset disappears from the map.
- [x] Add a KML (via the new vector loader) → delete → data source removed from `viewer.dataSources`.
- [x] Regression: delete a plain glTF model (not Ion-backed) → still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)