### PR TITLE
feat(mobility): teams + per-world principals (schema + resolver)

### DIFF
--- a/apps/mobility/lib/mobility/world-resolver.ts
+++ b/apps/mobility/lib/mobility/world-resolver.ts
@@ -159,9 +159,15 @@ export async function loadPublicWorldBySlug(
 
 /**
  * Page-level resolver. Pass `viewerId` if a session exists.
- * The auth gate is project-org membership: anyone in the owning
- * organisation can view an `authenticated` world. Tighter per-world
- * ACLs can graduate into their own table later.
+ *
+ * For `authenticated` worlds the gate is `MobilityWorldPrincipal` —
+ * a direct `user` grant or membership in a `team` grant. Empty
+ * principal list denies everyone; there is no org-membership
+ * fallback (the previous behaviour) since we now support per-world
+ * ACLs and there are no existing authenticated worlds to
+ * grandfather in. Owners still get access as the world's project
+ * organisation-owner via the `owner` short-circuit — otherwise a
+ * mis-configured world would lock out the operator who created it.
  */
 export async function resolveWorldForViewer(
   slug: string,
@@ -176,7 +182,9 @@ export async function resolveWorldForViewer(
     return { kind: "ok", world: await toPublicWorld(world) };
   }
   if (!viewerId) return { kind: "needs_signin" };
-  const membership = await prisma.organizationMember.findUnique({
+  // Org owners bypass the principal check — they created the world,
+  // it would be surprising if they had to grant themselves access.
+  const ownerMembership = await prisma.organizationMember.findUnique({
     where: {
       organizationId_userId: {
         organizationId: world.project.organizationId,
@@ -185,6 +193,22 @@ export async function resolveWorldForViewer(
     },
     select: { role: true },
   });
-  if (!membership) return { kind: "no_access" };
+  if (ownerMembership?.role === "owner") {
+    return { kind: "ok", world: await toPublicWorld(world) };
+  }
+  const grant = await prisma.mobilityWorldPrincipal.findFirst({
+    where: {
+      worldId: world.id,
+      OR: [
+        { kind: "user", userId: viewerId },
+        {
+          kind: "team",
+          team: { members: { some: { userId: viewerId } } },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+  if (!grant) return { kind: "no_access" };
   return { kind: "ok", world: await toPublicWorld(world) };
 }

--- a/packages/prisma/migrations/20260716120000_mobility_teams_and_world_principals/migration.sql
+++ b/packages/prisma/migrations/20260716120000_mobility_teams_and_world_principals/migration.sql
@@ -1,0 +1,92 @@
+-- CreateEnum
+CREATE TYPE "MobilityWorldPrincipalKind" AS ENUM ('user', 'team');
+
+-- CreateTable
+CREATE TABLE "Team" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Team_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamMember" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TeamMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MobilityWorldPrincipal" (
+    "id" TEXT NOT NULL,
+    "worldId" TEXT NOT NULL,
+    "kind" "MobilityWorldPrincipalKind" NOT NULL,
+    "userId" TEXT,
+    "teamId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MobilityWorldPrincipal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_organizationId_name_key" ON "Team"("organizationId", "name");
+
+-- CreateIndex
+CREATE INDEX "Team_organizationId_idx" ON "Team"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamMember_teamId_userId_key" ON "TeamMember"("teamId", "userId");
+
+-- CreateIndex
+CREATE INDEX "TeamMember_userId_idx" ON "TeamMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "TeamMember_teamId_idx" ON "TeamMember"("teamId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MobilityWorldPrincipal_worldId_kind_userId_teamId_key" ON "MobilityWorldPrincipal"("worldId", "kind", "userId", "teamId");
+
+-- CreateIndex
+CREATE INDEX "MobilityWorldPrincipal_worldId_idx" ON "MobilityWorldPrincipal"("worldId");
+
+-- CreateIndex
+CREATE INDEX "MobilityWorldPrincipal_userId_idx" ON "MobilityWorldPrincipal"("userId");
+
+-- CreateIndex
+CREATE INDEX "MobilityWorldPrincipal_teamId_idx" ON "MobilityWorldPrincipal"("teamId");
+
+-- AddForeignKey
+ALTER TABLE "Team" ADD CONSTRAINT "Team_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMember" ADD CONSTRAINT "TeamMember_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMember" ADD CONSTRAINT "TeamMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MobilityWorldPrincipal" ADD CONSTRAINT "MobilityWorldPrincipal_worldId_fkey" FOREIGN KEY ("worldId") REFERENCES "MobilityWorld"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MobilityWorldPrincipal" ADD CONSTRAINT "MobilityWorldPrincipal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MobilityWorldPrincipal" ADD CONSTRAINT "MobilityWorldPrincipal_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CHECK constraint: exactly one of userId/teamId must be set, matching `kind`.
+-- Postgres check constraints aren't first-class in the Prisma schema, so we
+-- enforce this here to prevent malformed rows at the DB layer as a backup
+-- for the API validation.
+ALTER TABLE "MobilityWorldPrincipal" ADD CONSTRAINT "MobilityWorldPrincipal_kind_target_ck"
+    CHECK (
+        (kind = 'user' AND "userId" IS NOT NULL AND "teamId" IS NULL)
+        OR
+        (kind = 'team' AND "teamId" IS NOT NULL AND "userId" IS NULL)
+    );

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -41,22 +41,24 @@ model Session {
 }
 
 model User {
-  id                      String               @id @default(cuid())
+  id                      String                   @id @default(cuid())
   name                    String?
-  email                   String?              @unique
+  email                   String?                  @unique
   emailVerified           DateTime?
   image                   String?
   password                String?
-  passwordResetToken      String?              @unique
+  passwordResetToken      String?                  @unique
   passwordResetTokenExp   DateTime?
   accounts                Account[]
   sessions                Session[]
   subscription            Subscription? // One-to-one relation with Subscription
   organizationMembers     OrganizationMember[]
-  organizationInvitesSent OrganizationInvite[] @relation("InvitesSent") // Invitations sent by this user
+  organizationInvitesSent OrganizationInvite[]     @relation("InvitesSent") // Invitations sent by this user
   activities              Activity[] // Activities performed by this user (as actor)
-  broadcastsSent          Broadcast[]          @relation("BroadcastsSent") // Push broadcasts triggered by this user
+  broadcastsSent          Broadcast[]              @relation("BroadcastsSent") // Push broadcasts triggered by this user
   projectRoleOverrides    ProjectMember[] // Per-project role overrides (per-campus access scoping)
+  teamMemberships         TeamMember[] // Membership in named groups within an org
+  worldGrants             MobilityWorldPrincipal[] @relation("UserWorldGrants") // Direct per-world access grants (Mobility)
 }
 
 model VerificationToken {
@@ -88,6 +90,9 @@ model Organization {
   members               OrganizationMember[]
   invites               OrganizationInvite[]
   projects              Project[]
+  /// Named groups of users within this organisation. Currently used
+  /// by Mobility to grant world access to a whole team at once.
+  teams                 Team[]
   assets                Asset[]
   activities            Activity[]
   cesiumIonIntegrations CesiumIonIntegration[]
@@ -121,6 +126,42 @@ model OrganizationMember {
   @@unique([organizationId, userId])
   @@index([userId])
   @@index([organizationId])
+}
+
+/// Named group of users within an organisation. First consumer is
+/// Mobility, which lets an operator grant world access to a whole
+/// team via `MobilityWorldPrincipal`. Kept org-generic so other
+/// verticals (Editor, Campus) can reuse the same table later.
+model Team {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String
+  description    String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  members      TeamMember[]
+  worldGrants  MobilityWorldPrincipal[] @relation("TeamWorldGrants")
+
+  /// Name is unique within an org — reduces the "which Support team
+  /// did you mean" problem on the picker.
+  @@unique([organizationId, name])
+  @@index([organizationId])
+}
+
+model TeamMember {
+  id        String   @id @default(cuid())
+  teamId    String
+  userId    String
+  createdAt DateTime @default(now())
+
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, userId])
+  @@index([userId])
+  @@index([teamId])
 }
 
 model OrganizationInvite {
@@ -998,6 +1039,11 @@ model MobilityWorld {
   /// Append-only stream of visitor + operator events for the analytics
   /// panel. See lib/mobility/world-events.ts.
   events            MobilityWorldEvent[]
+  /// Access-control principals for `authenticated`-visibility worlds.
+  /// Empty list = no access (strict; there is no legacy fallback).
+  /// Populated with a mix of `user` and `team` rows resolved at
+  /// viewer time.
+  principals        MobilityWorldPrincipal[]
 
   @@unique([projectId, slug])
   @@index([projectId])
@@ -1055,6 +1101,43 @@ enum MobilityWorldVisibility {
   public
   linkOnly
   authenticated
+}
+
+/// Access-control principal for an authenticated-visibility world.
+/// Polymorphic-ish: `kind` picks which of `userId`/`teamId` is set.
+/// One of the two must be non-null and the other null — enforced at
+/// the API layer since Postgres check constraints are awkward via
+/// Prisma migrations.
+///
+/// Cascade delete when the world, user, or team disappears — an
+/// orphan principal is meaningless. No fallback for empty principal
+/// list: an authenticated world with zero rows here denies everyone
+/// (there are no legacy authenticated worlds to grandfather in).
+model MobilityWorldPrincipal {
+  id        String                     @id @default(cuid())
+  worldId   String
+  kind      MobilityWorldPrincipalKind
+  /// Set when `kind = user`; null otherwise.
+  userId    String?
+  /// Set when `kind = team`; null otherwise.
+  teamId    String?
+  createdAt DateTime                   @default(now())
+
+  world MobilityWorld @relation(fields: [worldId], references: [id], onDelete: Cascade)
+  user  User?         @relation("UserWorldGrants", fields: [userId], references: [id], onDelete: Cascade)
+  team  Team?         @relation("TeamWorldGrants", fields: [teamId], references: [id], onDelete: Cascade)
+
+  /// Unique per (world, principal). Duplicate-grant attempts on the
+  /// API layer become a no-op upsert instead of a 500.
+  @@unique([worldId, kind, userId, teamId])
+  @@index([worldId])
+  @@index([userId])
+  @@index([teamId])
+}
+
+enum MobilityWorldPrincipalKind {
+  user
+  team
 }
 
 /// Append-only event stream per world. Powers the operator analytics


### PR DESCRIPTION
## Summary

Arc A PR1 of the **teams / push composer / rule engine** plan agreed upstream. Ships the data model and the strict access-control resolver. Admin UI (list/edit teams, assign principals per world) lands in PR2.

**Schema:**

- `Team` — named group of users within an org (unique per org name). Kept org-generic so Editor / Campus can reuse.
- `TeamMember` — join table with unique `(teamId, userId)`.
- `MobilityWorldPrincipal` — polymorphic access grant on an `authenticated` world; `kind` picks between `userId` and `teamId`. Postgres CHECK constraint enforces exactly one of the two is set. Cascade delete when the world, user, or team disappears.
- Enum `MobilityWorldPrincipalKind` + matching migration SQL.

**Resolver:**

- `resolveWorldForViewer` for `authenticated` worlds no longer falls back to org membership. Grant is required — either a direct `user` principal or membership in a `team` principal. **Empty principal list = deny.** No back-compat needed since there are no existing authenticated worlds.
- Org **owners** still bypass the principal check so a mis-configured world doesn't lock out its creator.

## Plan context

Full plan agreed on the parent thread. Locked-in decisions for that plan:
- Worlds-only push targeting (no `UserPushSubscription`)
- Webhook-driven rule engine (no polling loop)
- No back-compat for authenticated worlds

## Test plan

- [ ] Deploy runs the migration cleanly
- [ ] After merge, PR2 adds the admin UI to create teams and assign principals — until then, authenticated worlds are unreachable except by org owners (expected)
- [ ] Public + linkOnly worlds unchanged
- [ ] Org owner can still view every authenticated world in their org

🤖 Generated with [Claude Code](https://claude.com/claude-code)