### PR TITLE
feat(mobility): broadcast composer — deep-link field + history list

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
@@ -943,11 +943,26 @@ function ThemePreview({
 
 /* ───────────────────── Broadcast composer ─────────────────────── */
 
+interface BroadcastHistoryEntry {
+  id: string;
+  sentAt: string;
+  title: string | null;
+  attempted: number;
+  delivered: number;
+  pruned: number;
+  url: string | null;
+}
+
 function BroadcastCard({ world }: { world: World }) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const [url, setUrl] = useState("");
   const [sending, setSending] = useState(false);
   const router = useRouter();
+  const { data: historyData, mutate: mutateHistory } = useSWR<{
+    broadcasts: BroadcastHistoryEntry[];
+  }>(`/api/worlds/${world.id}/broadcasts`, accessFetcher);
+  const history = historyData?.broadcasts ?? [];
 
   const canSend =
     world.isPublished &&
@@ -961,10 +976,18 @@ function BroadcastCard({ world }: { world: World }) {
     if (!canSend) return;
     setSending(true);
     try {
+      const trimmedUrl = url.trim();
       const res = await fetch(`/api/worlds/${world.id}/broadcast`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ title: title.trim(), body: body.trim() }),
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          // Only forward `url` when the operator typed one — the
+          // server defaults to `/w/<slug>` otherwise, which is the
+          // right root behaviour for a generic broadcast.
+          ...(trimmedUrl ? { url: trimmedUrl } : {}),
+        }),
       });
       const data = (await res.json().catch(() => null)) as
         | { ok?: boolean; attempted?: number; delivered?: number; pruned?: number; error?: string }
@@ -977,6 +1000,8 @@ function BroadcastCard({ world }: { world: World }) {
       );
       setTitle("");
       setBody("");
+      setUrl("");
+      void mutateHistory();
       router.refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Broadcast failed");
