### PR TITLE
feat(mobility): teams admin UI + per-world access grants

### DIFF
--- a/apps/mobility/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/mobility/app/(dashboard)/components/DashboardShell.tsx
@@ -56,6 +56,7 @@ import {
   Settings,
   Sun,
   Users,
+  UsersRound,
 } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
 import {
@@ -179,10 +180,16 @@ function orgNavGroups(orgId: string, pathname: string): NavGroup[] {
           active: pathname === prefix,
         },
         {
-          label: "Team",
+          label: "Members",
           href: `${prefix}/settings/members`,
           icon: <Users size={16} strokeWidth={1.7} />,
           active: is("/settings/members"),
+        },
+        {
+          label: "Teams",
+          href: `${prefix}/teams`,
+          icon: <UsersRound size={16} strokeWidth={1.7} />,
+          active: is("/teams"),
         },
         {
           label: "Settings",

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "react-toastify";
+import useSWR from "swr";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -20,10 +21,12 @@ import {
   Lock,
   MapPin,
   Palette,
+  Plus,
   Search,
   Send,
   Trash2,
   Users,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { subsystemIcon as pickSubsystemIcon } from "@/lib/mobility/subsystem-icon";
@@ -368,6 +371,11 @@ export function WorldEditor({
 
       {/* Broadcast */}
       <BroadcastCard world={world} />
+
+      {/* Access — only visible when this world is set to authenticated. */}
+      {visibility === "authenticated" && (
+        <AccessCard worldId={world.id} orgId={orgId} />
+      )}
 
       {/* Device picker */}
       <section className="rounded-2xl border border-line-soft bg-surface-1/40 p-5">
@@ -1043,6 +1051,228 @@ function BroadcastCard({ world }: { world: World }) {
     </section>
   );
 }
+
+interface Principal {
+  id: string;
+  kind: "user" | "team";
+  createdAt: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  } | null;
+  team: { id: string; name: string; memberCount: number } | null;
+}
+
+interface OrgMemberOption {
+  userId: string;
+  user: { id: string; name: string | null; email: string | null };
+}
+
+interface TeamOption {
+  id: string;
+  name: string;
+  memberCount: number;
+}
+
+/** Access control for an authenticated-visibility world. Lists the
+ *  currently-granted principals (users + teams) and lets the operator
+ *  add or revoke grants. Only rendered when the world is
+ *  authenticated — public / linkOnly worlds don't gate on principals.
+ *  Empty list = no access, so the UI nudges the operator to add at
+ *  least one entry. */
+function AccessCard({ worldId, orgId }: { worldId: string; orgId: string }) {
+  const { data, mutate } = useSWR<{ principals: Principal[] }>(
+    `/api/worlds/${worldId}/principals`,
+    accessFetcher,
+  );
+  const { data: membersData } = useSWR<{ members: OrgMemberOption[] }>(
+    `/api/orgs/${orgId}/members`,
+    accessFetcher,
+  );
+  const { data: teamsData } = useSWR<{ teams: TeamOption[] }>(
+    `/api/orgs/${orgId}/teams`,
+    accessFetcher,
+  );
+  const principals = data?.principals ?? [];
+
+  const grantedUserIds = useMemo(
+    () => new Set(principals.filter((p) => p.user).map((p) => p.user!.id)),
+    [principals],
+  );
+  const grantedTeamIds = useMemo(
+    () => new Set(principals.filter((p) => p.team).map((p) => p.team!.id)),
+    [principals],
+  );
+
+  const teamOptions = (teamsData?.teams ?? []).filter(
+    (t) => !grantedTeamIds.has(t.id),
+  );
+  const userOptions = (membersData?.members ?? []).filter(
+    (m) => !grantedUserIds.has(m.userId),
+  );
+
+  const [pickerKind, setPickerKind] = useState<"team" | "user">("team");
+  const [pickerId, setPickerId] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function add() {
+    if (!pickerId) return;
+    setBusy(true);
+    try {
+      const body =
+        pickerKind === "user"
+          ? { kind: "user", userId: pickerId }
+          : { kind: "team", teamId: pickerId };
+      const res = await fetch(`/api/worlds/${worldId}/principals`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = (await res.json()) as { error?: string };
+        toast.error(err.error ?? "Grant failed");
+        return;
+      }
+      setPickerId("");
+      void mutate();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revoke(principal: Principal) {
+    const res = await fetch(
+      `/api/worlds/${worldId}/principals/${principal.id}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) {
+      const err = (await res.json()) as { error?: string };
+      toast.error(err.error ?? "Revoke failed");
+      return;
+    }
+    void mutate();
+  }
+
+  return (
+    <section className="mb-6 rounded-2xl border border-line-soft bg-surface-1/40 p-5">
+      <header className="mb-3">
+        <h2 className="text-sm font-semibold text-text-primary">Access</h2>
+        <p className="mt-1 text-xs text-text-secondary">
+          Authenticated worlds are only visible to the users and teams granted
+          access below. Org owners always have access.
+        </p>
+      </header>
+
+      {principals.length === 0 ? (
+        <p className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700">
+          No access grants yet. Only org owners can currently view this world.
+        </p>
+      ) : (
+        <ul className="mb-3 flex flex-wrap gap-2">
+          {principals.map((p) => (
+            <li
+              key={p.id}
+              className="inline-flex items-center gap-2 rounded-full border border-line-soft bg-bg px-2.5 py-1 text-xs"
+            >
+              <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+                {p.kind}
+              </span>
+              <span className="text-text-primary">
+                {p.team
+                  ? `${p.team.name} · ${p.team.memberCount}`
+                  : (p.user?.name ?? p.user?.email ?? p.user?.id ?? "?")}
+              </span>
+              <button
+                type="button"
+                onClick={() => revoke(p)}
+                aria-label="Revoke"
+                className="rounded-full p-0.5 text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-500"
+              >
+                <X size={11} strokeWidth={2.2} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex rounded-md border border-line-soft bg-bg text-xs">
+          <button
+            type="button"
+            onClick={() => {
+              setPickerKind("team");
+              setPickerId("");
+            }}
+            className={`px-3 py-1.5 ${
+              pickerKind === "team"
+                ? "bg-surface-2 font-medium text-text-primary"
+                : "text-text-tertiary hover:text-text-primary"
+            }`}
+          >
+            Team
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setPickerKind("user");
+              setPickerId("");
+            }}
+            className={`px-3 py-1.5 ${
+              pickerKind === "user"
+                ? "bg-surface-2 font-medium text-text-primary"
+                : "text-text-tertiary hover:text-text-primary"
+            }`}
+          >
+            User
+          </button>
+        </div>
+        <select
+          value={pickerId}
+          onChange={(e) => setPickerId(e.target.value)}
+          className="min-w-[220px] flex-1 rounded-md border border-line-strong bg-bg px-3 py-1.5 text-sm text-text-primary"
+        >
+          <option value="">
+            {pickerKind === "team"
+              ? teamOptions.length === 0
+                ? "No teams available"
+                : "Pick a team…"
+              : userOptions.length === 0
+                ? "No org members available"
+                : "Pick a user…"}
+          </option>
+          {pickerKind === "team"
+            ? teamOptions.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name} ({t.memberCount})
+                </option>
+              ))
+            : userOptions.map((m) => (
+                <option key={m.userId} value={m.userId}>
+                  {m.user.name ?? m.user.email ?? m.userId}
+                </option>
+              ))}
+        </select>
+        <button
+          type="button"
+          onClick={add}
+          disabled={busy || !pickerId}
+          className="inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          <Plus size={12} strokeWidth={2.2} />
+          Grant
+        </button>
+      </div>
+    </section>
+  );
+}
+
+const accessFetcher = (url: string) =>
+  fetch(url).then(async (r) => {
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  });
 
 function SubsystemIcon({ subsystem }: { subsystem: string }) {
   const Icon = pickSubsystemIcon(subsystem);

--- a/apps/mobility/app/(dashboard)/org/[orgId]/teams/TeamsClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/teams/TeamsClient.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import useSWR from "swr";
+import { toast } from "react-toastify";
+import { Plus, Trash2, Users, ChevronRight, Loader2 } from "lucide-react";
+import type { OrganizationRole } from "@prisma/client";
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (r) => {
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  });
+
+interface Team {
+  id: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface ListResponse {
+  teams: Team[];
+}
+
+export function TeamsClient({
+  orgId,
+  orgName,
+  yourRole,
+}: {
+  orgId: string;
+  orgName: string;
+  yourRole: OrganizationRole | null;
+}) {
+  const canManage = yourRole === "owner" || yourRole === "admin";
+  const { data, isLoading, mutate } = useSWR<ListResponse>(
+    `/api/orgs/${orgId}/teams`,
+    fetcher,
+  );
+  const teams = data?.teams ?? [];
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const create = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast.error("Name is required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/orgs/${orgId}/teams`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: trimmed,
+          description: description.trim() || null,
+        }),
+      });
+      const body = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        toast.error(body.error ?? "Create failed");
+        return;
+      }
+      toast.success(`Team "${trimmed}" created`);
+      setName("");
+      setDescription("");
+      void mutate();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const remove = async (team: Team) => {
+    if (
+      !confirm(
+        `Delete team "${team.name}"? Members lose team-based world access — direct grants are unaffected.`,
+      )
+    ) {
+      return;
+    }
+    const res = await fetch(`/api/orgs/${orgId}/teams/${team.id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      const body = (await res.json()) as { error?: string };
+      toast.error(body.error ?? "Delete failed");
+      return;
+    }
+    toast.success(`Team "${team.name}" deleted`);
+    void mutate();
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-[1200px] px-6 py-10 md:px-10">
+      <header className="mb-8">
+        <p className="text-xs font-medium uppercase tracking-[0.28em] text-text-tertiary">
+          {orgName}
+        </p>
+        <h1 className="mt-1 text-3xl font-light text-text-primary">Teams</h1>
+        <p className="mt-2 max-w-2xl text-sm text-text-secondary">
+          Named groups of org members. Grant world access to a whole team at
+          once instead of picking individual users.
+        </p>
+      </header>
+
+      {canManage && (
+        <section className="mb-8 rounded-2xl border border-line-soft bg-bg p-6">
+          <h2 className="mb-4 text-lg font-medium text-text-primary">
+            Create a team
+          </h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="text-sm">
+              <span className="mb-1 block text-text-tertiary">Name</span>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Traffic control room"
+                className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+              />
+            </label>
+            <label className="text-sm">
+              <span className="mb-1 block text-text-tertiary">Description</span>
+              <input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional"
+                className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+              />
+            </label>
+          </div>
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={create}
+              disabled={submitting}
+              className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-colors hover:bg-accent-hover disabled:opacity-50"
+            >
+              {submitting ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Plus size={14} />
+              )}
+              Create team
+            </button>
+          </div>
+        </section>
+      )}
+
+      <section className="rounded-2xl border border-line-soft bg-bg">
+        <div className="border-b border-line-soft px-6 py-4">
+          <h2 className="text-lg font-medium text-text-primary">All teams</h2>
+        </div>
+        {isLoading ? (
+          <p className="px-6 py-8 text-sm text-text-tertiary">Loading…</p>
+        ) : teams.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-text-tertiary">
+            No teams yet.{" "}
+            {canManage
+              ? "Create one above to start grouping org members."
+              : "Ask an admin to create one."}
+          </p>
+        ) : (
+          <ul className="divide-y divide-line-soft">
+            {teams.map((t) => (
+              <li key={t.id} className="flex items-center gap-4 px-6 py-4">
+                <Link
+                  href={`/org/${orgId}/teams/${t.id}`}
+                  className="group flex-1 min-w-0"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium text-text-primary group-hover:text-accent">
+                      {t.name}
+                    </span>
+                    <span className="inline-flex items-center gap-1 rounded-full bg-surface-2 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+                      <Users size={9} strokeWidth={2.2} />
+                      {t.memberCount}
+                    </span>
+                  </div>
+                  {t.description && (
+                    <p className="mt-1 truncate text-sm text-text-secondary">
+                      {t.description}
+                    </p>
+                  )}
+                </Link>
+                {canManage && (
+                  <button
+                    type="button"
+                    onClick={() => remove(t)}
+                    aria-label={`Delete ${t.name}`}
+                    className="rounded-md p-1.5 text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-500"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
+                <Link
+                  href={`/org/${orgId}/teams/${t.id}`}
+                  aria-label={`Open ${t.name}`}
+                  className="rounded-md p-1.5 text-text-tertiary transition-colors hover:bg-surface-2 hover:text-text-primary"
+                >
+                  <ChevronRight size={14} />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/mobility/app/(dashboard)/org/[orgId]/teams/[teamId]/TeamDetailClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/teams/[teamId]/TeamDetailClient.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import useSWR from "swr";
+import { toast } from "react-toastify";
+import { ArrowLeft, Loader2, Plus, X, Search } from "lucide-react";
+import type { OrganizationRole } from "@prisma/client";
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (r) => {
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  });
+
+interface TeamMember {
+  id: string;
+  userId: string;
+  createdAt: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  };
+}
+
+interface TeamResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: string;
+  members: TeamMember[];
+}
+
+interface OrgMember {
+  id: string;
+  userId: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+  };
+}
+
+interface OrgMembersResponse {
+  members: OrgMember[];
+}
+
+export function TeamDetailClient({
+  orgId,
+  orgName,
+  teamId,
+  teamName,
+  yourRole,
+}: {
+  orgId: string;
+  orgName: string;
+  teamId: string;
+  teamName: string;
+  yourRole: OrganizationRole | null;
+}) {
+  const canManage = yourRole === "owner" || yourRole === "admin";
+  const { data: team, mutate: mutateTeam } = useSWR<TeamResponse>(
+    `/api/orgs/${orgId}/teams/${teamId}`,
+    fetcher,
+  );
+  const { data: orgMembersData } = useSWR<OrgMembersResponse>(
+    `/api/orgs/${orgId}/members`,
+    fetcher,
+  );
+
+  const [query, setQuery] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // Members not yet in the team, matching the search query.
+  const candidates = useMemo(() => {
+    if (!orgMembersData || !team) return [];
+    const inTeam = new Set(team.members.map((m) => m.userId));
+    const q = query.trim().toLowerCase();
+    return orgMembersData.members.filter((m) => {
+      if (inTeam.has(m.userId)) return false;
+      if (!q) return true;
+      return (
+        (m.user.name ?? "").toLowerCase().includes(q) ||
+        (m.user.email ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [orgMembersData, team, query]);
+
+  const add = async (userId: string) => {
+    setBusyId(userId);
+    try {
+      const res = await fetch(
+        `/api/orgs/${orgId}/teams/${teamId}/members`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId }),
+        },
+      );
+      const body = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        toast.error(body.error ?? "Add failed");
+        return;
+      }
+      void mutateTeam();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const remove = async (member: TeamMember) => {
+    setBusyId(member.id);
+    try {
+      const res = await fetch(
+        `/api/orgs/${orgId}/teams/${teamId}/members/${member.id}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        toast.error(body.error ?? "Remove failed");
+        return;
+      }
+      void mutateTeam();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-[1200px] px-6 py-10 md:px-10">
+      <header className="mb-8">
+        <Link
+          href={`/org/${orgId}/teams`}
+          className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.28em] text-text-tertiary hover:text-text-primary"
+        >
+          <ArrowLeft size={12} />
+          {orgName} · Teams
+        </Link>
+        <h1 className="mt-1 text-3xl font-light text-text-primary">
+          {teamName}
+        </h1>
+        {team?.description && (
+          <p className="mt-2 max-w-2xl text-sm text-text-secondary">
+            {team.description}
+          </p>
+        )}
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <section className="rounded-2xl border border-line-soft bg-bg">
+          <div className="border-b border-line-soft px-5 py-4">
+            <h2 className="text-sm font-medium text-text-primary">
+              Members ({team?.members.length ?? 0})
+            </h2>
+          </div>
+          {!team ? (
+            <p className="px-5 py-6 text-sm text-text-tertiary">Loading…</p>
+          ) : team.members.length === 0 ? (
+            <p className="px-5 py-6 text-sm text-text-tertiary">
+              No one on this team yet.
+            </p>
+          ) : (
+            <ul className="divide-y divide-line-soft">
+              {team.members.map((m) => (
+                <li
+                  key={m.id}
+                  className="flex items-center gap-3 px-5 py-3"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="truncate text-sm text-text-primary">
+                      {m.user.name ?? m.user.email ?? m.user.id}
+                    </p>
+                    {m.user.name && m.user.email && (
+                      <p className="truncate text-[11px] text-text-tertiary">
+                        {m.user.email}
+                      </p>
+                    )}
+                  </div>
+                  {canManage && (
+                    <button
+                      type="button"
+                      onClick={() => remove(m)}
+                      disabled={busyId === m.id}
+                      aria-label={`Remove ${m.user.name ?? m.user.email}`}
+                      className="rounded-md p-1.5 text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
+                    >
+                      {busyId === m.id ? (
+                        <Loader2 size={14} className="animate-spin" />
+                      ) : (
+                        <X size={14} />
+                      )}
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {canManage && (
+          <section className="rounded-2xl border border-line-soft bg-bg">
+            <div className="border-b border-line-soft px-5 py-4">
+              <h2 className="text-sm font-medium text-text-primary">
+                Add org members
+              </h2>
+            </div>
+            <div className="px-5 py-4">
+              <div className="mb-3 flex items-center gap-2 rounded-md border border-line-soft bg-bg pl-3">
+                <Search size={14} className="text-text-tertiary" aria-hidden />
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search by name or email…"
+                  className="min-w-0 flex-1 bg-transparent py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary"
+                />
+              </div>
+              {!orgMembersData ? (
+                <p className="text-sm text-text-tertiary">Loading…</p>
+              ) : candidates.length === 0 ? (
+                <p className="text-sm text-text-tertiary">
+                  {query
+                    ? "No matching org member."
+                    : "Every org member is already on this team."}
+                </p>
+              ) : (
+                <ul className="divide-y divide-line-soft">
+                  {candidates.slice(0, 20).map((m) => (
+                    <li
+                      key={m.userId}
+                      className="flex items-center gap-3 py-2.5"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="truncate text-sm text-text-primary">
+                          {m.user.name ?? m.user.email ?? m.user.id}
+                        </p>
+                        {m.user.name && m.user.email && (
+                          <p className="truncate text-[11px] text-text-tertiary">
+                            {m.user.email}
+                          </p>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => add(m.userId)}
+                        disabled={busyId === m.userId}
+                        className="inline-flex items-center gap-1 rounded-md border border-line-soft px-2.5 py-1 text-xs font-medium text-text-primary transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+                      >
+                        {busyId === m.userId ? (
+                          <Loader2 size={12} className="animate-spin" />
+                        ) : (
+                          <Plus size={12} />
+                        )}
+                        Add
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {candidates.length > 20 && (
+                <p className="mt-2 text-[11px] text-text-tertiary">
+                  Showing 20 of {candidates.length} — refine the search.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/mobility/app/(dashboard)/org/[orgId]/teams/[teamId]/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/teams/[teamId]/page.tsx
@@ -1,0 +1,48 @@
+import { notFound } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { TeamDetailClient } from "./TeamDetailClient";
+
+type Params = Promise<{ orgId: string; teamId: string }>;
+
+export const metadata = { title: "Team" };
+
+export default async function TeamDetailPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, teamId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) notFound();
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+  const team = await prisma.team.findFirst({
+    where: { id: teamId, organizationId: orgId },
+    select: { id: true, name: true },
+  });
+  if (!team) notFound();
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { name: true },
+  });
+  if (!org) notFound();
+
+  return (
+    <TeamDetailClient
+      orgId={orgId}
+      orgName={org.name}
+      teamId={team.id}
+      teamName={team.name}
+      yourRole={membership.role}
+    />
+  );
+}

--- a/apps/mobility/app/(dashboard)/org/[orgId]/teams/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/teams/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { TeamsClient } from "./TeamsClient";
+
+type Params = Promise<{ orgId: string }>;
+
+export const metadata = { title: "Teams" };
+
+export default async function OrgTeamsPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) notFound();
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { name: true },
+  });
+  if (!org) notFound();
+  return (
+    <TeamsClient
+      orgId={orgId}
+      orgName={org.name}
+      yourRole={membership.role}
+    />
+  );
+}

--- a/apps/mobility/app/api/orgs/[orgId]/teams/[teamId]/members/[teamMemberId]/route.ts
+++ b/apps/mobility/app/api/orgs/[orgId]/teams/[teamId]/members/[teamMemberId]/route.ts
@@ -1,0 +1,36 @@
+/**
+ * DELETE /api/orgs/[orgId]/teams/[teamId]/members/[teamMemberId]
+ *   Remove a user from a team. 404 when the row doesn't belong to
+ *   the given team+org (defence-in-depth against id-guessing).
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+
+type Params = Promise<{
+  orgId: string;
+  teamId: string;
+  teamMemberId: string;
+}>;
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId, teamId, teamMemberId } = await params;
+  const denied = await requireOrgAccess(orgId, "manage");
+  if (denied) return denied;
+
+  const row = await prisma.teamMember.findFirst({
+    where: {
+      id: teamMemberId,
+      teamId,
+      team: { organizationId: orgId },
+    },
+    select: { id: true },
+  });
+  if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await prisma.teamMember.delete({ where: { id: teamMemberId } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/mobility/app/api/orgs/[orgId]/teams/[teamId]/members/route.ts
+++ b/apps/mobility/app/api/orgs/[orgId]/teams/[teamId]/members/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/orgs/[orgId]/teams/[teamId]/members
+ *   Add a user to a team. Body: `{ userId }`. The user must already be
+ *   an OrganizationMember of the team's org — no cross-org grants.
+ *
+ *   Duplicate adds are a no-op (upsert-like), so the picker doesn't
+ *   have to filter its list against already-added users.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { Prisma } from "@prisma/client";
+
+type Params = Promise<{ orgId: string; teamId: string }>;
+
+const Body = z.object({
+  userId: z.string().min(1),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId, teamId } = await params;
+  const denied = await requireOrgAccess(orgId, "manage");
+  if (denied) return denied;
+
+  const team = await prisma.team.findFirst({
+    where: { id: teamId, organizationId: orgId },
+    select: { id: true },
+  });
+  if (!team) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const { userId } = parsed.data;
+
+  const orgMembership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: { organizationId: orgId, userId },
+    },
+    select: { userId: true },
+  });
+  if (!orgMembership) {
+    return NextResponse.json(
+      { error: "User is not a member of this organisation" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const member = await prisma.teamMember.create({
+      data: { teamId, userId },
+      select: {
+        id: true,
+        userId: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true, image: true } },
+      },
+    });
+    return NextResponse.json({
+      id: member.id,
+      userId: member.userId,
+      createdAt: member.createdAt.toISOString(),
+      user: member.user,
+    });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      // Already a member — return the existing row so the client can
+      // treat this as idempotent.
+      const existing = await prisma.teamMember.findUnique({
+        where: { teamId_userId: { teamId, userId } },
+        select: {
+          id: true,
+          userId: true,
+          createdAt: true,
+          user: { select: { id: true, name: true, email: true, image: true } },
+        },
+      });
+      if (existing) {
+        return NextResponse.json({
+          id: existing.id,
+          userId: existing.userId,
+          createdAt: existing.createdAt.toISOString(),
+          user: existing.user,
+        });
+      }
+    }
+    throw err;
+  }
+}

--- a/apps/mobility/app/api/orgs/[orgId]/teams/[teamId]/route.ts
+++ b/apps/mobility/app/api/orgs/[orgId]/teams/[teamId]/route.ts
@@ -1,0 +1,133 @@
+/**
+ * GET    /api/orgs/[orgId]/teams/[teamId] — team detail + members.
+ * PATCH  /api/orgs/[orgId]/teams/[teamId] — rename / re-describe.
+ * DELETE /api/orgs/[orgId]/teams/[teamId] — drop the team (cascades
+ *                                             members + world grants).
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { Prisma } from "@prisma/client";
+
+type Params = Promise<{ orgId: string; teamId: string }>;
+
+const PatchBody = z.object({
+  name: z.string().trim().min(1).max(80).optional(),
+  description: z.string().trim().max(500).nullable().optional(),
+});
+
+async function loadScopedTeam(orgId: string, teamId: string) {
+  return prisma.team.findFirst({
+    where: { id: teamId, organizationId: orgId },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      createdAt: true,
+      members: {
+        orderBy: { createdAt: "asc" },
+        select: {
+          id: true,
+          userId: true,
+          createdAt: true,
+          user: {
+            select: { id: true, name: true, email: true, image: true },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId, teamId } = await params;
+  const denied = await requireOrgAccess(orgId, "read");
+  if (denied) return denied;
+
+  const team = await loadScopedTeam(orgId, teamId);
+  if (!team) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  return NextResponse.json({
+    id: team.id,
+    name: team.name,
+    description: team.description,
+    createdAt: team.createdAt.toISOString(),
+    members: team.members.map((m) => ({
+      id: m.id,
+      userId: m.userId,
+      createdAt: m.createdAt.toISOString(),
+      user: m.user,
+    })),
+  });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId, teamId } = await params;
+  const denied = await requireOrgAccess(orgId, "manage");
+  if (denied) return denied;
+
+  const exists = await prisma.team.findFirst({
+    where: { id: teamId, organizationId: orgId },
+    select: { id: true },
+  });
+  if (!exists) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PatchBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const updated = await prisma.team.update({
+      where: { id: teamId },
+      data: parsed.data,
+      select: { id: true, name: true, description: true },
+    });
+    return NextResponse.json(updated);
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "A team with that name already exists" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId, teamId } = await params;
+  const denied = await requireOrgAccess(orgId, "manage");
+  if (denied) return denied;
+
+  const exists = await prisma.team.findFirst({
+    where: { id: teamId, organizationId: orgId },
+    select: { id: true },
+  });
+  if (!exists) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await prisma.team.delete({ where: { id: teamId } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/mobility/app/api/orgs/[orgId]/teams/route.ts
+++ b/apps/mobility/app/api/orgs/[orgId]/teams/route.ts
@@ -1,0 +1,101 @@
+/**
+ * GET  /api/orgs/[orgId]/teams — list teams in the org with member
+ *                                 counts, ordered oldest-first so the
+ *                                 UI has stable ordering across polls.
+ * POST /api/orgs/[orgId]/teams — create a team. Requires `manage`
+ *                                 (same bar as inviting members).
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireOrgAccess } from "@/lib/authz";
+import { Prisma } from "@prisma/client";
+
+type Params = Promise<{ orgId: string }>;
+
+const CreateBody = z.object({
+  name: z.string().trim().min(1).max(80),
+  description: z.string().trim().max(500).optional().nullable(),
+});
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId } = await params;
+  const denied = await requireOrgAccess(orgId, "read");
+  if (denied) return denied;
+
+  const teams = await prisma.team.findMany({
+    where: { organizationId: orgId },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      createdAt: true,
+      _count: { select: { members: true } },
+    },
+  });
+  return NextResponse.json({
+    teams: teams.map((t) => ({
+      id: t.id,
+      name: t.name,
+      description: t.description,
+      memberCount: t._count.members,
+      createdAt: t.createdAt.toISOString(),
+    })),
+  });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { orgId } = await params;
+  const denied = await requireOrgAccess(orgId, "manage");
+  if (denied) return denied;
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = CreateBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const team = await prisma.team.create({
+      data: {
+        organizationId: orgId,
+        name: parsed.data.name,
+        description: parsed.data.description ?? null,
+      },
+      select: { id: true, name: true, description: true, createdAt: true },
+    });
+    return NextResponse.json({
+      id: team.id,
+      name: team.name,
+      description: team.description,
+      memberCount: 0,
+      createdAt: team.createdAt.toISOString(),
+    });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "A team with that name already exists in this organisation" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/apps/mobility/app/api/worlds/[worldId]/principals/[principalId]/route.ts
+++ b/apps/mobility/app/api/worlds/[worldId]/principals/[principalId]/route.ts
@@ -1,0 +1,33 @@
+/**
+ * DELETE /api/worlds/[worldId]/principals/[principalId]
+ *   Revoke an access grant. 404 when the row doesn't belong to the
+ *   given world (defence-in-depth against id-guessing across worlds).
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ worldId: string; principalId: string }>;
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { worldId, principalId } = await params;
+  const world = await prisma.mobilityWorld.findUnique({
+    where: { id: worldId },
+    select: { projectId: true },
+  });
+  if (!world) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const denied = await requireProjectAccess(world.projectId, "write");
+  if (denied) return denied;
+
+  const row = await prisma.mobilityWorldPrincipal.findFirst({
+    where: { id: principalId, worldId },
+    select: { id: true },
+  });
+  if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await prisma.mobilityWorldPrincipal.delete({ where: { id: principalId } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/mobility/app/api/worlds/[worldId]/principals/route.ts
+++ b/apps/mobility/app/api/worlds/[worldId]/principals/route.ts
@@ -1,0 +1,207 @@
+/**
+ * GET  /api/worlds/[worldId]/principals — list access grants (users
+ *                                          and teams) with denormalised
+ *                                          display info.
+ * POST /api/worlds/[worldId]/principals — add a grant. Body is
+ *   `{ kind: "user", userId }` or `{ kind: "team", teamId }`. The
+ *   subject must belong to the world's org, and duplicates are a
+ *   no-op returning the existing row.
+ *
+ * Requires project `write` access — same bar as broadcast.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+import { Prisma } from "@prisma/client";
+
+type Params = Promise<{ worldId: string }>;
+
+const AddBody = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("user"), userId: z.string().min(1) }),
+  z.object({ kind: z.literal("team"), teamId: z.string().min(1) }),
+]);
+
+async function loadWorldOrDeny(worldId: string) {
+  return prisma.mobilityWorld.findUnique({
+    where: { id: worldId },
+    select: {
+      projectId: true,
+      project: { select: { organizationId: true } },
+    },
+  });
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { worldId } = await params;
+  const world = await loadWorldOrDeny(worldId);
+  if (!world) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const denied = await requireProjectAccess(world.projectId, "read");
+  if (denied) return denied;
+
+  const rows = await prisma.mobilityWorldPrincipal.findMany({
+    where: { worldId },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      kind: true,
+      createdAt: true,
+      user: { select: { id: true, name: true, email: true, image: true } },
+      team: {
+        select: {
+          id: true,
+          name: true,
+          _count: { select: { members: true } },
+        },
+      },
+    },
+  });
+  return NextResponse.json({
+    principals: rows.map((r) => ({
+      id: r.id,
+      kind: r.kind,
+      createdAt: r.createdAt.toISOString(),
+      user: r.user,
+      team: r.team
+        ? { id: r.team.id, name: r.team.name, memberCount: r.team._count.members }
+        : null,
+    })),
+  });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { worldId } = await params;
+  const world = await loadWorldOrDeny(worldId);
+  if (!world) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const denied = await requireProjectAccess(world.projectId, "write");
+  if (denied) return denied;
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = AddBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  // Enforce that the subject belongs to the world's organisation.
+  // Without this, an operator with write access to a project could
+  // grant access to any user or team by id — a subtle privilege
+  // escalation across orgs.
+  if (parsed.data.kind === "user") {
+    const inOrg = await prisma.organizationMember.findUnique({
+      where: {
+        organizationId_userId: {
+          organizationId: world.project.organizationId,
+          userId: parsed.data.userId,
+        },
+      },
+      select: { userId: true },
+    });
+    if (!inOrg) {
+      return NextResponse.json(
+        { error: "User is not a member of this organisation" },
+        { status: 400 },
+      );
+    }
+  } else {
+    const team = await prisma.team.findFirst({
+      where: {
+        id: parsed.data.teamId,
+        organizationId: world.project.organizationId,
+      },
+      select: { id: true },
+    });
+    if (!team) {
+      return NextResponse.json(
+        { error: "Team not found in this organisation" },
+        { status: 400 },
+      );
+    }
+  }
+
+  try {
+    const row = await prisma.mobilityWorldPrincipal.create({
+      data:
+        parsed.data.kind === "user"
+          ? { worldId, kind: "user", userId: parsed.data.userId }
+          : { worldId, kind: "team", teamId: parsed.data.teamId },
+      select: {
+        id: true,
+        kind: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true, image: true } },
+        team: {
+          select: {
+            id: true,
+            name: true,
+            _count: { select: { members: true } },
+          },
+        },
+      },
+    });
+    return NextResponse.json({
+      id: row.id,
+      kind: row.kind,
+      createdAt: row.createdAt.toISOString(),
+      user: row.user,
+      team: row.team
+        ? { id: row.team.id, name: row.team.name, memberCount: row.team._count.members }
+        : null,
+    });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      // Idempotent — return the existing row.
+      const existing = await prisma.mobilityWorldPrincipal.findFirst({
+        where:
+          parsed.data.kind === "user"
+            ? { worldId, kind: "user", userId: parsed.data.userId }
+            : { worldId, kind: "team", teamId: parsed.data.teamId },
+        select: {
+          id: true,
+          kind: true,
+          createdAt: true,
+          user: { select: { id: true, name: true, email: true, image: true } },
+          team: {
+            select: {
+              id: true,
+              name: true,
+              _count: { select: { members: true } },
+            },
+          },
+        },
+      });
+      if (existing) {
+        return NextResponse.json({
+          id: existing.id,
+          kind: existing.kind,
+          createdAt: existing.createdAt.toISOString(),
+          user: existing.user,
+          team: existing.team
+            ? {
+                id: existing.team.id,
+                name: existing.team.name,
+                memberCount: existing.team._count.members,
+              }
+            : null,
+        });
+      }
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Arc A PR2 — operator surfaces that consume the schema shipped in #249. **Stacked on #249** — base branch is `feat/mobility-teams-and-world-principals`, so the diff shows only PR2's additions. Merges cleanly against `main` once #249 lands.

**Teams admin (`/org/[orgId]/teams`):**

- List page — create + delete teams, member-count chip per row.
- Detail page (`/teams/[teamId]`) — split into "Members" (remove) and "Add org members" (search + add). Picker filters out users already on the team so the list is always actionable.
- Nav — new "Teams" entry in the org-level sidebar between Members and Settings. Renamed the old "Team" nav to "Members" since it always pointed at the members page.

**Per-world access (`AccessCard` on WorldEditor):**

- Only rendered when the world is set to `authenticated` — public / linkOnly worlds don't gate on principals.
- Lists current grants as chips (team name + member count, or user display name), with a revoke button per row. Empty state is an amber warning since no grants = no access.
- Add form: Team/User tab picker → filtered dropdown → Grant button. Options are pre-filtered to hide already-granted principals.

**API routes (all with org/project auth gates):**

- `GET|POST /api/orgs/[orgId]/teams` — list/create with unique name enforcement (409 on duplicate).
- `GET|PATCH|DELETE /api/orgs/[orgId]/teams/[teamId]` — team CRUD with cross-org id-guessing defence.
- `POST /api/orgs/[orgId]/teams/[teamId]/members` — idempotent add (returns existing row on P2002), rejects non-org users.
- `DELETE /api/orgs/[orgId]/teams/[teamId]/members/[teamMemberId]`.
- `GET|POST /api/worlds/[worldId]/principals` — list/add grants; discriminated-union body `{kind, userId|teamId}`, enforces the subject belongs to the world's org so cross-org escalation can't happen.
- `DELETE /api/worlds/[worldId]/principals/[principalId]`.

Teams routes gate on `requireOrgAccess(orgId, "manage")` for mutations, `"read"` for lists. World-principal routes gate on `requireProjectAccess(projectId, "write")` — same bar as broadcast.

## Test plan

- [ ] Create a team, add org members, verify member count
- [ ] Delete a team → cascades members + world grants
- [ ] Set a world to `authenticated` visibility → AccessCard appears
- [ ] Grant a team → user in that team can view `/w/<slug>`; others get 403
- [ ] Grant a user directly → same works
- [ ] Revoke → viewer loses access on next page load
- [ ] Non-owner without any grant sees the access-denied surface
- [ ] Cross-org privilege escalation attempt (grant a user from another org) rejected with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)