### PR TITLE
feat(mobility): per-subsystem icons for aid/vms/vsls/radar

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -14,7 +14,6 @@ import {
   ArrowUpRight,
   Bell,
   Box,
-  Camera,
   CheckCircle2,
   Compass,
   Copy,
@@ -35,6 +34,7 @@ import {
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { subsystemIcon } from "@/lib/mobility/subsystem-icon";
 import { DmsFace } from "@/lib/mobility/dms-render";
 import {
   applyMapEnvSettings,
@@ -1180,9 +1180,7 @@ function DeviceDrawer({
     [key: string]: unknown;
   };
 
-  const subsystemIcon: LucideIcon =
-    device.subsystem === "cctv" ? Camera : device.subsystem === "dms" ? Signpost : Radio;
-  const SubsystemIcon = subsystemIcon;
+  const SubsystemIcon: LucideIcon = subsystemIcon(device.subsystem);
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/AlertsClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/AlertsClient.tsx
@@ -4,18 +4,16 @@ import { useMemo, useState } from "react";
 import useSWR from "swr";
 import Link from "next/link";
 import {
-  AlertTriangle,
   ArrowRight,
   Bell,
-  Camera,
   CheckCircle2,
   Database,
   RefreshCcw,
   ShieldOff,
-  Signpost,
   WifiOff,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { subsystemIcon } from "@/lib/mobility/subsystem-icon";
 
 interface AlertRow {
   deviceId: string;
@@ -205,12 +203,7 @@ function AlertItem({
   alert: AlertRow;
   openHref: string;
 }) {
-  const SubsystemIcon =
-    alert.subsystem === "cctv"
-      ? Camera
-      : alert.subsystem === "dms"
-        ? Signpost
-        : AlertTriangle;
+  const SubsystemIcon: LucideIcon = subsystemIcon(alert.subsystem);
   const kindIcon = alert.kind === "offline" ? WifiOff : ShieldOff;
   const KindIcon = kindIcon;
   return (

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/devices/DevicesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/devices/DevicesClient.tsx
@@ -6,18 +6,21 @@ import Link from "next/link";
 import { toast } from "react-toastify";
 import {
   ArrowRight,
-  Camera,
   CheckCircle2,
   Eye,
   EyeOff,
   Layers,
   RefreshCcw,
   Search,
-  Signpost,
   TrafficCone,
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { INET_SUBSYSTEMS } from "@klorad/connectors/inet-atms";
+import {
+  subsystemDescriptor,
+  subsystemIcon,
+} from "@/lib/mobility/subsystem-icon";
 
 interface DeviceRow {
   id: string;
@@ -50,7 +53,10 @@ const fetcher = (url: string) =>
   });
 
 type StatusFilter = "all" | "needs-review" | "included" | "public" | "catalog";
-type SubsystemFilter = "all" | "cctv" | "dms";
+// Kept as a wide `string` so the picker survives future additions to
+// `INET_SUBSYSTEMS` without a code change here — the filter chip row
+// is generated from that enum below.
+type SubsystemFilter = "all" | string;
 
 export function DevicesClient({
   orgId,
@@ -228,8 +234,13 @@ export function DevicesClient({
           value={subsystem}
           options={[
             { value: "all", label: "All types" },
-            { value: "cctv", label: "CCTV", icon: Camera },
-            { value: "dms", label: "DMS", icon: Signpost },
+            // Emit one chip per connector-known subsystem so the
+            // demo enums (aid / vms / vsls / radar) surface without
+            // touching this file.
+            ...INET_SUBSYSTEMS.map((s) => {
+              const d = subsystemDescriptor(s);
+              return { value: s, label: d.label, icon: d.icon };
+            }),
           ]}
           onChange={(v) => setSubsystem(v as SubsystemFilter)}
         />
@@ -358,8 +369,7 @@ function DeviceRow({
   selected: boolean;
   onToggle: () => void;
 }) {
-  const SubsystemIcon =
-    device.subsystem === "cctv" ? Camera : device.subsystem === "dms" ? Signpost : Layers;
+  const SubsystemIcon: LucideIcon = subsystemIcon(device.subsystem);
   return (
     <li
       className={`flex items-center gap-3 px-4 py-3 transition-colors ${

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/discovered/DiscoveredClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/discovered/DiscoveredClient.tsx
@@ -6,18 +6,16 @@ import Link from "next/link";
 import { toast } from "react-toastify";
 import {
   ArrowRight,
-  Camera,
   CheckCircle2,
   Database,
   Eye,
   Inbox,
   Layers,
   RefreshCcw,
-  Signpost,
-  TrafficCone,
   XCircle,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { subsystemIcon } from "@/lib/mobility/subsystem-icon";
 
 interface Device {
   id: string;
@@ -297,12 +295,7 @@ function DeviceRow({
   busy: boolean;
   onAct: (action: Action) => void;
 }) {
-  const SubsystemIcon =
-    device.subsystem === "cctv"
-      ? Camera
-      : device.subsystem === "dms"
-        ? Signpost
-        : TrafficCone;
+  const SubsystemIcon: LucideIcon = subsystemIcon(device.subsystem);
   return (
     <li className="grid items-center gap-3 px-5 py-3 md:grid-cols-[auto_1fr_auto]">
       <span

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
@@ -9,7 +9,6 @@ import {
   ArrowLeft,
   BarChart3,
   Bell,
-  Camera,
   Check,
   Copy,
   Download,
@@ -23,11 +22,11 @@ import {
   Palette,
   Search,
   Send,
-  Signpost,
   Trash2,
   Users,
   type LucideIcon,
 } from "lucide-react";
+import { subsystemIcon as pickSubsystemIcon } from "@/lib/mobility/subsystem-icon";
 
 type Visibility = "public" | "linkOnly" | "authenticated";
 
@@ -1046,13 +1045,8 @@ function BroadcastCard({ world }: { world: World }) {
 }
 
 function SubsystemIcon({ subsystem }: { subsystem: string }) {
-  if (subsystem === "cctv") {
-    return <Camera size={12} strokeWidth={1.8} className="text-text-tertiary" aria-hidden />;
-  }
-  if (subsystem === "dms") {
-    return <Signpost size={12} strokeWidth={1.8} className="text-text-tertiary" aria-hidden />;
-  }
-  return <MapPin size={12} strokeWidth={1.8} className="text-text-tertiary" aria-hidden />;
+  const Icon = pickSubsystemIcon(subsystem);
+  return <Icon size={12} strokeWidth={1.8} className="text-text-tertiary" aria-hidden />;
 }
 
 function VisibilityOption({

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -9,18 +9,16 @@ import mapboxgl, {
 import {
   ArrowLeft,
   Box,
-  Camera,
   Layers as LayersIcon,
   MapPin,
   Moon,
   Mountain,
-  Radio,
   Settings,
-  Signpost,
   Sun,
   Sunrise,
   Sunset,
 } from "lucide-react";
+import { subsystemIcon } from "@/lib/mobility/subsystem-icon";
 import type { PublicWorldDevice } from "@/lib/mobility/world-resolver";
 import {
   applyMapEnvSettings,
@@ -975,12 +973,7 @@ function DeviceDrawer({
   onClose: () => void;
 }) {
   if (!device) return null;
-  const Icon =
-    device.subsystem === "cctv"
-      ? Camera
-      : device.subsystem === "dms"
-        ? Signpost
-        : Radio;
+  const Icon = subsystemIcon(device.subsystem);
 
   return (
     <aside

--- a/apps/mobility/lib/mobility/subsystem-icon.ts
+++ b/apps/mobility/lib/mobility/subsystem-icon.ts
@@ -1,0 +1,75 @@
+/**
+ * Central lookup for subsystem → icon + label. Every UI surface that
+ * renders a device row (Operator drawer, public WorldViewer, Discovered
+ * list, Alerts feed, DevicesClient table, WorldEditor filter chips) used
+ * to hardcode a `cctv → Camera / dms → Signpost / else → Radio`
+ * ternary. Adding a new subsystem — as we did for the PSMdt-iNET demo
+ * (aid / vms / vsls / radar) — required editing every one of those
+ * files. This helper puts the mapping in one place.
+ *
+ * When a new subsystem lands in `@klorad/connectors/inet-atms`
+ * `INET_SUBSYSTEMS`, add a case here and every consumer picks it up.
+ */
+import {
+  Camera,
+  Gauge,
+  Radar,
+  Radio,
+  ScanEye,
+  Signpost,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface SubsystemDescriptor {
+  /** Component to render — always the same shape as `Camera` /
+   *  `Signpost` so consumers can keep their existing `<Icon .../>` sites
+   *  untouched. */
+  icon: LucideIcon;
+  /** Short label suitable for a badge or chip. Falls back to the raw
+   *  subsystem string when there's no branded label. */
+  label: string;
+}
+
+/**
+ * The `subsystem` field on `MobilityDevice` is a free-text string
+ * chosen by the connector. Historically it's been one of the values
+ * below, but we don't want a strict enum here so the UI keeps
+ * rendering *something* if a future connector emits a new value.
+ */
+export function subsystemDescriptor(subsystem: string | null | undefined): SubsystemDescriptor {
+  switch ((subsystem ?? "").toLowerCase()) {
+    case "cctv":
+      return { icon: Camera, label: "CCTV" };
+    case "aid":
+      // Automated Incident Detection — a camera that watches for
+      // events rather than serving a live feed. `ScanEye` reads as
+      // "camera + attention" which matches the pitch language.
+      return { icon: ScanEye, label: "AID" };
+    case "dms":
+      return { icon: Signpost, label: "DMS" };
+    case "vms":
+      // Variable Message Sign — same wire shape as DMS, different
+      // regional name. Reuse the sign icon.
+      return { icon: Signpost, label: "VMS" };
+    case "vsls":
+      // Variable Speed Limit Signs. Gauge reads as speed.
+      return { icon: Gauge, label: "VSLS" };
+    case "radar":
+      return { icon: Radar, label: "RADAR" };
+    default:
+      return {
+        icon: Radio,
+        label: (subsystem ?? "").toUpperCase() || "DEVICE",
+      };
+  }
+}
+
+/** Sugar for the common site — `const Icon = subsystemIcon(device.subsystem)`. */
+export function subsystemIcon(subsystem: string | null | undefined): LucideIcon {
+  return subsystemDescriptor(subsystem).icon;
+}
+
+/** Sugar for badge / chip text. */
+export function subsystemLabel(subsystem: string | null | undefined): string {
+  return subsystemDescriptor(subsystem).label;
+}


### PR DESCRIPTION
## Summary
The four new PSMdt-iNET demo subsystems from #239 (`aid`, `vms`, `vsls`, `radar`) were rendering with generic fallback icons across every UI surface — different in each file, wrong everywhere. A radar showing as a Radio icon reads badly in the pitch demo.

## What changed
New `apps/mobility/lib/mobility/subsystem-icon.ts` centralises the mapping. When a new subsystem lands in `@klorad/connectors/inet-atms` `INET_SUBSYSTEMS`, add one `case` in the helper and every consumer picks it up.

Icons:
| Subsystem | Icon | Note |
|---|---|---|
| `cctv` | Camera | unchanged |
| `aid`  | ScanEye | reads as "camera + attention" |
| `dms`  | Signpost | unchanged |
| `vms`  | Signpost | same wire shape as DMS, regional name |
| `vsls` | Gauge | speed indicator |
| `radar`| Radar | Lucide has it exactly |
| _fallback_ | Radio | matches historic default |

## Callsites collapsed
- **Operator.tsx** — drawer header icon
- **WorldViewer.tsx** (public) — bottom-sheet device drawer
- **DiscoveredClient.tsx** — needs-review row icon
- **AlertsClient.tsx** — alert row icon
- **DevicesClient.tsx** — table row icon AND the filter chip group. Chips are now generated from `INET_SUBSYSTEMS`, so operators can filter by any of the six subsystems (previously chips were hardcoded to cctv/dms only). Filter type widened from a strict union to `"all" | string` so future enum additions surface with no code change here.
- **WorldEditor.tsx** — the tiny inline `<SubsystemIcon />` helper now delegates to the shared function.

## Test plan
- [ ] Sync devices from the mock (or any iNET source with all six subsystems enabled) → open Operator → click a radar device → drawer shows a Radar icon in the header, not a Radio.
- [ ] Open Devices page → filter chip row shows CCTV / AID / DMS / VMS / VSLS / RADAR each with their own icon.
- [ ] Open the public World viewer for a mixed-subsystem world → each device's bottom-sheet drawer picks up the correct icon.
- [ ] Alerts and Discovered lists similarly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)