### PR TITLE
feat(mock-inet): scenarios that mutate device data (Arc C PR1)

### DIFF
--- a/apps/mock-inet/app/api/demo/overrides/route.ts
+++ b/apps/mock-inet/app/api/demo/overrides/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/demo/overrides
+ *   List the currently-active status overrides. Debug affordance for
+ *   the demo picker + operator troubleshooting — lets someone confirm
+ *   that a scenario POST actually took effect on the instance handling
+ *   /status calls.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireBasicAuth } from "@/lib/auth";
+import { activeOverrides } from "@/lib/overrides";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const denied = requireBasicAuth(request);
+  if (denied) return denied;
+  const now = Date.now();
+  return NextResponse.json({
+    now,
+    overrides: activeOverrides().map((o) => ({
+      ...o,
+      expiresInMs: Math.max(0, o.expiresAt - now),
+    })),
+  });
+}

--- a/apps/mock-inet/app/api/demo/scenario/[name]/route.ts
+++ b/apps/mock-inet/app/api/demo/scenario/[name]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBasicAuth } from "@/lib/auth";
-import { runIncident, runTraffic, runVmsInspection } from "@/lib/scenarios";
+import {
+  runDmsAlarm,
+  runIncident,
+  runIncidentCascade,
+  runRadarSpike,
+  runTraffic,
+  runVmsInspection,
+} from "@/lib/scenarios";
 
 export const runtime = "nodejs";
 
@@ -14,21 +21,38 @@ export async function POST(request: NextRequest, { params }: Params) {
   const { name } = await params;
   const url = new URL(request.url);
   const host = `${url.protocol}//${url.host}`;
+  // Optional `deviceId` query for the targeted scenarios; when omitted
+  // the runner picks a random device of the right subsystem.
+  const deviceId = url.searchParams.get("deviceId") ?? undefined;
 
-  switch (name) {
-    case "incident":
-      return NextResponse.json(runIncident());
-    case "vms-inspection":
-      return NextResponse.json(runVmsInspection(host));
-    case "traffic":
-      return NextResponse.json(runTraffic());
-    default:
-      return NextResponse.json(
-        {
-          error: "Unknown scenario",
-          detail: "Expected `incident`, `vms-inspection`, or `traffic`.",
-        },
-        { status: 400 },
-      );
+  try {
+    switch (name) {
+      case "incident":
+        return NextResponse.json(runIncident());
+      case "vms-inspection":
+        return NextResponse.json(runVmsInspection(host));
+      case "traffic":
+        return NextResponse.json(runTraffic());
+      case "radar-spike":
+        return NextResponse.json(runRadarSpike(deviceId));
+      case "dms-alarm":
+        return NextResponse.json(runDmsAlarm(deviceId));
+      case "incident-cascade":
+        return NextResponse.json(runIncidentCascade());
+      default:
+        return NextResponse.json(
+          {
+            error: "Unknown scenario",
+            detail:
+              "Expected `incident`, `vms-inspection`, `traffic`, `radar-spike`, `dms-alarm`, or `incident-cascade`.",
+          },
+          { status: 400 },
+        );
+    }
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Scenario failed" },
+      { status: 500 },
+    );
   }
 }

--- a/apps/mock-inet/app/page.tsx
+++ b/apps/mock-inet/app/page.tsx
@@ -51,8 +51,18 @@ export default function Home() {
             "POST /api/demo/scenario/incident",
             "POST /api/demo/scenario/vms-inspection",
             "POST /api/demo/scenario/traffic",
+            "POST /api/demo/scenario/radar-spike (optional ?deviceId=…)",
+            "POST /api/demo/scenario/dms-alarm (optional ?deviceId=…)",
+            "POST /api/demo/scenario/incident-cascade",
+            "GET  /api/demo/overrides — inspect active status overrides",
           ]}
         />
+        <p style={{ marginTop: 12, color: "#94a3b8", fontSize: 13 }}>
+          Radar / DMS scenarios flip device status for 3 minutes and
+          emit <code>device.status_changed</code> events. Wire a
+          webhook against them from Mobility to drive the alert-rule
+          engine.
+        </p>
       </Section>
 
       <p style={{ marginTop: 40, color: "#64748b" }}>

