### PR TITLE
feat(mobility): DMS canonical, de-overlap icons, real traffic footage

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -1324,6 +1324,8 @@ function DeviceDrawer({
                     src={payload.media.url}
                     controls
                     playsInline
+                    autoPlay
+                    loop
                     muted
                     className="aspect-video w-full"
                   />

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/devices/DevicesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/devices/DevicesClient.tsx
@@ -235,11 +235,11 @@ export function DevicesClient({
           options={[
             { value: "all", label: "All types" },
             // Emit one chip per connector-known subsystem so demo
-            // enums surface without touching this file. Hide DMS
-            // since VMS is the same physical device under a
-            // different regional name — the source picker enforces
-            // one-or-the-other to avoid duplicate rows.
-            ...INET_SUBSYSTEMS.filter((s) => s !== "dms").map((s) => {
+            // enums surface without touching this file. Hide VMS
+            // since DMS is the same physical device under Parsons'
+            // canonical name — the source picker enforces one-or-the-
+            // other to avoid duplicate rows.
+            ...INET_SUBSYSTEMS.filter((s) => s !== "vms").map((s) => {
               const d = subsystemDescriptor(s);
               return { value: s, label: d.label, icon: d.icon };
             }),

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
@@ -423,11 +423,12 @@ function AddSourceForm({
   // DMS and VMS are the same physical device with different regional
   // names (Parsons/US = DMS, European/Greek = VMS). Ticking both on
   // the same tenant collides on `(sourceId, externalDeviceId)` and
-  // one silently overwrites the other. Hide DMS from the picker;
-  // Parsons-native tenants can hand-edit `config.subsystems` if
-  // they need the DMS label.
+  // one silently overwrites the other. Hide VMS from the picker;
+  // DMS is the canonical name across our data and Mobility UI, and
+  // the mock aliases `/atms/vms-rest/…` back to DMS for any tenant
+  // that hand-edits `config.subsystems` to add the legacy label.
   const pickerSubsystems = useMemo(
-    () => INET_SUBSYSTEMS.filter((s) => s !== "dms"),
+    () => INET_SUBSYSTEMS.filter((s) => s !== "vms"),
     [],
   );
   // Default: every visible subsystem ticked. The mock serves all of

--- a/apps/mock-inet/lib/devices.ts
+++ b/apps/mock-inet/lib/devices.ts
@@ -123,24 +123,23 @@ export function parseSubsystem(value: string): Subsystem | null {
 }
 
 /**
- * Alias `dms` → `vms` so the legacy Parsons subsystem name serves the
- * same data as its regional twin. Our source workbook only has
- * VMS-shaped rows; without this alias, `/atms/dms-rest/rest/dms/`
- * returns [] and Mobility sources that tick "DMS" get nothing.
+ * Alias `vms` → `dms` so the legacy regional subsystem name still
+ * resolves. Our seed now produces DMS-tagged rows (Parsons naming is
+ * canonical in the Mobility picker), so `/atms/vms-rest/rest/vms/`
+ * would return [] without this alias.
  *
  * Note: if an operator ticks *both* dms and vms on their source,
- * they'll double-sync the same physical signs (once as vms:… and
- * once as dms:…, different packed ids). Pick one — VMS is the
- * canonical name for our data.
+ * they'll double-sync the same physical signs. Pick one — DMS is the
+ * canonical name.
  */
 export function fetchFromSubsystem(requested: Subsystem): Subsystem {
-  return requested === "dms" ? "vms" : requested;
+  return requested === "vms" ? "dms" : requested;
 }
 
 /**
  * Per-subsystem live status — what the per-device status endpoint
  * (path shape `/atms/{sub}-rest/rest/{sub}/{id}/status`) returns.
- * VMS/VSLS/DMS reuse the pre-baked DMS-shaped status from the seed.
+ * DMS/VMS/VSLS reuse the pre-baked NTCIP-shaped status from the seed.
  * CCTV/AID/RADAR get lightweight computed shapes so the Mobility
  * drawer has something to render for them (previously radar and aid
  * showed "no live data — the source returned no current status").

--- a/apps/mock-inet/scripts/build-seed-from-csv.ts
+++ b/apps/mock-inet/scripts/build-seed-from-csv.ts
@@ -23,7 +23,12 @@ interface FileSpec {
 const FILES: FileSpec[] = [
   { file: "aid.csv", subsystem: "aid" },
   { file: "cctv.csv", subsystem: "cctv" },
-  { file: "vms.csv", subsystem: "vms" },
+  // Workbook is VMS-native (Greek regional naming). Emit rows tagged
+  // as `dms` — Parsons' name for the same physical device — since the
+  // Mobility picker treats DMS as canonical and VMS as a hidden
+  // alias. Device codes get rewritten `W-VMS-…` → `W-DMS-…` at row
+  // construction so the labels line up.
+  { file: "vms.csv", subsystem: "dms" },
   { file: "vsls.csv", subsystem: "vsls" },
   { file: "radar-main.csv", subsystem: "radar" },
   { file: "radar-ramp.csv", subsystem: "radar" },
@@ -141,8 +146,16 @@ function parseChainage(s: string): { mileMarker: number | null; chainage: string
 }
 
 function rowToDevice(subsystem: Subsystem, raw: Record<string, string>): Device | null {
-  const code = pick(raw, "code", "device", "id");
-  if (!code) return null;
+  const rawCode = pick(raw, "code", "device", "id");
+  if (!rawCode) return null;
+  // Rename `W-VMS-15.01` → `W-DMS-15.01` when the row lands under the
+  // DMS subsystem so the device label ("DMS W-DMS-…") reads
+  // consistently — otherwise it would be "DMS W-VMS-…", a leaky
+  // reminder that our workbook is VMS-native.
+  // The workbook has direction/pole prefixes on every code
+  // (`W-`, `WR-`, `WF-`, `E-`, `ER-`, `EF-`), so match the `-VMS-`
+  // segment rather than a fixed leading string.
+  const code = subsystem === "dms" ? rawCode.replace(/-VMS-/, "-DMS-") : rawCode;
 
   const rawLat = parseNumber(pick(raw, "latitude", "lat"));
   const rawLng = parseNumber(pick(raw, "longitude", "long", "lng"));
@@ -205,11 +218,11 @@ function rowToDevice(subsystem: Subsystem, raw: Record<string, string>): Device 
     base.hlsUri = AID_DEMO_HLS;
     base.controlType = "status and command";
   }
-  if (subsystem === "vms") {
+  if (subsystem === "dms") {
     base.signType = 1;
     base.pixelWidth = 84;
     base.pixelHeight = 7;
-    base.status = makeVmsStatus(code);
+    base.status = makeDmsStatus(code);
   }
   if (subsystem === "vsls") {
     base.signType = 2;
@@ -223,14 +236,21 @@ function rowToDevice(subsystem: Subsystem, raw: Record<string, string>): Device 
   return base;
 }
 
+// Real road-traffic footage from Wikimedia Commons (VP8/VP9 WebM,
+// CC-BY-SA / public domain). Movie clips (Tears of Steel, Sintel)
+// looked wrong on a traffic-camera panel — an operator glances at
+// the drawer and expects to see a road. The drawer's <video>
+// element plays WebM natively in Chrome/Edge/Firefox; Safari
+// requires H.264 MP4 and will fall back to the placeholder — an
+// acceptable tradeoff for the current demo target.
 const CCTV_DEMO_HLS =
-  "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8";
+  "https://upload.wikimedia.org/wikipedia/commons/6/68/Avtocesta.webm";
 const AID_DEMO_HLS =
-  "https://demo.unified-streaming.com/k8s/features/stable/video/sintel/sintel.ism/.m3u8";
+  "https://upload.wikimedia.org/wikipedia/commons/8/80/Verkehr_auf_Autobahn_A4_bei_Bautzen_%281%29.webm";
 
 function primaryRoadFor(subsystem: Subsystem): string {
   switch (subsystem) {
-    case "vms":
+    case "dms":
     case "vsls":
       return "Flyover";
     case "radar":
@@ -249,14 +269,16 @@ function defaultLabel(subsystem: Subsystem): string {
       return "PTZ";
     case "aid":
       return "AID";
-    case "vms":
-      return "VMS";
+    case "dms":
+      return "DMS";
     case "vsls":
       return "VSLS";
     case "radar":
       return "RADAR";
-    case "dms":
-      return "DMS";
+    case "vms":
+      // Not emitted by any FILES entry after the DMS rename — kept
+      // to satisfy the exhaustive Subsystem union.
+      return "VMS";
   }
 }
 
@@ -276,10 +298,10 @@ function rawFirstColumn(raw: Record<string, string>): string {
   return "";
 }
 
-/** Rotating VMS/DMS messages, keyed off a hash of the device id so
- *  each sign in the map shows different text and the demo doesn't
- *  read as "one identical message repeated 35 times". */
-const VMS_MESSAGES = [
+/** Rotating DMS messages, keyed off a hash of the device id so each
+ *  sign in the map shows different text and the demo doesn't read as
+ *  "one identical message repeated 35 times". */
+const DMS_MESSAGES = [
   "[pb]TRAFFIC AHEAD[nl]REDUCE SPEED",
   "[pb]INCIDENT[nl]LANE 2 CLOSED",
   "[pb]NO INCIDENTS[nl]DRIVE SAFE",
@@ -294,8 +316,8 @@ function idHash(id: string): number {
   return Math.abs(h);
 }
 
-function makeVmsStatus(id: string) {
-  const message = VMS_MESSAGES[idHash(id) % VMS_MESSAGES.length]!;
+function makeDmsStatus(id: string) {
+  const message = DMS_MESSAGES[idHash(id) % DMS_MESSAGES.length]!;
   return {
     signId: id,
     connectable: true,
@@ -434,9 +456,55 @@ function main() {
     );
   }
 
+  const jittered = deoverlapCoLocated(output);
+  console.log(`[seed] spread ${jittered} co-located devices in small rings`);
+
   writeFileSync(OUT_PATH, JSON.stringify(output, null, 2), "utf8");
   console.log(`[seed] wrote ${output.length} devices → ${OUT_PATH}`);
   console.log("[seed] totals:", perSubsystem);
+}
+
+/** Icons stacked on identical coordinates were unclickable — the top
+ *  one absorbs every click and the ones under it can't be selected.
+ *  Group devices by ~1-metre-rounded coord and spread each cluster
+ *  in a small ring so every device gets its own icon slot.
+ *
+ *  Deterministic: within a cluster we sort by externalId and hand
+ *  out angles by index, so re-seeding produces the same layout.
+ *  Ring radius scales with cluster size — a 2-device pair stays
+ *  tight (~10 m centre-to-centre), a 10-device pile-up gets a wider
+ *  ring so the icons don't overlap edge-to-edge at typical zoom. */
+function deoverlapCoLocated(devices: Device[]): number {
+  const groups = new Map<string, Device[]>();
+  for (const d of devices) {
+    const key = `${d.latitude.toFixed(5)},${d.longitude.toFixed(5)}`;
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(d);
+    else groups.set(key, [d]);
+  }
+  const METRES_PER_DEGREE_LAT = 111_320;
+  let moved = 0;
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    group.sort((a, b) => a.externalId.localeCompare(b.externalId));
+    const centerLat = group[0]!.latitude;
+    const centerLng = group[0]!.longitude;
+    const metresPerDegreeLng =
+      METRES_PER_DEGREE_LAT * Math.cos((centerLat * Math.PI) / 180);
+    // 8 m minimum + 1 m per additional device — keeps 2-device pairs
+    // tight and prevents 10+ pile-ups from overlapping around the
+    // ring circumference.
+    const radiusMetres = 8 + Math.max(0, group.length - 2);
+    for (let i = 0; i < group.length; i += 1) {
+      const angle = (2 * Math.PI * i) / group.length;
+      const dLat = (radiusMetres * Math.sin(angle)) / METRES_PER_DEGREE_LAT;
+      const dLng = (radiusMetres * Math.cos(angle)) / metresPerDegreeLng;
+      group[i]!.latitude = centerLat + dLat;
+      group[i]!.longitude = centerLng + dLng;
+      moved += 1;
+    }
+  }
+  return moved;
 }
 
 /** Nearest CCTV anchor by chainage delta, subject to same direction.


### PR DESCRIPTION
## Summary

Three demo-polish items rolled into one PR since they all touch the sign-family devices.

- **DMS is now canonical, VMS hidden.** Reversed from the previous PR — DMS is what most Parsons tenants expect. Seed emits rows tagged `subsystem: "dms"` from the same VMS-native workbook, rewriting device codes `<prefix>-VMS-…` → `<prefix>-DMS-…` so labels ("DMS W-DMS-15.01") read consistently. Mock's alias flipped: `/atms/vms-rest/…` now resolves to DMS data for any tenant that hand-edits `config.subsystems` to add the legacy name. Mobility picker + devices filter hide VMS instead of DMS.

- **De-overlap co-located devices.** 435 of 775 devices in the seed shared exact coordinates — AID cameras borrowing their nearest CCTV's lat/lng, VMS/VSLS panels on the same gantry, RM radars mounted with a paired AID. Stacked icons meant the top device absorbed every click and the ones beneath were unselectable. Post-processing pass in `main()` groups devices by 5-decimal-rounded coord and spreads each cluster in a small ring (8 m + 1 m per additional device beyond 2), sorted by `externalId` for deterministic layout. All devices in a cluster stay visibly close but each gets its own icon slot.

- **Real traffic footage on cameras.** Was serving Tears of Steel (CCTV) and Sintel (AID) — movie clips on a traffic-camera panel read wrong at a glance. Swapped to two Wikimedia Commons public-domain highway WebM clips (Slovenian Avtocesta for CCTV, German A4 Bautzen for AID) so the drawer visibly matches the icon. Drawer `<video>` gets `autoPlay loop` so a 10-second clip doesn't stop dead after the first play.

## Test plan

After merge → Vercel redeploys `apps/mock-inet`, then in Klorad Mobility (delete + re-add source to pick up new picker defaults):

- [ ] Source picker shows DMS chip, no VMS chip
- [ ] Devices filter shows DMS chip, no VMS chip
- [ ] After sync: DMS 35 devices with codes like `W-DMS-15.01`
- [ ] Map view — previously stacked icons are now spread in small rings, each clickable
- [ ] CCTV drawer → autoplays a highway/traffic clip on loop
- [ ] AID drawer → autoplays a different highway/traffic clip on loop
- [ ] `curl https://klorad-mock-inet.vercel.app/atms/vms-rest/rest/vms/?limit=1` still returns rows (alias fallback)

## Sources

- Traffic HLS search: [Bitmovin sample streams](https://bitmovin.com/blog/mpeg-dash-hls-examples-sample-streams/), [iptvplayer test list](https://iptvplayer.stream/free-m3u8-hls-test-streams-urls) — confirmed no public HLS traffic streams exist
- Video clips: [Avtocesta.webm](https://commons.wikimedia.org/wiki/File:Avtocesta.webm) (CC-BY-SA), [Verkehr auf Autobahn A4 bei Bautzen.webm](https://commons.wikimedia.org/wiki/File:Verkehr_auf_Autobahn_A4_bei_Bautzen_(1).webm) (public domain), both from [Wikimedia Commons road-traffic category](https://commons.wikimedia.org/wiki/Category:Videos_of_road_traffic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)