@@ -1032,6 +1057,20 @@ function BroadcastCard({ world }: { world: World }) {
             className="mt-1 block w-full rounded-md border border-line-soft bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent focus:outline-none"
           />
         </label>
+        <label className="block text-xs font-medium text-text-secondary">
+          Deep link
+          <span className="ml-1.5 rounded bg-surface-2 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+            optional
+          </span>
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            maxLength={500}
+            placeholder={`/w/${world.slug}/incident/42 · defaults to the world root`}
+            className="mt-1 block w-full rounded-md border border-line-soft bg-bg px-3 py-2 font-mono text-xs text-text-primary placeholder:text-text-tertiary focus:border-accent focus:outline-none"
+          />
+        </label>
         <div className="flex items-center justify-between">
           {reason ? (
             <p className="text-[11px] text-text-tertiary">{reason}</p>
@@ -1048,6 +1087,40 @@ function BroadcastCard({ world }: { world: World }) {
           </button>
         </div>
       </form>
+
+      {history.length > 0 && (
+        <div className="mt-5 border-t border-line-soft pt-4">
+          <h3 className="mb-2 text-[11px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+            Recent broadcasts
+          </h3>
+          <ul className="divide-y divide-line-soft">
+            {history.map((b) => (
+              <li key={b.id} className="flex items-start gap-3 py-2.5">
+                <div className="flex-1 min-w-0">
+                  <p className="truncate text-sm text-text-primary">
+                    {b.title ?? "(untitled broadcast)"}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-text-tertiary">
+                    {formatRelative(b.sentAt)}
+                    {b.url ? (
+                      <>
+                        {" · "}
+                        <span className="font-mono">{b.url}</span>
+                      </>
+                    ) : null}
+                  </p>
+                </div>
+                <span
+                  className="shrink-0 rounded-full bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-text-secondary"
+                  title={`${b.delivered} delivered / ${b.attempted} attempted / ${b.pruned} pruned`}
+                >
+                  {b.delivered} / {b.attempted}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/mobility/app/api/worlds/[worldId]/broadcast/route.ts
+++ b/apps/mobility/app/api/worlds/[worldId]/broadcast/route.ts
@@ -84,6 +84,11 @@ export async function POST(
     kind: "broadcast_sent",
     meta: {
       title: parsed.data.title,
+      // Persist the deep-link URL that was pushed so the operator's
+      // "recent broadcasts" list can show where each notification
+      // pointed. Defaults to the world root when the composer left
+      // it blank (same fallback as the push payload itself).
+      url: parsed.data.url ?? `/w/${world.slug}`,
       attempted: result.attempted,
       delivered: result.delivered,
       pruned: result.pruned,

--- a/apps/mobility/app/api/worlds/[worldId]/broadcasts/route.ts
+++ b/apps/mobility/app/api/worlds/[worldId]/broadcasts/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /api/worlds/[worldId]/broadcasts
+ *   Recent broadcast audit log (last 10). Reads from `MobilityWorldEvent`
+ *   rows tagged `broadcast_sent` — the same rows the broadcast POST
+ *   endpoint appends. Meta carries `{title, attempted, delivered, pruned}`.
+ *
+ * Requires `read` on the project — the audit log is operator-only.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ worldId: string }>;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { worldId } = await params;
+  const world = await prisma.mobilityWorld.findUnique({
+    where: { id: worldId },
+    select: { projectId: true },
+  });
+  if (!world) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const denied = await requireProjectAccess(world.projectId, "read");
+  if (denied) return denied;
+
+  const rows = await prisma.mobilityWorldEvent.findMany({
+    where: { worldId, kind: "broadcast_sent" },
+    orderBy: { createdAt: "desc" },
+    take: 10,
+    select: { id: true, createdAt: true, meta: true },
+  });
+
+  return NextResponse.json({
+    broadcasts: rows.map((r) => {
+      const meta = (r.meta ?? {}) as {
+        title?: string;
+        attempted?: number;
+        delivered?: number;
+        pruned?: number;
+        url?: string;
+      };
+      return {
+        id: r.id,
+        sentAt: r.createdAt.toISOString(),
+        title: meta.title ?? null,
+        attempted: meta.attempted ?? 0,
+        delivered: meta.delivered ?? 0,
+        pruned: meta.pruned ?? 0,
+        url: meta.url ?? null,
+      };
+    }),
+  });
+}


### PR DESCRIPTION
## Summary

Arc B PR1. **Stacked on #250** — base branch is `feat/mobility-teams-admin-ui` since both PRs touch the same `WorldEditor.tsx`. Rebases cleanly to `main` once #249 + #250 merge in order.

The push pipe (`sendPushToWorld` + subscriber upsert) and the composer form were already in place from Mobility Worlds PR3. This adds the two things that were still missing:

- **Deep-link field.** Optional URL input on the composer. Empty defaults to `/w/<slug>` server-side (unchanged behaviour). When set, tapping the notification deep-links into a specific incident, alert, or map view instead of just the world root. The URL is persisted in `MobilityWorldEvent.meta` alongside the other broadcast metrics so history can show where each notification pointed.

- **Recent broadcasts list.** New `GET /api/worlds/[worldId]/broadcasts` returns the last 10 rows tagged `broadcast_sent` with title, timestamp, delivered/attempted counts, and the deep-link URL. Rendered under the composer form so the operator can confirm the send just fired and see what's already gone out. Requires project `read`.

Arc C PR3's auto-fanout from alert rules will re-use both — alert-triggered notifications will write to the same event log and show up in this history alongside manual broadcasts.

## Test plan

- [ ] Send a broadcast with a title/body but no URL → history row shows `/w/<slug>` as the deep link
- [ ] Send a broadcast with `?url=/w/<slug>/incident/42` → notification tap opens that specific path, history row shows the custom URL
- [ ] Sending 11+ broadcasts caps the history list at 10 (most recent first)
- [ ] Non-project-write user cannot POST the broadcast (existing gate); non-project-read user cannot GET the history

🤖 Generated with [Claude Code](https://claude.com/claude-code)