### PR TITLE
feat(mobility): real live data in operator drawer for every subsystem

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -1281,8 +1281,15 @@ function DeviceDrawer({
               </span>
             </div>
 
-            {/* DMS face */}
-            {device.subsystem === "dms" &&
+            {/* DMS / VMS / VSLS face — all three subsystems share the
+                same NTCIP status shape (`message`, `brightness`,
+                `maxLinesPerPage`, `maxCharsPerLine`). The DmsFace
+                renderer scales to the reported grid size, so a VSLS
+                24×24 panel showing "80" and a VMS 84×7 running "TRAFFIC
+                AHEAD" both render correctly from the same block. */}
+            {(device.subsystem === "dms" ||
+              device.subsystem === "vms" ||
+              device.subsystem === "vsls") &&
               typeof live.status.raw.message === "string" && (
                 <div className="rounded-xl border border-line-soft bg-black p-3">
                   <DmsFace
@@ -1360,9 +1367,14 @@ function DeviceDrawer({
           </div>
         )}
 
-        {/* DMS sign details — surface the rich status data the
-            renderer doesn't show otherwise. */}
-        {device.subsystem === "dms" && live?.status && (
+        {/* DMS / VMS / VSLS sign details — surface the rich status
+            data (short status, control mode, brightness/photocell
+            levels, beacon) the face renderer doesn't show. Same
+            shape across all three sign families. */}
+        {(device.subsystem === "dms" ||
+          device.subsystem === "vms" ||
+          device.subsystem === "vsls") &&
+          live?.status && (
           <DmsSignDetails
             status={live.status.raw as Record<string, unknown>}
             payload={payload as Record<string, unknown>}

--- a/apps/mobility/app/api/devices/[deviceId]/live/route.ts
+++ b/apps/mobility/app/api/devices/[deviceId]/live/route.ts
@@ -29,8 +29,6 @@ export async function GET(
       projectId: true,
       subsystem: true,
       externalDeviceId: true,
-      payload: true,
-      lastSeenAt: true,
       source: {
         select: {
           label: true,
@@ -78,41 +76,21 @@ export async function GET(
       urls: {
         list: `${base}/`,
         device: `${base}/${externalId}`,
-        // CCTV has no per-id /status endpoint in iNET; null signals
-        // that to the UI.
-        status: subsystem === "dms" ? `${base}/${externalId}/status` : null,
+        // Every iNET subsystem the connector talks to now exposes a
+        // per-id /status endpoint (mock or upstream) — surface the
+        // URL so the drawer's debug panel is honest about where the
+        // live payload came from.
+        status: `${base}/${externalId}/status`,
       },
     };
   }
   const source = describeSource();
 
-  // CCTV — iNET exposes no per-id status endpoint. The "live" signal
-  // is the video stream itself plus the device's `active` flag from
-  // the last sync; synthesise a status from the cached payload so
-  // the drawer doesn't show "No live data" for every camera.
-  if (device.subsystem === "cctv") {
-    const payload = device.payload as Record<string, unknown> | null;
-    const active =
-      payload && typeof payload.active === "boolean"
-        ? (payload.active as boolean)
-        : true;
-    return NextResponse.json({
-      status: {
-        online: active,
-        alarm: null,
-        observedAt: device.lastSeenAt.toISOString(),
-        raw: {
-          active,
-          note:
-            "CCTV has no per-device status endpoint; live signal is the stream.",
-        },
-      },
-      source,
-    });
-  }
-
-  // DMS — call the connector's getStatus. The adapter keys results
-  // by the *packed* id (e.g. `dms:21413`), so build that explicitly.
+  // All subsystems — call the connector's getStatus. The adapter keys
+  // results by the *packed* id (e.g. `dms:21413`), so build that
+  // explicitly. Subsystems whose upstream doesn't implement /status
+  // return an empty record and the drawer shows "no live data" — the
+  // connector's fan-out already tolerates 404s.
   try {
     const connector = await buildConnector({
       connectorId: device.source.connectorId,

--- a/apps/mock-inet/scripts/build-seed-from-csv.ts
+++ b/apps/mock-inet/scripts/build-seed-from-csv.ts
@@ -192,19 +192,24 @@ function rowToDevice(subsystem: Subsystem, raw: Record<string, string>): Device 
   };
 
   // Subsystem-specific enrichments.
-  if (subsystem === "cctv" || subsystem === "aid") {
-    // No live stream in the mock — set a demo HLS pointing at a
-    // sample loop the map can render as a placeholder. The client
-    // just needs the field to exist for the "Live" tab to render.
+  if (subsystem === "cctv") {
     base.hlsInd = true;
-    base.hlsUri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8";
+    base.hlsUri = CCTV_DEMO_HLS;
+    base.controlType = "status and command";
+  }
+  if (subsystem === "aid") {
+    // AID cameras carry a distinct demo loop so the drawer visibly
+    // differs from a PTZ feed at the same chainage. Overridden by the
+    // AID backfill pass further down (which also picks the demo).
+    base.hlsInd = true;
+    base.hlsUri = AID_DEMO_HLS;
     base.controlType = "status and command";
   }
   if (subsystem === "vms") {
     base.signType = 1;
     base.pixelWidth = 84;
     base.pixelHeight = 7;
-    base.status = makeDefaultStatus(code);
+    base.status = makeVmsStatus(code);
   }
   if (subsystem === "vsls") {
     base.signType = 2;
@@ -212,11 +217,16 @@ function rowToDevice(subsystem: Subsystem, raw: Record<string, string>): Device 
     base.pixelHeight = 24;
     base.lane = pick(raw, "relative location") || null;
     base.groupIndex = parseNumber(pick(raw, "grouping")) ?? null;
-    base.status = makeDefaultStatus(code);
+    base.status = makeVslsStatus(code);
   }
 
   return base;
 }
+
+const CCTV_DEMO_HLS =
+  "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8";
+const AID_DEMO_HLS =
+  "https://demo.unified-streaming.com/k8s/features/stable/video/sintel/sintel.ism/.m3u8";
 
 function primaryRoadFor(subsystem: Subsystem): string {
   switch (subsystem) {
@@ -266,18 +276,62 @@ function rawFirstColumn(raw: Record<string, string>): string {
   return "";
 }
 
-function makeDefaultStatus(id: string) {
+/** Rotating VMS/DMS messages, keyed off a hash of the device id so
+ *  each sign in the map shows different text and the demo doesn't
+ *  read as "one identical message repeated 35 times". */
+const VMS_MESSAGES = [
+  "[pb]TRAFFIC AHEAD[nl]REDUCE SPEED",
+  "[pb]INCIDENT[nl]LANE 2 CLOSED",
+  "[pb]NO INCIDENTS[nl]DRIVE SAFE",
+  "[pb]ROADWORK[nl]KM 15 TO 17",
+  "[pb]WET ROAD[nl]KEEP DISTANCE",
+  "[pb]DELAYS[nl]EXPECT 5 MIN",
+] as const;
+
+function idHash(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i += 1) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+function makeVmsStatus(id: string) {
+  const message = VMS_MESSAGES[idHash(id) % VMS_MESSAGES.length]!;
   return {
     signId: id,
     connectable: true,
     shortStatus: 0,
     controlMode: "photocell" as const,
     timestamp: Date.now(),
-    message: "[pb]FLYOVER[nl]Drive safe",
+    message,
     beacon: false,
     brightnessLevel: { min: 0, max: 100, current: 75 },
     photocellLevel: { min: 0, max: 100, current: 50 },
     lightOutput: { min: 0, max: 255, current: 200 },
+    maxLinesPerPage: 3,
+    maxCharsPerLine: 16,
+  };
+}
+
+/** VSLS panels show a lane speed limit — a single 2-digit number
+ *  rather than free text. Cycle 60 / 80 / 100 by id hash so the
+ *  operator drawer visibly differs between lanes. */
+function makeVslsStatus(id: string) {
+  const limits = [60, 80, 100] as const;
+  const limit = limits[idHash(id) % limits.length]!;
+  return {
+    signId: id,
+    connectable: true,
+    shortStatus: 0,
+    controlMode: "manual" as const,
+    timestamp: Date.now(),
+    message: `[pb]${limit}`,
+    beacon: false,
+    brightnessLevel: { min: 0, max: 100, current: 90 },
+    photocellLevel: { min: 0, max: 100, current: 55 },
+    lightOutput: { min: 0, max: 255, current: 220 },
+    maxLinesPerPage: 1,
+    maxCharsPerLine: 3,
+    speedLimit: limit,
   };
 }
 
@@ -354,14 +408,16 @@ function main() {
         routeId: null,
         agency: "DEMO",
         active: true,
-        // AID's primary output is an event stream — no video feed in
-        // the mock. Leave media hints null.
-        hlsInd: null,
-        hlsUri: null,
+        // AID cameras stream video alongside their event feed —
+        // point at a distinct demo loop so the drawer's video panel
+        // renders and the operator can see it's a different camera
+        // to the PTZ at the same chainage.
+        hlsInd: true,
+        hlsUri: AID_DEMO_HLS,
         dashUri: null,
         cameraIpAddr: null,
         url: null,
-        controlType: "status",
+        controlType: "status and command",
         signType: null,
         pixelWidth: null,
         pixelHeight: null,

--- a/packages/connectors/src/adapters/inet-atms/adapter.ts
+++ b/packages/connectors/src/adapters/inet-atms/adapter.ts
@@ -465,13 +465,13 @@ export function createInetAtmsConnector(): InetAtmsConnector {
       if (!client) return out;
       // The ATMS REST surface is one-id-per-call for status; fan out
       // in parallel. Caller is expected to chunk to a sensible batch.
-      // CCTV records don't carry status on the device GET (the field is
-      // null) and there's no documented per-id CCTV status endpoint,
-      // so for CCTV we synthesise a minimal `online: true` from the
-      // device record's `active` flag fetched on getEntity. For now
-      // CCTV status is just an empty record; the dashboard treats
-      // missing entries as "no live data" and the drawer still shows
-      // the device's static fields.
+      // Every subsystem in STATUS_ENABLED_SUBSYSTEMS gets the same
+      // request shape; subsystem-specific payload extras (radar
+      // telemetry, aid event counts, cctv reachability stub) pass
+      // through via `InetStatus.raw`. If an upstream host doesn't
+      // implement /status for a subsystem it 404s and the id is
+      // silently dropped from the result — the drawer treats a
+      // missing entry as "no live data".
       await Promise.all(
         deviceIds.map(async (id) => {
           const unpacked = unpackId(id);


### PR DESCRIPTION
## Summary

The previous PR made the mock return `/status` for every subsystem and added tile components to the drawer, but three blockers meant almost no device actually rendered live data. This closes those gaps.

- **Live-status route** — hard-coded CCTV short-circuit synthesised a stub payload and never called the connector, so CCTV always showed "CCTV has no per-device status endpoint" even after we started serving one. Removed; every subsystem now goes through `connector.getStatus()` uniformly.
- **DMS face + `DmsSignDetails`** — both were gated `subsystem === "dms"` only. VMS and VSLS share the same NTCIP status shape (`message`, `brightness`, `maxLinesPerPage`, `maxCharsPerLine`), so extending the gates to `dms | vms | vsls` lights up 322 signs that previously showed no face.
- **AID `hlsUri`** — the seed backfill pass rebuilt every AID device from scratch and wiped the demo URL the initial pass set, so the drawer's video panel never had a stream. Restored, using a **distinct** demo stream (Sintel) so an AID camera visibly differs from the co-mounted PTZ (Tears of Steel) at the same chainage.

Bonus polish that makes the demo look like a real network:

- Mock seed rotates 6 VMS messages by id-hash — no more "FLYOVER / Drive safe" on all 35 signs.
- VSLS panels render as a lane-speed panel showing 60/80/100 (`[pb]NN` MULTI + narrower `maxCharsPerLine`), matching what a real VSLS displays.
- Drawer source-URL debug panel shows the `/status` URL for every subsystem now that the field always exists.

## Test plan

After merge → Vercel redeploys `apps/mock-inet`, then in Klorad Mobility:

- [ ] Select a CCTV device → drawer shows the video stream + "connectable" pill + fresh timestamp (not the removed "no per-device status" note)
- [ ] Select an AID device → drawer shows a *different* video (Sintel) + the event tile (count + last detection)
- [ ] Select a RADAR device → drawer shows the telemetry tile (volume / speed / occupancy / per-lane)
- [ ] Select a VMS device → drawer shows the rendered sign face with rotating messages
- [ ] Select a VSLS device → drawer shows the speed-limit panel (60/80/100)
- [ ] Debug URLs panel shows the `/status` URL for every subsystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)