### PR TITLE
feat(connectors): add aid/vms/vsls/radar iNET subsystems

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import useSWR from "swr";
 import { toast } from "react-toastify";
 import type { ConnectorDescriptor } from "@klorad/connectors";
+import { INET_SUBSYSTEMS } from "@klorad/connectors/inet-atms";
 
 interface SyncProgress {
   subsystem: string | null;
@@ -408,8 +409,13 @@ function AddSourceForm({
   const [host, setHost] = useState("https://demobe.parsonsinet.com");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [subCctv, setSubCctv] = useState(true);
-  const [subDms, setSubDms] = useState(true);
+  // Track subsystem selection by name so this stays maintenance-free
+  // as new subsystems (aid / vms / vsls / radar for the PSMdt-iNET
+  // demo, plus whatever ships next) land in `INET_SUBSYSTEMS`. Default
+  // to the two live iNET tenants have historically enabled.
+  const [selectedSubsystems, setSelectedSubsystems] = useState<
+    Set<string>
+  >(() => new Set(["cctv", "dms"]));
   const [mode, setMode] = useState<"fixture" | "live">("fixture");
   const [submitting, setSubmitting] = useState(false);
 
@@ -420,9 +426,11 @@ function AddSourceForm({
     }
     setSubmitting(true);
     try {
-      const subsystems: string[] = [];
-      if (subCctv) subsystems.push("cctv");
-      if (subDms) subsystems.push("dms");
+      // Emit in the same order as `INET_SUBSYSTEMS` so the payload
+      // is stable across restarts of the picker.
+      const subsystems: string[] = INET_SUBSYSTEMS.filter((s) =>
+        selectedSubsystems.has(s),
+      );
       const config: Record<string, unknown> = {
         host,
         subsystems,
@@ -536,22 +544,29 @@ function AddSourceForm({
         <fieldset className="text-sm md:col-span-2">
           <legend className="mb-1 text-text-tertiary">Subsystems</legend>
           <div className="flex flex-wrap gap-4">
-            <label className="inline-flex items-center gap-2 text-text-primary">
-              <input
-                type="checkbox"
-                checked={subCctv}
-                onChange={(e) => setSubCctv(e.target.checked)}
-              />
-              CCTV
-            </label>
-            <label className="inline-flex items-center gap-2 text-text-primary">
-              <input
-                type="checkbox"
-                checked={subDms}
-                onChange={(e) => setSubDms(e.target.checked)}
-              />
-              DMS
-            </label>
+            {INET_SUBSYSTEMS.map((subsystem) => (
+              <label
+                key={subsystem}
+                className="inline-flex items-center gap-2 text-text-primary"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedSubsystems.has(subsystem)}
+                  onChange={(e) =>
+                    setSelectedSubsystems((prev) => {
+                      const next = new Set(prev);
+                      if (e.target.checked) {
+                        next.add(subsystem);
+                      } else {
+                        next.delete(subsystem);
+                      }
+                      return next;
+                    })
+                  }
+                />
+                {subsystem.toUpperCase()}
+              </label>
+            ))}
           </div>
         </fieldset>
       </div>

--- a/packages/connectors/src/adapters/inet-atms/adapter.ts
+++ b/packages/connectors/src/adapters/inet-atms/adapter.ts
@@ -28,19 +28,38 @@ import {
 } from "./fixture.js";
 import { createInetHttpClient, type InetHttpClient } from "./client.js";
 import {
+  INET_SUBSYSTEMS,
   InetAtmsConfigSchema,
+  RawAidDeviceSchema,
   RawCctvDeviceSchema,
   RawDmsDeviceSchema,
+  RawRadarDeviceSchema,
   RawStatusSchema,
+  RawVmsDeviceSchema,
+  RawVslsDeviceSchema,
   type InetAtmsConfig,
   type InetDevice,
   type InetMedia,
   type InetStatus,
   type InetSubsystem,
+  type RawAidDevice,
   type RawCctvDevice,
   type RawDmsDevice,
+  type RawRadarDevice,
   type RawStatus,
+  type RawVmsDevice,
+  type RawVslsDevice,
 } from "./types.js";
+
+/** Subsystems that expose a `/status` endpoint the same way DMS does.
+ *  VMS is the regional alias for DMS; VSLS is the same wire shape with
+ *  an added lane label. CCTV / AID / RADAR don't advertise a
+ *  documented status endpoint on the ATMS surface. */
+const STATUS_ENABLED_SUBSYSTEMS: ReadonlySet<InetSubsystem> = new Set([
+  "dms",
+  "vms",
+  "vsls",
+]);
 
 const DEFAULT_PAGE_SIZE = 200;
 /** Safety brake — stop walking pages after this many round-trips even
@@ -54,17 +73,19 @@ export const INET_ATMS_CONNECTOR_ID = "inet-atms";
 function packId(subsystem: InetSubsystem, externalId: string): string {
   return `${subsystem}:${externalId}`;
 }
+function isInetSubsystem(value: string | undefined): value is InetSubsystem {
+  return (
+    typeof value === "string" &&
+    (INET_SUBSYSTEMS as readonly string[]).includes(value)
+  );
+}
+
 function unpackId(deviceId: string): {
   subsystem: InetSubsystem;
   externalId: string;
 } | null {
   const [subsystem, externalId, ...rest] = deviceId.split(":");
-  if (
-    rest.length > 0 ||
-    !subsystem ||
-    !externalId ||
-    !(subsystem === "cctv" || subsystem === "dms")
-  ) {
+  if (rest.length > 0 || !externalId || !isInetSubsystem(subsystem)) {
     return null;
   }
   return { subsystem, externalId };
@@ -141,6 +162,108 @@ function normaliseDms(raw: RawDmsDevice): InetDevice {
     name: raw.name ?? `DMS ${externalId}`,
     media: null,
   };
+}
+
+// ─────────────────────────────────────────────────────────────
+// PSMdt-iNET demo subsystems (aid / vms / vsls / radar)
+//
+// Each shares wire shape with an existing subsystem — see the aliased
+// schemas in `types.ts`. Normalisers stay tiny by delegating to the
+// parent normaliser and swapping the packed id + subsystem tag.
+// ─────────────────────────────────────────────────────────────
+
+function normaliseAid(raw: RawAidDevice): InetDevice {
+  const base = normaliseCctv(raw);
+  return {
+    ...base,
+    deviceId: packId("aid", base.externalId),
+    subsystem: "aid",
+    name: raw.name ?? `AID ${base.externalId}`,
+  };
+}
+
+function normaliseVms(raw: RawVmsDevice): InetDevice {
+  const base = normaliseDms(raw);
+  return {
+    ...base,
+    deviceId: packId("vms", base.externalId),
+    subsystem: "vms",
+    name: raw.name ?? `VMS ${base.externalId}`,
+  };
+}
+
+function normaliseVsls(raw: RawVslsDevice): InetDevice {
+  const base = normaliseDms(raw);
+  // VSLS rows are lane-scoped in the source — surface the lane as a
+  // suffix on the name so a gantry's three siblings render distinctly
+  // in the objects list.
+  const laneSuffix = raw.lane ? ` · ${raw.lane}` : "";
+  return {
+    ...base,
+    deviceId: packId("vsls", base.externalId),
+    subsystem: "vsls",
+    name: raw.name ?? `VSLS ${base.externalId}${laneSuffix}`,
+  };
+}
+
+function normaliseRadar(raw: RawRadarDevice): InetDevice {
+  const externalId = raw.deviceId;
+  return {
+    deviceId: packId("radar", externalId),
+    externalId,
+    subsystem: "radar",
+    type: raw.type ?? null,
+    lat: raw.latitude ?? null,
+    lng: raw.longitude ?? null,
+    mileMarker: raw.mileMarker != null ? String(raw.mileMarker) : null,
+    primaryRoad: raw.primaryRoad ?? null,
+    crossRoad: raw.crossRoad ?? null,
+    direction: raw.direction ?? null,
+    routeId: raw.routeId != null ? String(raw.routeId) : null,
+    agency: raw.agency ?? null,
+    name: raw.name ?? `RADAR ${externalId}`,
+    // Bearing is carried on `raw.bearing` — currently no `InetDevice`
+    // column for it, so it stays available via the passthrough Zod
+    // schema when downstream needs it (e.g. map icon rotation). No
+    // media surface for a radar.
+    media: null,
+  };
+}
+
+/** Route each subsystem's raw JSON through its parser + normaliser.
+ *  Returns null on parse failure so the caller can skip the row
+ *  without aborting the page. Keeps `listLive` + `getEntity` free of
+ *  a growing if/else chain per new subsystem. */
+function parseAndNormalise(
+  subsystem: InetSubsystem,
+  raw: unknown,
+): InetDevice | null {
+  switch (subsystem) {
+    case "cctv": {
+      const parsed = RawCctvDeviceSchema.safeParse(raw);
+      return parsed.success ? normaliseCctv(parsed.data) : null;
+    }
+    case "aid": {
+      const parsed = RawAidDeviceSchema.safeParse(raw);
+      return parsed.success ? normaliseAid(parsed.data) : null;
+    }
+    case "dms": {
+      const parsed = RawDmsDeviceSchema.safeParse(raw);
+      return parsed.success ? normaliseDms(parsed.data) : null;
+    }
+    case "vms": {
+      const parsed = RawVmsDeviceSchema.safeParse(raw);
+      return parsed.success ? normaliseVms(parsed.data) : null;
+    }
+    case "vsls": {
+      const parsed = RawVslsDeviceSchema.safeParse(raw);
+      return parsed.success ? normaliseVsls(parsed.data) : null;
+    }
+    case "radar": {
+      const parsed = RawRadarDeviceSchema.safeParse(raw);
+      return parsed.success ? normaliseRadar(parsed.data) : null;
+    }
+  }
 }
 
 /** Decode the NTCIP short-status bitfield into a single human-facing
@@ -223,14 +346,7 @@ export function createInetAtmsConnector(): InetAtmsConnector {
       const items: InetDevice[] = [];
       let freshThisPage = 0;
       for (const entry of raw) {
-        let device: InetDevice | null = null;
-        if (subsystem === "cctv") {
-          const parsed = RawCctvDeviceSchema.safeParse(entry);
-          if (parsed.success) device = normaliseCctv(parsed.data);
-        } else if (subsystem === "dms") {
-          const parsed = RawDmsDeviceSchema.safeParse(entry);
-          if (parsed.success) device = normaliseDms(parsed.data);
-        }
+        const device = parseAndNormalise(subsystem, entry);
         if (!device) continue;
         if (!seenExternalIds.has(device.externalId)) {
           seenExternalIds.add(device.externalId);
@@ -321,12 +437,7 @@ export function createInetAtmsConnector(): InetAtmsConnector {
           unpacked.subsystem,
           `/${unpacked.externalId}`,
         );
-        if (unpacked.subsystem === "cctv") {
-          const parsed = RawCctvDeviceSchema.safeParse(raw);
-          return parsed.success ? normaliseCctv(parsed.data) : null;
-        }
-        const parsed = RawDmsDeviceSchema.safeParse(raw);
-        return parsed.success ? normaliseDms(parsed.data) : null;
+        return parseAndNormalise(unpacked.subsystem, raw);
       } catch {
         return null;
       }
@@ -355,7 +466,9 @@ export function createInetAtmsConnector(): InetAtmsConnector {
       await Promise.all(
         deviceIds.map(async (id) => {
           const unpacked = unpackId(id);
-          if (!unpacked || unpacked.subsystem !== "dms") return;
+          if (!unpacked || !STATUS_ENABLED_SUBSYSTEMS.has(unpacked.subsystem)) {
+            return;
+          }
           try {
             const raw = await client!.getJson<unknown>(
               unpacked.subsystem,

--- a/packages/connectors/src/adapters/inet-atms/fixture.ts
+++ b/packages/connectors/src/adapters/inet-atms/fixture.ts
@@ -128,6 +128,14 @@ export const FIXTURE_DMS_DEVICES: InetDevice[] = [
 export const FIXTURE_DEVICES: Record<InetSubsystem, InetDevice[]> = {
   cctv: FIXTURE_CCTV_DEVICES,
   dms: FIXTURE_DMS_DEVICES,
+  // PSMdt-iNET demo subsystems have no in-package fixtures — a live
+  // source pointed at the `psmdt-inet-mock` deployment carries the
+  // real seeded inventory. Empty arrays keep the record total so
+  // `FIXTURE_DEVICES[subsystem]` never throws on any enum value.
+  aid: [],
+  vms: [],
+  vsls: [],
+  radar: [],
 };
 
 /** Seed status keyed by `deviceId`. Shapes mirror the live Parsons

--- a/packages/connectors/src/adapters/inet-atms/types.ts
+++ b/packages/connectors/src/adapters/inet-atms/types.ts
@@ -20,8 +20,21 @@ import { z } from "zod";
 
 /** Subsystems the adapter understands today. Add new ones to this
  *  union and they automatically appear in the per-tenant multi-select
- *  in the Mobility settings UI. */
-export const INET_SUBSYSTEMS = ["cctv", "dms"] as const;
+ *  in the Mobility settings UI.
+ *
+ *  `aid` / `vms` / `vsls` / `radar` were added to support the PSMdt-iNET
+ *  demo fleet — an on-tenant mock (`psmdt-inet-mock`) mirrors the same
+ *  REST surface as Parsons for these subsystems, so live sources point
+ *  at the mock host and the connector sees identical shapes to `cctv`
+ *  and `dms`. */
+export const INET_SUBSYSTEMS = [
+  "cctv",
+  "dms",
+  "aid",
+  "vms",
+  "vsls",
+  "radar",
+] as const;
 export type InetSubsystem = (typeof INET_SUBSYSTEMS)[number];
 
 /** Per-tenant config persisted with credentials encrypted at rest via
@@ -260,3 +273,51 @@ export const RawDmsDeviceSchema = z
   .passthrough();
 
 export type RawDmsDevice = z.infer<typeof RawDmsDeviceSchema>;
+
+/** VMS (Variable Message Sign) is the regional name for what Parsons
+ *  calls DMS — same wire shape, different label. Alias the schema so
+ *  the adapter code only threads one shape. */
+export const RawVmsDeviceSchema = RawDmsDeviceSchema;
+export type RawVmsDevice = RawDmsDevice;
+
+/** VSLS (Variable Speed Limit Sign) — one row per lane in the source
+ *  workbook, all with an inline status. Field surface matches DMS
+ *  closely, so we reuse that schema with two optional extras. */
+export const RawVslsDeviceSchema = RawDmsDeviceSchema.extend({
+  /** Lane label from the source (`LEFT LANE`, `MIDDLE LANE`, …). */
+  lane: z.string().nullish(),
+  /** Grouping key so the UI can render VSLS gantries as a set. */
+  groupIndex: z.number().int().nullish(),
+});
+export type RawVslsDevice = z.infer<typeof RawVslsDeviceSchema>;
+
+/** AID (Automatic Incident Detection) — a camera whose primary
+ *  output is an event stream, not a video feed. Shape mirrors CCTV
+ *  (they're often co-mounted on the same pole). */
+export const RawAidDeviceSchema = RawCctvDeviceSchema;
+export type RawAidDevice = RawCctvDevice;
+
+/** RADAR / ramp radar — vehicle-detection systems (VDS). No media;
+ *  carries a bearing so the map can rotate the icon. */
+export const RawRadarDeviceSchema = z
+  .object({
+    deviceId: z.union([z.string(), z.number()]).transform(String),
+    externalId: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    type: z.string().nullish(),
+    agency: z.string().nullish(),
+    active: z.boolean().nullish(),
+    latitude: z.number().nullish(),
+    longitude: z.number().nullish(),
+    mileMarker: z.number().nullish(),
+    primaryRoad: z.string().nullish(),
+    crossRoad: z.string().nullish(),
+    direction: z.string().nullish(),
+    routeId: z.union([z.string(), z.number()]).nullish(),
+    /** Facing bearing in degrees (0 = North, 90 = East). Sourced from
+     *  the `Rotation` column in the equipment workbook. */
+    bearing: z.number().nullish(),
+  })
+  .passthrough();
+export type RawRadarDevice = z.infer<typeof RawRadarDeviceSchema>;


### PR DESCRIPTION
## Summary
Extends `@klorad/connectors/inet-atms` to accept four PSMdt-iNET demo subsystems (`aid`, `vms`, `vsls`, `radar`) alongside the existing `cctv` and `dms`. A live Mobility source pointed at the incoming `psmdt-inet-mock` deployment now sees the same field surface for the new subsystems as for real Parsons ones — the sync pipeline flows without further change.

## Why
Parsons' shared iNET tenant only exposes stale demo data, so we're building a self-hosted mock (`psmdt-inet-mock`, standalone repo) to drive the three PSMdt sales scenarios (Response-to-Incident, VMS Inspection, Active Traffic Management). Mock's `/atms/{subsystem}-rest/rest/{subsystem}/` endpoints mirror Parsons byte-for-byte; this PR is the connector-side change that makes the new subsystems valid enum members.

## What changed

**`packages/connectors/src/adapters/inet-atms/types.ts`**
- Extend `INET_SUBSYSTEMS` union with `aid`, `vms`, `vsls`, `radar`.
- Add raw Zod schemas: VMS aliases DMS (same wire shape, regional name), AID aliases CCTV (co-mounted cameras), VSLS extends DMS with `lane` / `groupIndex`, RADAR is a new small shape with an optional `bearing`.

**`packages/connectors/src/adapters/inet-atms/adapter.ts`**
- New `parseAndNormalise(subsystem, raw)` dispatch table — `listLive` and `getEntity` route through one switch instead of a growing if/else chain.
- New `normaliseAid` / `normaliseVms` / `normaliseVsls` / `normaliseRadar` — all thin wrappers over the parent normaliser (except radar, standalone).
- `unpackId` accepts any value in `INET_SUBSYSTEMS`.
- `getStatus` fans out `/status` for `dms | vms | vsls`; cctv/aid/radar have no documented status endpoint.

**`packages/connectors/src/adapters/inet-atms/fixture.ts`**
- Empty arrays for the four new subsystems so `FIXTURE_DEVICES` is total for every enum value. Live-mode sources pointed at the mock carry the real seed.

**`apps/mobility/.../sources/SourcesClient.tsx`**
- Replace the two hardcoded `CCTV` / `DMS` checkboxes with a map over `INET_SUBSYSTEMS`. Selection tracked as `Set<string>` so the next connector-side enum addition surfaces with no UI change. Default set stays `{cctv, dms}`.

## Follow-ups (out of scope)
Per-subsystem icons + drawer content in `Operator.tsx`, `WorldViewer.tsx`, `WorldEditor.tsx`, `DiscoveredClient.tsx`, `AlertsClient.tsx` — currently the new subsystems fall through to the generic `Radio` icon and a bare drawer. Functional but not branded; a small design pass unblocks that later.

## Test plan
- [x] `pnpm --filter @klorad/connectors build` — passes.
- [x] `pnpm exec tsc --noEmit` in `apps/mobility` — passes.
- [ ] Create a Mobility source with `host = https://mock.psmdt-inet.dev`, enable all six subsystems, run Sync — inventory populates with mock-served rows.
- [ ] Deploy the mock (follow-up PR against `psmdt-inet-mock`), point a real Mobility source at it, verify sync-status polling for VMS + VSLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)