--- a/apps/mock-inet/lib/devices.ts
+++ b/apps/mock-inet/lib/devices.ts
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Device, Subsystem, WorldFilter } from "./types";
 import { isSubsystem } from "./types";
+import { getOverride } from "./overrides";
 
 let cache: Device[] | null = null;
 
@@ -151,6 +152,17 @@ export function fetchFromSubsystem(requested: Subsystem): Subsystem {
  * drawer's `live.status.raw` blob.
  */
 export function currentStatus(device: Device): Record<string, unknown> {
+  const raw = baseStatus(device);
+  // Merge any active scenario override on top. Overrides let the
+  // demo picker turn a single device "hot" for a few minutes without
+  // touching the seed — spike radar occupancy, alarm a DMS, drop
+  // reachability on a CCTV — and every subsequent /status call from
+  // that scenario's demo window returns the mutated value.
+  const override = getOverride(device.externalId);
+  return override ? { ...raw, ...override.patch, timestamp: Date.now() } : raw;
+}
+
+function baseStatus(device: Device): Record<string, unknown> {
   const now = Date.now();
   const base = {
     signId: device.externalId,

--- a/apps/mock-inet/lib/overrides.ts
+++ b/apps/mock-inet/lib/overrides.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-device status overrides driven by demo scenarios. Overrides
+ * live in-memory with an expiry timestamp — `currentStatus()` merges
+ * them on top of the deterministic base status so a scripted scenario
+ * (radar slowdown, DMS alarm, incident cascade) shows up on every
+ * subsequent `/status` call until the override lapses.
+ *
+ * Vercel serverless quirk (same one that applies to the event bus):
+ * each cold instance has its own overrides map. For a demo where the
+ * scenario POST and the /status GET land on the same warm instance
+ * this is fine; the connector polling on 15s intervals will hit the
+ * same instance within the demo window.
+ */
+export interface StatusOverride {
+  /** Epoch ms after which the override is discarded. */
+  expiresAt: number;
+  /** Fields merged over the base status shape by `currentStatus()`. */
+  patch: Record<string, unknown>;
+  /** Human-readable label surfaced by the /overrides debug endpoint. */
+  reason: string;
+}
+
+const overrides = new Map<string, StatusOverride>();
+
+export function setOverride(
+  externalId: string,
+  patch: Record<string, unknown>,
+  durationMs: number,
+  reason: string,
+): void {
+  overrides.set(externalId, {
+    expiresAt: Date.now() + durationMs,
+    patch,
+    reason,
+  });
+}
+
+/** Return the active override for a device, or `null` if none/expired.
+ *  Auto-purges expired entries as a side effect so the map doesn't
+ *  grow unbounded across a long-lived instance. */
+export function getOverride(externalId: string): StatusOverride | null {
+  const row = overrides.get(externalId);
+  if (!row) return null;
+  if (row.expiresAt < Date.now()) {
+    overrides.delete(externalId);
+    return null;
+  }
+  return row;
+}
+
+export function clearOverride(externalId: string): void {
+  overrides.delete(externalId);
+}
+
+/** For the /overrides debug endpoint — list every active override. */
+export function activeOverrides(): Array<{
+  externalId: string;
+  expiresAt: number;
+  reason: string;
+  patch: Record<string, unknown>;
+}> {
+  const now = Date.now();
+  const out: Array<{
+    externalId: string;
+    expiresAt: number;
+    reason: string;
+    patch: Record<string, unknown>;
+  }> = [];
+  for (const [externalId, row] of overrides.entries()) {
+    if (row.expiresAt < now) {
+      overrides.delete(externalId);
+      continue;
+    }
+    out.push({
+      externalId,
+      expiresAt: row.expiresAt,
+      reason: row.reason,
+      patch: row.patch,
+    });
+  }
+  return out;
+}

--- a/apps/mock-inet/lib/scenarios.ts
+++ b/apps/mock-inet/lib/scenarios.ts
@@ -12,7 +12,10 @@ import {
 } from "./incidents";
 import { createWorld } from "./worlds";
 import { startTicker, stopTicker, triggerSlowdown } from "./vds";
-import type { IncidentStatus } from "./types";
+import type { Device, IncidentStatus } from "./types";
+import { devicesBySubsystem } from "./devices";
+import { setOverride } from "./overrides";
+import { publish } from "./events";
 
 interface RunningIncident {
   id: string;
@@ -112,4 +115,131 @@ export function runTraffic(): { name: "traffic"; status: "started" | "reset" } {
 // straight from it instead of re-tracking here.
 function incidentStatus(id: string): IncidentStatus | null {
   return getIncident(id)?.status ?? null;
+}
+
+/** Default demo window for status overrides. Long enough for the
+ *  Mobility drawer's 15-second polling to see the "hot" values on
+ *  multiple polls; short enough that the demo self-cleans. */
+const OVERRIDE_MS = 3 * 60 * 1000;
+
+function pickRandom<T>(items: T[]): T | null {
+  if (items.length === 0) return null;
+  return items[Math.floor(Math.random() * items.length)]!;
+}
+
+function publishDeviceStatusChanged(device: Device): void {
+  publish({
+    type: "device.status_changed",
+    at: new Date().toISOString(),
+    // We forward the *device record* verbatim (matches the wire shape
+    // downstream connectors expect); the consumer can call /status to
+    // read the fresh values including our override.
+    payload: device,
+  });
+}
+
+/**
+ * Scenario 4 — Radar occupancy spike.
+ * Picks a radar (specific `deviceId` or random) and forces occupancy
+ * to `0.85` with speed dropped to `18` for 3 minutes. Fires two
+ * `device.status_changed` events: one at spike, one when the
+ * override expires (scheduled via `setTimeout`, best-effort).
+ *
+ * This is what an "alert me when occupancy > 70%" rule (Arc C PR3)
+ * fires on — the mock provides the trigger data on demand instead
+ * of waiting for real rush-hour traffic.
+ */
+export function runRadarSpike(deviceId?: string): {
+  name: "radar-spike";
+  status: "started";
+  deviceId: string;
+} {
+  const pool = devicesBySubsystem("radar");
+  const device = deviceId
+    ? pool.find((d) => d.externalId === deviceId) ?? pickRandom(pool)
+    : pickRandom(pool);
+  if (!device) throw new Error("No radar devices seeded");
+  setOverride(
+    device.externalId,
+    { occupancy: 0.85, speed: 18, volume: 105 },
+    OVERRIDE_MS,
+    "Scenario: radar occupancy spike",
+  );
+  publishDeviceStatusChanged(device);
+  setTimeout(() => publishDeviceStatusChanged(device), OVERRIDE_MS + 200);
+  return { name: "radar-spike", status: "started", deviceId: device.externalId };
+}
+
+/**
+ * Scenario 5 — DMS alarm.
+ * Picks a DMS sign and flips its `shortStatus` to a non-zero value +
+ * `connectable` false for 3 minutes. This makes it show up as
+ * `offline` / `alarmed` — the two `MobilityAlert.kind` values —
+ * without any actual outage. Feeds "alert me when a sign faults"
+ * rules downstream.
+ */
+export function runDmsAlarm(deviceId?: string): {
+  name: "dms-alarm";
+  status: "started";
+  deviceId: string;
+} {
+  const pool = devicesBySubsystem("dms");
+  const device = deviceId
+    ? pool.find((d) => d.externalId === deviceId) ?? pickRandom(pool)
+    : pickRandom(pool);
+  if (!device) throw new Error("No DMS devices seeded");
+  setOverride(
+    device.externalId,
+    {
+      connectable: false,
+      shortStatus: 0x0004,
+      controlMode: "manual",
+      message: "[pb]SIGN FAULT[nl]TECH DISPATCHED",
+    },
+    OVERRIDE_MS,
+    "Scenario: DMS alarm",
+  );
+  publishDeviceStatusChanged(device);
+  setTimeout(() => publishDeviceStatusChanged(device), OVERRIDE_MS + 200);
+  return { name: "dms-alarm", status: "started", deviceId: device.externalId };
+}
+
+/**
+ * Scenario 6 — Incident cascade.
+ * Combines the existing incident runner with a co-located radar
+ * spike + a DMS alarm to reproduce a realistic "something happened
+ * on the highway" moment: incident posted → nearby radar starts
+ * showing a jam → a downstream sign flips to a fault-adjacent
+ * message asking traffic to slow. Rule editors can wire distinct
+ * push targets to each of the three underlying events.
+ */
+export function runIncidentCascade(): {
+  name: "incident-cascade";
+  status: "started";
+  incidentId: string;
+  radarDeviceId: string | null;
+  dmsDeviceId: string | null;
+} {
+  const incident = runIncident();
+  const radar = pickRandom(devicesBySubsystem("radar"));
+  const dms = pickRandom(devicesBySubsystem("dms"));
+  let radarDeviceId: string | null = null;
+  let dmsDeviceId: string | null = null;
+  if (radar) {
+    const spike = runRadarSpike(radar.externalId);
+    radarDeviceId = spike.deviceId;
+  }
+  // Stagger the DMS alarm 4s in so the demo watcher sees the events
+  // arrive as a sequence, not all at once.
+  if (dms) {
+    setTimeout(() => runDmsAlarm(dms.externalId), 4_000);
+    dmsDeviceId = dms.externalId;
+  }
+  return {
+    name: "incident-cascade",
+    status: "started",
+    incidentId: incident.incidentId,
+    radarDeviceId,
+    dmsDeviceId,
+  };
 }


### PR DESCRIPTION
## Summary

Arc C PR1 — the **trigger side** of the alert-rule engine. Adds three new one-tap scenarios that flip a device's live status for a demo window, plus a small override store the `/status` handler merges over the base value. Independent of Arc A + Arc B — mock-only.

## New scenarios

- **`POST /api/demo/scenario/radar-spike[?deviceId=…]`** — forces `occupancy: 0.85`, `speed: 18`, `volume: 105` on a target radar for 3 minutes. What "alert me when occupancy > 70%" (Arc C PR3) fires on.
- **`POST /api/demo/scenario/dms-alarm[?deviceId=…]`** — flips a DMS to `connectable: false`, `shortStatus: 0x0004`, `controlMode: manual`, with a fault-adjacent message. Feeds `MobilityAlert.kind = offline|alarmed` triggers.
- **`POST /api/demo/scenario/incident-cascade`** — chains the existing incident runner with a radar spike + (staggered 4 s later) a DMS alarm. One press produces a realistic "something happened on the highway" event sequence.

## Override plumbing

- `lib/overrides.ts` — `Map<externalId, {expiresAt, patch, reason}>` (in-memory; same cold-instance caveat as the existing event bus). Auto-purges expired entries on read.
- `currentStatus()` splits into `baseStatus()` + a shallow merge of any active override — the drawer's "last polled" timestamp always refreshes so overrides look live.

## Debug affordance

- **`GET /api/demo/overrides`** — lists every active override with `{externalId, reason, expiresInMs, patch}`. Handy for confirming a scenario POST actually took effect on the instance that's serving `/status` calls.

## Test plan

- [ ] `POST /api/demo/scenario/radar-spike` → status for chosen radar now returns `occupancy: 0.85` on subsequent polls
- [ ] Same scenario replays after 3 minutes with normal values (override lapses)
- [ ] `POST /api/demo/scenario/dms-alarm` → DMS status returns `connectable: false` + `shortStatus: 0x0004`
- [ ] `POST /api/demo/scenario/incident-cascade` → response has `{incidentId, radarDeviceId, dmsDeviceId}`; overrides show up on `/api/demo/overrides`
- [ ] All three fire `device.status_changed` on the SSE stream (webhook consumer in PR2 will subscribe here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)