### PR TITLE
fix(mock-inet): drop unrecognised comment key from vercel.json

### DIFF
--- a/apps/mock-inet/vercel.json
+++ b/apps/mock-inet/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-  "//": "Skip the light audits step other apps run — the DATABASE_URL check in @klorad/dev-audits assumes every app hits Prisma, but the mock is stateless (no DB, no Prisma). Build stays limited to the app's own build script.",
   "buildCommand": "cd ../.. && pnpm vercel:build:mock-inet",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile --prod=false",
   "framework": "nextjs",


### PR DESCRIPTION
## Summary
Vercel's config schema rejects unknown top-level keys with:
```
Invalid request: should NOT have additional property "//"
```

I added a `"//"` field to `apps/mock-inet/vercel.json` in #241 as an inline explanation of why the audits step is skipped. JSON has no comment syntax, and Vercel's validator refuses to load the config — so the buildCommand override from #241 never actually took effect. That's why the same audits-error keeps appearing on the mock's deploys.

## Fix
Drop the `"//"` field. Comment lives in the git log now.

## After merge
The next deploy off `main` (or a "Redeploy → without cache" on the current one) should load the config cleanly and skip the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)