### PR TITLE
fix(campus): let the cover image show through on news + event detail

### DIFF
--- a/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/events/[id]/page.tsx
@@ -126,23 +126,22 @@ export default async function EventDetailPage({
     <main id="main" data-consumer lang={locale}>
 
       <article className="mx-auto max-w-[760px]">
-        {/* Striped cover + optional event image. */}
+        {/* Cover art. Clean image when the event has one; diagonal
+            accent stripes as the fallback when it doesn't. Matches
+            the news detail page — the earlier soft-light overlay
+            made real photos read as tinted textures. */}
         <div
           className="relative h-56 w-full md:h-72"
-          style={{
-            ...stripedBanner(accent, 22),
-            ...(event.imageUrl
+          style={
+            event.imageUrl
               ? {
-                  backgroundImage: `url(${event.imageUrl}), ${
-                    (stripedBanner(accent, 22) as { backgroundImage: string })
-                      .backgroundImage
-                  }`,
-                  backgroundSize: "cover, auto",
-                  backgroundPosition: "center, top left",
-                  backgroundBlendMode: "soft-light, normal",
+                  backgroundImage: `url(${event.imageUrl})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                  backgroundColor: accent,
                 }
-              : null),
-          }}
+              : stripedBanner(accent, 22)
+          }
         >
           <Link
             href={`/campus/${token}${lang}`}

--- a/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
+++ b/apps/campus/app/(public)/campus/[token]/news/[id]/page.tsx
@@ -103,26 +103,24 @@ export default async function NewsDetailPage({
     <main id="main" data-consumer lang={locale}>
 
       <article className="mx-auto max-w-[760px]">
-        {/* Striped cover + image. `stripedBanner` paints the diagonal
-            accent pattern; if a post image is set it sits behind the
-            stripes via background-image, blended through the soft
-            tint. Back chip floats top-left over both. */}
+        {/* Cover art. When the post has an image, show it cleanly —
+            the earlier design blended the striped accent pattern on
+            top via `soft-light`, but that made the image read as a
+            tinted texture instead of a photograph. When there's no
+            image, fall back to the diagonal accent stripes so the
+            cover still carries the campus's colour. */}
         <div
           className="relative h-56 w-full md:h-72"
-          style={{
-            ...stripedBanner(accent, 22),
-            ...(post.imageUrl
+          style={
+            post.imageUrl
               ? {
-                  backgroundImage: `url(${post.imageUrl}), ${
-                    (stripedBanner(accent, 22) as { backgroundImage: string })
-                      .backgroundImage
-                  }`,
-                  backgroundSize: "cover, auto",
-                  backgroundPosition: "center, top left",
-                  backgroundBlendMode: "soft-light, normal",
+                  backgroundImage: `url(${post.imageUrl})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                  backgroundColor: accent,
                 }
-              : null),
-          }}
+              : stripedBanner(accent, 22)
+          }
         >
           <Link
             href={`/campus/${token}${lang}`}


### PR DESCRIPTION
## Summary
Public news and event detail pages layered the diagonal `stripedBanner` accent pattern on top of the uploaded photo via `background-blend-mode: soft-light`. That makes real photographs read as tinted textures — the operator's upload becomes unreadable.

## Fix
Show the image cleanly when one is set. Fall back to the striped banner only when there's no image, so imageless announcements still get the campus-accent cover.

Same one-file pattern in both `news/[id]/page.tsx` and `events/[id]/page.tsx` — fixed both.

## Test plan
- [x] News detail with image → photo renders cleanly, no stripe overlay.
- [x] News detail without image → diagonal accent stripes still fill the cover.
- [x] Events detail with image → same clean photo.
- [x] Events detail without image → stripes fallback.
- [x] Back-chevron chip stays legible over both (white chip on any background).

🤖 Generated with [Claude Code](https://claude.com/claude-code)