### PR TITLE
fix(editor): drop orphan Cesium Ion assets from scene on save

### DIFF
--- a/apps/editor/app/(protected)/org/[orgId]/projects/[projectId]/builder/page.tsx
+++ b/apps/editor/app/(protected)/org/[orgId]/projects/[projectId]/builder/page.tsx
@@ -250,6 +250,33 @@ const sanitizeSceneData = (
       })()
     : [];
 
+  // Drop orphan `cesiumIonAssets` — rows with no corresponding `Model`
+  // in `objects`. These appear when an earlier version of
+  // `removeObject` failed to filter the sidecar array (fixed centrally
+  // in PR #236). Without this sweep, a stuck deleted-but-still-
+  // rendering asset reappears on every reload until the operator
+  // finds a way to remove it manually.
+  //
+  // Match rule: `cesiumIonAsset.assetId` (Cesium Ion asset id) equals
+  // `model.cesiumAssetId` (Ion id stamped on the model row when the
+  // asset was added). Falls back to a `name` match so historical
+  // models added before `cesiumAssetId` was populated still keep
+  // their sidecar alive.
+  const orphanFilteredCesiumIonAssets = cleanCesiumIonAssets.filter(
+    (asset: any) => {
+      const assetId = asset?.assetId ? String(asset.assetId) : null;
+      const assetName = typeof asset?.name === "string" ? asset.name : null;
+      return cleanObjects.some((obj: any) => {
+        const objCesiumId = obj?.cesiumAssetId
+          ? String(obj.cesiumAssetId)
+          : null;
+        if (assetId && objCesiumId && objCesiumId === assetId) return true;
+        if (assetName && obj?.name === assetName) return true;
+        return false;
+      });
+    },
+  );
+
   return {
     objects: cleanObjects,
     observationPoints: cleanObservationPoints,
@@ -257,7 +284,7 @@ const sanitizeSceneData = (
     selectedLocation: cleanSelectedLocation,
     showTiles,
     basemapType: basemapType || "cesium",
-    cesiumIonAssets: cleanCesiumIonAssets,
+    cesiumIonAssets: orphanFilteredCesiumIonAssets,
     cesiumLightingEnabled: cesiumLightingEnabled || false,
     cesiumShadowsEnabled: cesiumShadowsEnabled || false,
     cesiumCurrentTime: cesiumCurrentTime || null,


### PR DESCRIPTION
## Summary
Existing projects have persisted ghost Ion assets (tilesets, KMLs) that show up on the map but not in the scene tree — the sidecar `cesiumIonAssets` row was left behind by the pre-#236 delete bug. This adds a save-time sweep so any Save heals the persisted scene.

## Fix
Inside `sanitizeSceneData()`, after the existing dedup pass, drop any `cesiumIonAssets` row that has no matching `Model` in `objects`. Match rule mirrors the delete fix from #236:

1. `cesiumIonAsset.assetId === model.cesiumAssetId` (Ion id) — primary.
2. Fallback: `cesiumIonAsset.name === model.name` for historical rows.

## Repro
Open a project with a ghost tileset → Save → reload → ghost is gone.

## Test plan
- [x] Broken project (orphan Ion asset) → Save → reload → orphan gone.
- [x] Healthy project → Save → all Ion assets survive.
- [x] Regression: newly added Cesium Ion asset paired with its Model row still gets persisted.

## Related
- #236 — central delete-action fix so new orphans don't accumulate going forward.
- #233 / #234 — vector loader + toggle; sweep applies uniformly to tilesets and vector rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)