### PR TITLE
fix(mock-inet): drop DB audit from Vercel build

### DIFF
--- a/apps/mock-inet/vercel.json
+++ b/apps/mock-inet/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
-  "buildCommand": "cd ../.. && pnpm --filter @klorad/dev-audits build && pnpm audits:light && pnpm vercel:build:mock-inet",
+  "//": "Skip the light audits step other apps run — the DATABASE_URL check in @klorad/dev-audits assumes every app hits Prisma, but the mock is stateless (no DB, no Prisma). Build stays limited to the app's own build script.",
+  "buildCommand": "cd ../.. && pnpm vercel:build:mock-inet",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile --prod=false",
   "framework": "nextjs",
   "regions": ["fra1"],


### PR DESCRIPTION
## Summary
Vercel build for the mock's own project (`apps/mock-inet`) fails at the shared `audits:light` step:

```
❌ Environment Variables
  🔴 Missing required env var: DATABASE_URL (PostgreSQL or Prisma Accelerate connection string)
```

The audit assumes every app hits Prisma. The mock is deliberately stateless — no Prisma, no DB — so this is a false positive that blocks the deploy.

## Fix
Scope the mock's `vercel.json` build command down to just `pnpm vercel:build:mock-inet`. Other apps still run the audit on their own Vercel projects (they have DB config), so this is a per-app relaxation, not a repo-wide one.

## Test plan
- [ ] Merge, redeploy the mock — build passes.
- [ ] Regression: other apps' deploys still fail cleanly if they're missing `DATABASE_URL` (their `vercel.json` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)