### PR TITLE
fix(mobility): backfill mock status + AID/RADAR drawer + DMS alias

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -1306,8 +1306,11 @@ function DeviceDrawer({
                 </div>
               )}
 
-            {/* CCTV stream */}
-            {device.subsystem === "cctv" &&
+            {/* CCTV / AID stream — AID cameras run the same
+                hlsUri / snapshot fallback chain as CCTV; separating
+                them here would just duplicate the render blocks. */}
+            {(device.subsystem === "cctv" ||
+              device.subsystem === "aid") &&
               payload.media?.kind === "cctv-stream" && (
                 <div className="overflow-hidden rounded-xl border border-line-soft bg-black">
                   <video
@@ -1320,20 +1323,39 @@ function DeviceDrawer({
                 </div>
               )}
 
-            {/* CCTV snapshot — refresh every 5 s with a cache-busting
-                query so the still updates without a manual reload. */}
-            {device.subsystem === "cctv" &&
+            {/* CCTV / AID snapshot — refresh every 5 s with a
+                cache-busting query so the still updates without a
+                manual reload. */}
+            {(device.subsystem === "cctv" ||
+              device.subsystem === "aid") &&
               payload.media?.kind === "cctv-snapshot" && (
                 <CctvSnapshot url={payload.media.url} alt={device.name} />
               )}
 
-            {/* CCTV without any media URL — say so explicitly instead
-                of leaving a blank panel below the status. */}
-            {device.subsystem === "cctv" && !payload.media && (
-              <div className="rounded-xl border border-line-soft bg-surface-2 p-5 text-center text-xs text-text-tertiary">
-                No live stream or snapshot URL is configured for this
-                camera on the source.
-              </div>
+            {/* CCTV / AID without any media URL — say so explicitly
+                instead of leaving a blank panel below the status. */}
+            {(device.subsystem === "cctv" ||
+              device.subsystem === "aid") &&
+              !payload.media && (
+                <div className="rounded-xl border border-line-soft bg-surface-2 p-5 text-center text-xs text-text-tertiary">
+                  No live stream or snapshot URL is configured for this
+                  camera on the source.
+                </div>
+              )}
+
+            {/* AID event stats — the source's status blob carries a
+                count + last-detection timestamp; surface them as a
+                small tile so AID cameras aren't just "connectable". */}
+            {device.subsystem === "aid" && live?.status && (
+              <AidEventTile status={live.status.raw as Record<string, unknown>} />
+            )}
+
+            {/* RADAR / VDS live telemetry — volume, mean speed, lane
+                occupancy sampled from the source. Shows nothing when
+                the source didn't return traffic fields (older mocks,
+                unconfigured devices) so the drawer stays clean. */}
+            {device.subsystem === "radar" && live?.status && (
+              <RadarTelemetryTile status={live.status.raw as Record<string, unknown>} />
             )}
           </div>
         )}
@@ -1415,6 +1437,112 @@ function CctvSnapshot({ url, alt }: { url: string; alt: string }) {
       <p className="px-3 py-1.5 text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
         Snapshot · refreshing every 5 s
       </p>
+    </div>
+  );
+}
+
+/* ─── AID event tile ───────────────────────────────────────────────── */
+
+/**
+ * Compact panel for AID cameras — surfaces the incident-count and
+ * last-detection timestamp the source ships in the status blob. Falls
+ * back gracefully when either field is missing so the drawer stays
+ * clean on hosts that don't report them.
+ */
+function AidEventTile({ status }: { status: Record<string, unknown> }) {
+  const eventCount =
+    typeof status.eventCount === "number" ? status.eventCount : null;
+  const lastDetection =
+    typeof status.lastDetection === "string" ? status.lastDetection : null;
+  const message =
+    typeof status.message === "string" ? status.message : null;
+
+  if (eventCount === null && !lastDetection && !message) return null;
+
+  return (
+    <div className="rounded-xl border border-line-soft bg-surface-2 p-4">
+      <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
+        Automated Incident Detection
+      </div>
+      <div className="flex items-baseline gap-3">
+        {eventCount !== null && (
+          <span className="text-2xl font-semibold text-text-primary">
+            {eventCount}
+          </span>
+        )}
+        {message && (
+          <span className="text-sm text-text-secondary">{message}</span>
+        )}
+      </div>
+      {lastDetection && (
+        <div className="mt-2 text-[11px] text-text-tertiary">
+          Last detection · {relativeFrom(lastDetection)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Radar / VDS telemetry tile ───────────────────────────────────── */
+
+/**
+ * Traffic snapshot for RADAR / RAMP RADAR / RM RADAR devices — the
+ * `volume`, `speed`, and `occupancy` fields that iNET's VDS surface
+ * exposes for each detector. Three-column tile so the drawer reads
+ * as a scanner readout, not a wall of text.
+ */
+function RadarTelemetryTile({ status }: { status: Record<string, unknown> }) {
+  const volume = typeof status.volume === "number" ? status.volume : null;
+  const speed = typeof status.speed === "number" ? status.speed : null;
+  const occupancy =
+    typeof status.occupancy === "number" ? status.occupancy : null;
+
+  if (volume === null && speed === null && occupancy === null) return null;
+
+  return (
+    <div className="rounded-xl border border-line-soft bg-surface-2 p-4">
+      <div className="mb-3 text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
+        Traffic sensor
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        <RadarStat label="Volume" value={volume} unit="veh/min" />
+        <RadarStat label="Speed" value={speed} unit="km/h" />
+        <RadarStat
+          label="Occupancy"
+          value={
+            occupancy !== null
+              ? Math.round(occupancy * 100)
+              : null
+          }
+          unit="%"
+        />
+      </div>
+    </div>
+  );
+}
+
+function RadarStat({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value: number | null;
+  unit: string;
+}) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
+        {label}
+      </div>
+      <div className="mt-1 flex items-baseline gap-1">
+        <span className="text-xl font-semibold text-text-primary">
+          {value ?? "—"}
+        </span>
+        {value !== null && (
+          <span className="text-[11px] text-text-tertiary">{unit}</span>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/mock-inet/app/atms/[...path]/route.ts
+++ b/apps/mock-inet/app/atms/[...path]/route.ts
@@ -20,7 +20,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBasicAuth } from "@/lib/auth";
 import {
+  currentStatus,
   deviceByExternalId,
+  fetchFromSubsystem,
   pageDevices,
   parseSubsystem,
 } from "@/lib/devices";
@@ -68,7 +70,11 @@ function listResponse(subsystem: Subsystem, request: NextRequest) {
   const lng = url.searchParams.has("lng")
     ? Number(url.searchParams.get("lng"))
     : undefined;
-  const items = pageDevices(subsystem, {
+  // `dms` is aliased to `vms` — see `fetchFromSubsystem`. The
+  // connector doesn't read the response's `subsystem` field (it
+  // packs its own from the config), so returning VMS-shaped rows
+  // verbatim under the DMS path is safe.
+  const items = pageDevices(fetchFromSubsystem(subsystem), {
     limit,
     startId,
     query,
@@ -79,18 +85,24 @@ function listResponse(subsystem: Subsystem, request: NextRequest) {
 }
 
 function singleResponse(subsystem: Subsystem, externalId: string) {
-  const device = deviceByExternalId(subsystem, externalId);
+  const device = deviceByExternalId(
+    fetchFromSubsystem(subsystem),
+    externalId,
+  );
   if (!device) return notFound();
   return NextResponse.json(device);
 }
 
 function statusResponse(subsystem: Subsystem, externalId: string) {
-  // Only DMS-family devices carry a distinct status shape. Parsons
-  // tolerates the /status suffix on any device but returns null or an
-  // empty object for cctv/aid/radar — mirror that.
-  const device = deviceByExternalId(subsystem, externalId);
+  const device = deviceByExternalId(
+    fetchFromSubsystem(subsystem),
+    externalId,
+  );
   if (!device) return notFound();
-  return NextResponse.json(device.status ?? {});
+  // Live per-subsystem status — see `currentStatus()`. CCTV / AID /
+  // RADAR now return sensible shapes instead of `{}` so the operator
+  // drawer has data to render.
+  return NextResponse.json(currentStatus(device));
 }
 
 function notFound() {

--- a/apps/mock-inet/lib/devices.ts
+++ b/apps/mock-inet/lib/devices.ts
@@ -121,3 +121,120 @@ export function filterDevices(filter: WorldFilter): Device[] {
 export function parseSubsystem(value: string): Subsystem | null {
   return isSubsystem(value) ? value : null;
 }
+
+/**
+ * Alias `dms` → `vms` so the legacy Parsons subsystem name serves the
+ * same data as its regional twin. Our source workbook only has
+ * VMS-shaped rows; without this alias, `/atms/dms-rest/rest/dms/`
+ * returns [] and Mobility sources that tick "DMS" get nothing.
+ *
+ * Note: if an operator ticks *both* dms and vms on their source,
+ * they'll double-sync the same physical signs (once as vms:… and
+ * once as dms:…, different packed ids). Pick one — VMS is the
+ * canonical name for our data.
+ */
+export function fetchFromSubsystem(requested: Subsystem): Subsystem {
+  return requested === "dms" ? "vms" : requested;
+}
+
+/**
+ * Per-subsystem live status — what the per-device status endpoint
+ * (path shape `/atms/{sub}-rest/rest/{sub}/{id}/status`) returns.
+ * VMS/VSLS/DMS reuse the pre-baked DMS-shaped status from the seed.
+ * CCTV/AID/RADAR get lightweight computed shapes so the Mobility
+ * drawer has something to render for them (previously radar and aid
+ * showed "no live data — the source returned no current status").
+ *
+ * All shapes carry `signId`, `connectable`, `timestamp` so the
+ * connector's normaliser (`RawStatusSchema` — every field `.nullish()`
+ * and `.passthrough()`) accepts them. Subsystem-specific extras
+ * (volume/speed for radar, eventCount for aid) pass through into the
+ * drawer's `live.status.raw` blob.
+ */
+export function currentStatus(device: Device): Record<string, unknown> {
+  const now = Date.now();
+  const base = {
+    signId: device.externalId,
+    connectable: true,
+    timestamp: now,
+  };
+
+  switch (device.subsystem) {
+    case "vms":
+    case "vsls":
+    case "dms":
+      return device.status
+        ? { ...device.status, timestamp: now }
+        : base;
+
+    case "cctv":
+      // Cameras have no NTCIP-style status on Parsons — just report
+      // reachability and let the drawer render the stream URL.
+      return base;
+
+    case "aid": {
+      // Fake event count + last detection driven by the current hour
+      // so successive polls tell a coherent story within a demo.
+      const hourBucket = Math.floor(now / 3_600_000);
+      const seed =
+        [...device.externalId].reduce((a, c) => a + c.charCodeAt(0), 0) +
+        hourBucket;
+      const eventCount = seed % 5;
+      const minutesAgo = seed % 55;
+      return {
+        ...base,
+        eventCount,
+        lastDetection:
+          eventCount > 0
+            ? new Date(now - minutesAgo * 60_000).toISOString()
+            : null,
+        message:
+          eventCount > 0
+            ? `${eventCount} incident${eventCount === 1 ? "" : "s"} detected in the last hour`
+            : "No incidents detected",
+      };
+    }
+
+    case "radar": {
+      // Synthetic traffic snapshot per radar. Deterministic per
+      // device + 5-second time bucket so successive polls return the
+      // same values within a bucket and vary between — reads as
+      // "live but not jittery" for a demo. Rush-hour bump matches
+      // the pattern in `lib/vds.ts`.
+      const bucket = Math.floor(now / 5000);
+      const seed =
+        [...device.externalId].reduce((a, c) => a + c.charCodeAt(0), 0) +
+        bucket;
+      const rush = isRushHour(now);
+      const baseVolume = rush ? 90 : 40;
+      const baseSpeed = rush ? 65 : 95;
+      const jitter = () => ((seed * 9301 + 49297) % 233280) / 233280 - 0.5;
+      const volume = Math.max(0, Math.round(baseVolume + jitter() * 20));
+      const speed = Math.max(5, Math.round(baseSpeed + jitter() * 12));
+      const occupancy = Math.min(1, Math.max(0, volume / 120));
+      return {
+        ...base,
+        volume,
+        speed,
+        occupancy: Number(occupancy.toFixed(3)),
+        perLane: [1, 2, 3].map((lane) => ({
+          lane,
+          volume: Math.max(0, Math.round(volume / 3 + jitter() * 6)),
+          speed: Math.max(5, Math.round(speed + jitter() * 5)),
+          occupancy: Number(
+            Math.min(1, Math.max(0, occupancy + jitter() * 0.05)).toFixed(3),
+          ),
+        })),
+      };
+    }
+  }
+}
+
+function isRushHour(now: number): boolean {
+  const d = new Date(now);
+  const minutes = d.getHours() * 60 + d.getMinutes();
+  return (
+    (minutes >= 7 * 60 + 30 && minutes < 9 * 60 + 30) ||
+    (minutes >= 17 * 60 && minutes < 19 * 60)
+  );
+}

--- a/apps/mock-inet/lib/types.ts
+++ b/apps/mock-inet/lib/types.ts
@@ -79,8 +79,12 @@ export interface Device {
   signType: number | null;
   pixelWidth: number | null;
   pixelHeight: number | null;
-  /** Only inline on DMS/VMS list responses. */
-  status: DmsStatus | null;
+  /** Inline snapshot for DMS/VMS/VSLS list responses. Other subsystems
+   *  (cctv/aid/radar) get status generated live at request time by
+   *  `currentStatus()` — see `lib/devices.ts`. Typed loosely because
+   *  the shape differs per subsystem; the connector accepts any
+   *  passthrough. */
+  status: Record<string, unknown> | null;
 
   // VSLS
   lane: string | null;

--- a/packages/connectors/src/adapters/inet-atms/adapter.ts
+++ b/packages/connectors/src/adapters/inet-atms/adapter.ts
@@ -51,14 +51,23 @@ import {
   type RawVslsDevice,
 } from "./types.js";
 
-/** Subsystems that expose a `/status` endpoint the same way DMS does.
- *  VMS is the regional alias for DMS; VSLS is the same wire shape with
- *  an added lane label. CCTV / AID / RADAR don't advertise a
- *  documented status endpoint on the ATMS surface. */
+/** Subsystems that expose a `/status` endpoint. Parsons only documents
+ *  the DMS shape (and VMS is the regional alias for the same); we
+ *  extend to CCTV / AID / RADAR here so the operator drawer can show
+ *  reachability + subsystem-specific telemetry for the PSMdt demo
+ *  fleet. The tolerant `RawStatusSchema.passthrough()` in `types.ts`
+ *  accepts whatever the source returns — subsystem-specific fields
+ *  (radar's volume/speed, aid's eventCount) reach the drawer via
+ *  `InetStatus.raw`. Hosts that don't implement `/status` for these
+ *  subsystems return an empty body and we silently skip them (the
+ *  fan-out is a `try/catch`, no crash on 404). */
 const STATUS_ENABLED_SUBSYSTEMS: ReadonlySet<InetSubsystem> = new Set([
+  "cctv",
   "dms",
   "vms",
   "vsls",
+  "aid",
+  "radar",
 ]);
 
 const DEFAULT_PAGE_SIZE = 200;


### PR DESCRIPTION
## Summary

Three fixes that unblock AID, RADAR, and DMS in the PSMdt-iNET demo:

- **DMS empty** — `/atms/dms-rest/rest/dms/` now serves VMS-shaped rows via `fetchFromSubsystem()`. Our workbook has no DMS-native rows, so an operator ticking DMS on their source used to get an empty sync.
- **AID / RADAR "no live data"** — mock's `currentStatus()` now generates per-subsystem shapes at request time:
  - `cctv` → reachability stub
  - `aid` → hour-bucketed `eventCount` / `lastDetection` / `message`
  - `radar` → 5-second bucketed `volume` / `speed` / `occupancy` / `perLane` with a rush-hour multiplier
  - `vms` / `vsls` / `dms` — pre-baked shape, fresh timestamp
- **Connector** — extended `STATUS_ENABLED_SUBSYSTEMS` from `[dms, vms, vsls]` to include `cctv`, `aid`, `radar`. Hosts that don't implement `/status` for a subsystem are already tolerated (try/catch fan-out).
- **Mobility Operator drawer** — widened the CCTV video-panel gate to also cover `aid` (they share the media path), plus new `AidEventTile` and `RadarTelemetryTile` blocks that read from `live.status.raw` (no schema change).

## Test plan

- [ ] After merge → redeploy mock to Vercel
- [ ] `curl https://klorad-mock-inet.vercel.app/atms/dms-rest/rest/dms/` returns VMS rows (not `[]`)
- [ ] `curl https://klorad-mock-inet.vercel.app/atms/aid-rest/rest/aid/{id}/status` returns `{signId, connectable, timestamp, eventCount, lastDetection, message}`
- [ ] `curl https://klorad-mock-inet.vercel.app/atms/radar-rest/rest/radar/{id}/status` returns `{signId, connectable, timestamp, volume, speed, occupancy, perLane}`
- [ ] In Mobility Operator drawer: AID device shows video-panel + event tile; RADAR device shows telemetry tile
- [ ] DMS sync on a source with the `dms` subsystem ticked pulls devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)