### PR TITLE
feat(mobility): alert-rule engine + webhook consumer (Arc C PR2)

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/SourcesClient.tsx
@@ -27,6 +27,10 @@ interface SourceRow {
   syncStatus: string | null;
   syncStartedAt: string | null;
   syncProgress: SyncProgress | null;
+  /** True when the source has an inbound webhook registered with the
+   *  upstream — surfaces on the row as a "Webhook ✓" chip so the
+   *  operator knows the alert engine will actually see events. */
+  hasWebhook: boolean;
 }
 
 interface Props {
@@ -217,6 +221,47 @@ function SourceRowItem({
     }
   };
 
+  const registerWebhook = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/sources/${row.id}/webhook`, {
+        method: "POST",
+      });
+      const body = (await res.json()) as {
+        ok?: boolean;
+        deliveryUrl?: string;
+        error?: string;
+      };
+      if (!res.ok || !body.ok) {
+        toast.error(body.error ?? "Webhook registration failed");
+        return;
+      }
+      toast.success("Webhook registered — upstream events will now trigger rules");
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const unregisterWebhook = async () => {
+    if (!confirm("Remove the inbound webhook? Alert rules will stop firing until re-registered."))
+      return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/sources/${row.id}/webhook`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        toast.success("Webhook removed");
+        onChanged();
+      } else {
+        toast.error("Remove failed");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const lastSyncedDisplay = row.lastSyncedAt
     ? new Date(row.lastSyncedAt).toLocaleString()
     : "never";
@@ -281,6 +326,27 @@ function SourceRowItem({
                 ? "Syncing…"
                 : "Sync now"}
           </button>
+          {row.hasWebhook ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={unregisterWebhook}
+              title="Remove the inbound webhook — rules stop firing until re-registered."
+              className="inline-flex items-center gap-1.5 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-700 transition-colors hover:border-red-500/60 hover:bg-red-500/10 hover:text-red-600 disabled:opacity-50"
+            >
+              Webhook ✓
+            </button>
+          ) : (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={registerWebhook}
+              title="Provision an inbound webhook so upstream events fire the project's alert rules."
+              className="rounded-md border border-line-strong px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+            >
+              Register webhook
+            </button>
+          )}
           <button
             type="button"
             disabled={busy || isRunning}

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/sources/page.tsx
@@ -57,6 +57,7 @@ export default async function SourcesPage({
       syncStatus: true,
       syncStartedAt: true,
       syncProgress: true,
+      webhookId: true,
     },
   });
 
@@ -65,7 +66,7 @@ export default async function SourcesPage({
   // Marshal Date / JSON fields into the client-friendly shape the
   // SourcesClient expects (Date → ISO string; JSON value → typed
   // SyncProgress shape).
-  const serialised = initialSources.map((s) => ({
+  const serialised = initialSources.map(({ webhookId, ...s }) => ({
     ...s,
     syncStartedAt: s.syncStartedAt ? s.syncStartedAt.toISOString() : null,
     syncProgress:
@@ -79,6 +80,9 @@ export default async function SourcesPage({
             message?: string;
           })
         : null,
+    // Boolean projection — the secret / id itself never crosses to
+    // the client.
+    hasWebhook: webhookId !== null,
   }));
 
   return (

--- a/apps/mobility/app/api/projects/[projectId]/alert-rules/[ruleId]/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/alert-rules/[ruleId]/route.ts
@@ -1,0 +1,98 @@
+/**
+ * PATCH  /api/projects/[projectId]/alert-rules/[ruleId] — update.
+ * DELETE /api/projects/[projectId]/alert-rules/[ruleId] — remove.
+ *
+ * Requires project `write`.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+import { RuleBody, RuleTargets } from "@/lib/mobility/alert-rules";
+import type { Prisma } from "@prisma/client";
+
+type Params = Promise<{ projectId: string; ruleId: string }>;
+
+const PatchBody = z
+  .object({
+    name: z.string().trim().min(1).max(80).optional(),
+    enabled: z.boolean().optional(),
+    targets: RuleTargets.optional(),
+  })
+  .and(z.union([z.object({}), RuleBody]));
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId, ruleId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  const rule = await prisma.mobilityAlertRule.findFirst({
+    where: { id: ruleId, projectId },
+    select: { id: true },
+  });
+  if (!rule) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PatchBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  // Prisma's typed update accepts only the fields we set — build the
+  // patch conditionally so unspecified fields aren't reset to defaults.
+  const data: Prisma.MobilityAlertRuleUpdateInput = {};
+  if (parsed.data.name !== undefined) data.name = parsed.data.name;
+  if (parsed.data.enabled !== undefined) data.enabled = parsed.data.enabled;
+  if ("kind" in parsed.data) {
+    data.kind = parsed.data.kind;
+    data.config = parsed.data.config as unknown as Prisma.InputJsonValue;
+  }
+  if (parsed.data.targets !== undefined) {
+    data.targets = parsed.data.targets as unknown as Prisma.InputJsonValue;
+  }
+
+  const updated = await prisma.mobilityAlertRule.update({
+    where: { id: ruleId },
+    data,
+    select: {
+      id: true,
+      name: true,
+      sourceId: true,
+      enabled: true,
+      kind: true,
+      config: true,
+      targets: true,
+      updatedAt: true,
+    },
+  });
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId, ruleId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  const rule = await prisma.mobilityAlertRule.findFirst({
+    where: { id: ruleId, projectId },
+    select: { id: true },
+  });
+  if (!rule) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await prisma.mobilityAlertRule.delete({ where: { id: ruleId } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/mobility/app/api/projects/[projectId]/alert-rules/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/alert-rules/route.ts
@@ -1,0 +1,110 @@
+/**
+ * GET  /api/projects/[projectId]/alert-rules — list.
+ * POST /api/projects/[projectId]/alert-rules — create. Body validated
+ *   against `RuleBody` (discriminated on `kind`) + a `targets` shape.
+ *
+ * Requires project `write` for create, `read` for list.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+import { RuleBody, RuleTargets } from "@/lib/mobility/alert-rules";
+import type { Prisma } from "@prisma/client";
+
+type Params = Promise<{ projectId: string }>;
+
+const CreateBody = z
+  .object({
+    name: z.string().trim().min(1).max(80),
+    sourceId: z.string().nullable().optional(),
+    targets: RuleTargets.optional(),
+    enabled: z.boolean().optional(),
+  })
+  .and(RuleBody);
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "read");
+  if (denied) return denied;
+
+  const rules = await prisma.mobilityAlertRule.findMany({
+    where: { projectId },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      name: true,
+      sourceId: true,
+      enabled: true,
+      kind: true,
+      config: true,
+      targets: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+  return NextResponse.json({ rules });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = CreateBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.sourceId) {
+    const src = await prisma.mobilityDataSource.findFirst({
+      where: { id: parsed.data.sourceId, projectId },
+      select: { id: true },
+    });
+    if (!src) {
+      return NextResponse.json(
+        { error: "Source does not belong to this project" },
+        { status: 400 },
+      );
+    }
+  }
+
+  const rule = await prisma.mobilityAlertRule.create({
+    data: {
+      projectId,
+      sourceId: parsed.data.sourceId ?? null,
+      name: parsed.data.name,
+      enabled: parsed.data.enabled ?? true,
+      kind: parsed.data.kind,
+      config: parsed.data.config as unknown as Prisma.InputJsonValue,
+      targets: (parsed.data.targets ?? { worldIds: [] }) as unknown as Prisma.InputJsonValue,
+    },
+    select: {
+      id: true,
+      name: true,
+      sourceId: true,
+      enabled: true,
+      kind: true,
+      config: true,
+      targets: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+  return NextResponse.json(rule);
+}

--- a/apps/mobility/app/api/projects/[projectId]/sources/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/sources/route.ts
@@ -52,11 +52,31 @@ export async function GET(
       syncStatus: true,
       syncStartedAt: true,
       syncProgress: true,
+      // Only expose a boolean — the secret itself never leaves the
+      // register-webhook POST response.
+      webhookId: true,
       createdAt: true,
       updatedAt: true,
     },
   });
-  return NextResponse.json({ sources: rows });
+  return NextResponse.json({
+    sources: rows.map((r) => ({
+      id: r.id,
+      connectorId: r.connectorId,
+      label: r.label,
+      config: r.config,
+      enabled: r.enabled,
+      pollIntervalSeconds: r.pollIntervalSeconds,
+      lastSyncedAt: r.lastSyncedAt,
+      lastError: r.lastError,
+      syncStatus: r.syncStatus,
+      syncStartedAt: r.syncStartedAt,
+      syncProgress: r.syncProgress,
+      hasWebhook: r.webhookId !== null,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    })),
+  });
 }
 
 export async function POST(

--- a/apps/mobility/app/api/sources/[sourceId]/webhook/route.ts
+++ b/apps/mobility/app/api/sources/[sourceId]/webhook/route.ts
@@ -1,0 +1,181 @@
+/**
+ * POST   /api/sources/[sourceId]/webhook — provision an inbound
+ *   webhook so upstream events land on
+ *   `/api/webhooks/inet-atms/[sourceId]`. Generates a random secret,
+ *   persists it on the source, and POSTs to the upstream's webhook
+ *   registry (mock: `POST {host}/api/webhooks`). Returns the URL +
+ *   secret so the operator can also register it manually if the
+ *   auto-provision hop fails.
+ *
+ * DELETE /api/sources/[sourceId]/webhook — clears the local secret /
+ *   webhookId + best-effort DELETE against the upstream.
+ *
+ * Requires project `write` access — same bar as the sync toggle.
+ */
+import { randomBytes } from "node:crypto";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+import { decryptCredentials } from "@/lib/mobility/data-source";
+
+type Params = Promise<{ sourceId: string }>;
+
+/** Upstream event types the alert engine cares about. `vds.tick`
+ *  fires 1Hz on the mock and is pure telemetry; skip it so the
+ *  webhook consumer isn't spammed. */
+const SUBSCRIBED_EVENTS = [
+  "device.status_changed",
+  "incident.posted",
+  "incident.status_changed",
+] as const;
+
+function baseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ??
+    process.env.NEXTAUTH_URL ??
+    "http://localhost:3004"
+  );
+}
+
+async function fetchSource(sourceId: string) {
+  return prisma.mobilityDataSource.findUnique({
+    where: { id: sourceId },
+    select: {
+      id: true,
+      projectId: true,
+      connectorId: true,
+      config: true,
+      credentialsEncrypted: true,
+      webhookId: true,
+    },
+  });
+}
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { sourceId } = await params;
+  const source = await fetchSource(sourceId);
+  if (!source) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const denied = await requireProjectAccess(source.projectId, "write");
+  if (denied) return denied;
+
+  if (source.connectorId !== "inet-atms") {
+    return NextResponse.json(
+      { error: "Webhook auto-provision only supports the iNET-ATMS connector" },
+      { status: 400 },
+    );
+  }
+
+  const config = (source.config ?? {}) as { host?: string };
+  const host = (config.host ?? "").replace(/\/$/, "");
+  if (!host) {
+    return NextResponse.json(
+      { error: "Source has no host configured" },
+      { status: 400 },
+    );
+  }
+
+  const secret = randomBytes(24).toString("hex");
+  const deliveryUrl = `${baseUrl()}/api/webhooks/inet-atms/${sourceId}`;
+
+  const creds = decryptCredentials(source.credentialsEncrypted);
+  const authHeader = basicAuthHeader(creds);
+  const upstreamRes = await fetch(`${host}/api/webhooks`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(authHeader ? { Authorization: authHeader } : {}),
+    },
+    body: JSON.stringify({
+      url: deliveryUrl,
+      events: SUBSCRIBED_EVENTS,
+      secret,
+    }),
+  }).catch(() => null);
+
+  if (!upstreamRes) {
+    return NextResponse.json(
+      {
+        error: "Could not reach the upstream to auto-register the webhook",
+        // Return the secret + URL anyway so the operator can register
+        // it manually via the mock's picker if they choose.
+        deliveryUrl,
+        secret,
+      },
+      { status: 502 },
+    );
+  }
+  if (!upstreamRes.ok) {
+    return NextResponse.json(
+      {
+        error: `Upstream refused the registration (${upstreamRes.status})`,
+        deliveryUrl,
+        secret,
+      },
+      { status: 502 },
+    );
+  }
+
+  const body = (await upstreamRes.json().catch(() => ({}))) as {
+    id?: string;
+  };
+
+  // Persist last so a mid-flight failure above doesn't leave the
+  // source pointing at a webhook it never provisioned.
+  await prisma.mobilityDataSource.update({
+    where: { id: sourceId },
+    data: { webhookSecret: secret, webhookId: body.id ?? null },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    deliveryUrl,
+    webhookId: body.id ?? null,
+    // Return the secret exactly once so it's visible in the picker's
+    // response toast. Subsequent GETs never expose it.
+    secret,
+  });
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { sourceId } = await params;
+  const source = await fetchSource(sourceId);
+  if (!source) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const denied = await requireProjectAccess(source.projectId, "write");
+  if (denied) return denied;
+
+  const config = (source.config ?? {}) as { host?: string };
+  const host = (config.host ?? "").replace(/\/$/, "");
+  const creds = decryptCredentials(source.credentialsEncrypted);
+  const authHeader = basicAuthHeader(creds);
+
+  // Best-effort upstream cleanup — if the mock is down or unreachable,
+  // still clear the local record so the operator can re-register.
+  if (host && source.webhookId) {
+    await fetch(`${host}/api/webhooks/${source.webhookId}`, {
+      method: "DELETE",
+      headers: authHeader ? { Authorization: authHeader } : undefined,
+    }).catch(() => null);
+  }
+
+  await prisma.mobilityDataSource.update({
+    where: { id: sourceId },
+    data: { webhookSecret: null, webhookId: null },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+function basicAuthHeader(
+  creds: Record<string, unknown> | null,
+): string | null {
+  const username = typeof creds?.username === "string" ? creds.username : null;
+  const password = typeof creds?.password === "string" ? creds.password : null;
+  if (!username && !password) return null;
+  return `Basic ${Buffer.from(`${username ?? ""}:${password ?? ""}`).toString("base64")}`;
+}

--- a/apps/mobility/app/api/webhooks/inet-atms/[sourceId]/route.ts
+++ b/apps/mobility/app/api/webhooks/inet-atms/[sourceId]/route.ts
@@ -1,0 +1,154 @@
+/**
+ * POST /api/webhooks/inet-atms/[sourceId]
+ *   Inbound webhook consumer for the mock (and any real iNET tenant
+ *   that follows the same envelope). Verifies the HMAC signature on
+ *   the request body against the source's stored `webhookSecret`,
+ *   parses the event, walks the project's enabled alert rules, and
+ *   opens a `MobilityAlert` per matching rule.
+ *
+ * The push fan-out to world subscribers is Arc C PR3 — this endpoint
+ * only inserts the alert rows and returns the count. Once PR3 lands
+ * the same insert path also dispatches pushes.
+ *
+ * Auth: HMAC only. No session, no CSRF token, no rate-limit yet —
+ * upstream is the mock, which controls the secret.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { evaluateRules, type StoredRule, type UpstreamEvent } from "@/lib/mobility/alert-rules";
+
+export const runtime = "nodejs";
+
+type Params = Promise<{ sourceId: string }>;
+
+const SIGNATURE_HEADER = "x-psmdt-signature";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { sourceId } = await params;
+  const source = await prisma.mobilityDataSource.findUnique({
+    where: { id: sourceId },
+    select: { id: true, projectId: true, webhookSecret: true, enabled: true },
+  });
+  if (!source) {
+    return NextResponse.json({ error: "Unknown source" }, { status: 404 });
+  }
+  if (!source.webhookSecret) {
+    return NextResponse.json(
+      { error: "Webhook not registered for this source" },
+      { status: 400 },
+    );
+  }
+  if (!source.enabled) {
+    // Return 200 with a note so the upstream doesn't retry and
+    // eventually deactivate the webhook while the source is paused.
+    return NextResponse.json({ ok: true, ignored: "source disabled" });
+  }
+
+  // Read the raw body once — needed both for HMAC verify and for
+  // JSON parse.
+  const rawBody = await req.text();
+  const signatureHeader = req.headers.get(SIGNATURE_HEADER);
+  if (!verifySignature(rawBody, source.webhookSecret, signatureHeader)) {
+    return NextResponse.json({ error: "Bad signature" }, { status: 401 });
+  }
+
+  let event: UpstreamEvent;
+  try {
+    event = JSON.parse(rawBody) as UpstreamEvent;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!event || typeof event !== "object" || typeof event.type !== "string") {
+    return NextResponse.json({ error: "Malformed event" }, { status: 400 });
+  }
+
+  const rules = await prisma.mobilityAlertRule.findMany({
+    where: {
+      projectId: source.projectId,
+      enabled: true,
+      // Rules scoped to a source only match webhooks from that source;
+      // project-wide rules (sourceId = null) match every source.
+      OR: [{ sourceId: null }, { sourceId: source.id }],
+    },
+    select: {
+      id: true,
+      name: true,
+      enabled: true,
+      kind: true,
+      config: true,
+      targets: true,
+    },
+  });
+
+  const matches = evaluateRules(event, rules as StoredRule[]);
+  if (matches.length === 0) {
+    return NextResponse.json({ ok: true, matched: 0 });
+  }
+
+  // Resolve device ids in one query so we don't roundtrip per match.
+  // `externalId` is the *unpacked* form the mock ships; our stored
+  // `externalDeviceId` matches that shape (see sync.ts line 254).
+  const externalIds = Array.from(
+    new Set(matches.map((m) => m.externalId).filter((s): s is string => !!s)),
+  );
+  const devices = externalIds.length
+    ? await prisma.mobilityDevice.findMany({
+        where: {
+          projectId: source.projectId,
+          sourceId: source.id,
+          externalDeviceId: { in: externalIds },
+        },
+        select: { id: true, externalDeviceId: true },
+      })
+    : [];
+  const deviceIdByExternal = new Map(
+    devices.map((d) => [d.externalDeviceId, d.id]),
+  );
+
+  let inserted = 0;
+  for (const match of matches) {
+    if (!match.externalId) continue;
+    const deviceId = deviceIdByExternal.get(match.externalId);
+    if (!deviceId) continue;
+    await prisma.mobilityAlert.create({
+      data: {
+        projectId: source.projectId,
+        deviceId,
+        kind: match.alertKind,
+        message: `[${match.ruleName}] ${match.message}`,
+      },
+    });
+    inserted += 1;
+    // Arc C PR3 fan-out hook lands here — for now the caller can
+    // read `MobilityAlert` and drive push separately.
+  }
+
+  return NextResponse.json({ ok: true, matched: matches.length, inserted });
+}
+
+/** Compare the incoming signature to a re-computed one using
+ *  constant-time equality so we don't leak byte positions through a
+ *  timing side channel. Header format matches the mock's sender:
+ *  `sha256=<hex>`. */
+function verifySignature(
+  body: string,
+  secret: string,
+  header: string | null,
+): boolean {
+  if (!header) return false;
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+  const supplied = header.startsWith("sha256=") ? header.slice(7) : header;
+  if (supplied.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(
+      Buffer.from(expected, "hex"),
+      Buffer.from(supplied, "hex"),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/mobility/lib/mobility/alert-rules.ts
+++ b/apps/mobility/lib/mobility/alert-rules.ts
@@ -1,0 +1,238 @@
+/**
+ * Alert-rule evaluator. Pure functions — no DB, no side effects; the
+ * webhook consumer calls `evaluateRules(event, rules)` and passes the
+ * resulting alerts to the insert path. Splitting keeps the evaluator
+ * testable and lets Arc C PR3's rule editor preview matches against
+ * current state without a webhook round-trip.
+ */
+import { z } from "zod";
+import type { MobilityAlertKind } from "@prisma/client";
+
+// ─── Rule config schemas ────────────────────────────────────────────
+
+/** Numeric comparison ops the threshold evaluator supports. */
+const ThresholdOp = z.enum(["gt", "gte", "lt", "lte", "eq"]);
+export type ThresholdOp = z.infer<typeof ThresholdOp>;
+
+export const ThresholdConfig = z.object({
+  subsystem: z.string().min(1),
+  field: z.string().min(1),
+  op: ThresholdOp,
+  value: z.number(),
+});
+export type ThresholdConfig = z.infer<typeof ThresholdConfig>;
+
+/** Upstream event types the mock emits — mirrored from
+ *  `apps/mock-inet/lib/types.ts`. Kept as a plain string enum here
+ *  so this file doesn't cross the workspace boundary. */
+const UpstreamEventType = z.enum([
+  "device.status_changed",
+  "incident.posted",
+  "incident.status_changed",
+  "vds.tick",
+]);
+
+export const EventConfig = z.object({
+  eventType: UpstreamEventType,
+});
+export type EventConfig = z.infer<typeof EventConfig>;
+
+/** Combined discriminator — used at the API layer to validate the
+ *  `{kind, config}` pair coming from the rule editor form. */
+export const RuleBody = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("threshold"), config: ThresholdConfig }),
+  z.object({ kind: z.literal("event"), config: EventConfig }),
+]);
+export type RuleBody = z.infer<typeof RuleBody>;
+
+export const RuleTargets = z.object({
+  /** Push notification targets — the world subscribers Arc C PR3
+   *  fans out to when this rule fires. Empty = alert row only,
+   *  no push. */
+  worldIds: z.array(z.string()).default([]),
+});
+export type RuleTargets = z.infer<typeof RuleTargets>;
+
+// ─── Upstream event shapes (mirrored, not imported) ─────────────────
+
+export interface DeviceStatusEvent {
+  type: "device.status_changed";
+  at: string;
+  payload: {
+    subsystem: string;
+    externalId?: string;
+    deviceId?: string;
+    // Anything else the mock ships through — we only read `status.*`
+    // when the rule is a threshold; the rest passes through opaquely.
+    status?: Record<string, unknown> | null;
+    [k: string]: unknown;
+  };
+}
+
+export interface IncidentEvent {
+  type: "incident.posted" | "incident.status_changed";
+  at: string;
+  payload: {
+    id: string;
+    title?: string;
+    status?: string;
+    deviceId?: string | null;
+    [k: string]: unknown;
+  };
+}
+
+export type UpstreamEvent =
+  | DeviceStatusEvent
+  | IncidentEvent
+  | { type: "vds.tick"; at: string; payload: unknown };
+
+// ─── Rule shape as read from Prisma ─────────────────────────────────
+
+export interface StoredRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  kind: "threshold" | "event";
+  config: unknown;
+  targets: unknown;
+}
+
+// ─── Evaluator ──────────────────────────────────────────────────────
+
+/** What the webhook consumer produces per fired rule — enough for the
+ *  DB insert + the (Arc C PR3) push dispatch. Kept flat + serialisable
+ *  so nothing else in the pipeline needs to look up rule details. */
+export interface RuleMatch {
+  ruleId: string;
+  ruleName: string;
+  externalId: string | null;
+  subsystem: string | null;
+  alertKind: MobilityAlertKind;
+  message: string;
+  targetWorldIds: string[];
+}
+
+/** Walk `rules` against a single upstream `event`. Returns one match
+ *  per rule that fires. A malformed rule config drops the rule for
+ *  this evaluation (not an outage) rather than throwing. */
+export function evaluateRules(
+  event: UpstreamEvent,
+  rules: StoredRule[],
+): RuleMatch[] {
+  const out: RuleMatch[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    if (rule.kind === "threshold" && event.type === "device.status_changed") {
+      const parsedConfig = ThresholdConfig.safeParse(rule.config);
+      if (!parsedConfig.success) continue;
+      const match = matchThreshold(event, parsedConfig.data);
+      if (!match) continue;
+      out.push(buildMatch(rule, match.externalId, match.subsystem, match.msg));
+    } else if (rule.kind === "event") {
+      const parsedConfig = EventConfig.safeParse(rule.config);
+      if (!parsedConfig.success) continue;
+      if (parsedConfig.data.eventType !== event.type) continue;
+      const eventMatch = matchEvent(event);
+      out.push(
+        buildMatch(rule, eventMatch.externalId, eventMatch.subsystem, eventMatch.msg),
+      );
+    }
+  }
+  return out;
+}
+
+function matchThreshold(
+  event: DeviceStatusEvent,
+  cfg: ThresholdConfig,
+): {
+  externalId: string | null;
+  subsystem: string;
+  msg: string;
+} | null {
+  if ((event.payload.subsystem ?? "") !== cfg.subsystem) return null;
+  const status = event.payload.status;
+  if (!status || typeof status !== "object") return null;
+  const raw = (status as Record<string, unknown>)[cfg.field];
+  if (typeof raw !== "number") return null;
+  if (!compare(raw, cfg.op, cfg.value)) return null;
+  return {
+    externalId:
+      typeof event.payload.externalId === "string"
+        ? event.payload.externalId
+        : typeof event.payload.deviceId === "string"
+          ? event.payload.deviceId
+          : null,
+    subsystem: cfg.subsystem,
+    msg: `${cfg.subsystem}.${cfg.field} ${cfg.op} ${cfg.value} (observed ${raw})`,
+  };
+}
+
+function matchEvent(event: UpstreamEvent): {
+  externalId: string | null;
+  subsystem: string | null;
+  msg: string;
+} {
+  if (event.type === "device.status_changed") {
+    const p = event.payload;
+    return {
+      externalId:
+        typeof p.externalId === "string"
+          ? p.externalId
+          : typeof p.deviceId === "string"
+            ? p.deviceId
+            : null,
+      subsystem: typeof p.subsystem === "string" ? p.subsystem : null,
+      msg: `Device ${p.externalId ?? p.deviceId ?? "?"} status changed`,
+    };
+  }
+  if (event.type === "incident.posted" || event.type === "incident.status_changed") {
+    return {
+      externalId: (event.payload.deviceId as string) ?? null,
+      subsystem: null,
+      msg:
+        event.type === "incident.posted"
+          ? `Incident posted: ${event.payload.title ?? event.payload.id}`
+          : `Incident ${event.payload.id} → ${event.payload.status ?? "?"}`,
+    };
+  }
+  return { externalId: null, subsystem: null, msg: `${event.type} received` };
+}
+
+function buildMatch(
+  rule: StoredRule,
+  externalId: string | null,
+  subsystem: string | null,
+  msg: string,
+): RuleMatch {
+  const targets = RuleTargets.safeParse(rule.targets);
+  const worldIds = targets.success ? targets.data.worldIds : [];
+  // For now every rule maps to `alarmed`. When we grow a distinct
+  // "device stayed offline for N minutes" evaluator (v2), it will
+  // emit `offline` instead — but the current evaluator sees a single
+  // status snapshot, not a duration, so `alarmed` is the honest
+  // classification.
+  return {
+    ruleId: rule.id,
+    ruleName: rule.name,
+    externalId,
+    subsystem,
+    alertKind: "alarmed",
+    message: msg,
+    targetWorldIds: worldIds,
+  };
+}
+
+function compare(observed: number, op: ThresholdOp, target: number): boolean {
+  switch (op) {
+    case "gt":
+      return observed > target;
+    case "gte":
+      return observed >= target;
+    case "lt":
+      return observed < target;
+    case "lte":
+      return observed <= target;
+    case "eq":
+      return observed === target;
+  }
+}

--- a/packages/prisma/migrations/20260716140000_mobility_alert_rules_and_source_webhook/migration.sql
+++ b/packages/prisma/migrations/20260716140000_mobility_alert_rules_and_source_webhook/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "MobilityAlertRuleKind" AS ENUM ('threshold', 'event');
+
+-- AlterTable
+ALTER TABLE "MobilityDataSource"
+    ADD COLUMN "webhookSecret" TEXT,
+    ADD COLUMN "webhookId" TEXT;
+
+-- CreateTable
+CREATE TABLE "MobilityAlertRule" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "sourceId" TEXT,
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "kind" "MobilityAlertRuleKind" NOT NULL,
+    "config" JSONB NOT NULL DEFAULT '{}',
+    "targets" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MobilityAlertRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MobilityAlertRule_projectId_enabled_idx" ON "MobilityAlertRule"("projectId", "enabled");
+
+-- CreateIndex
+CREATE INDEX "MobilityAlertRule_sourceId_enabled_idx" ON "MobilityAlertRule"("sourceId", "enabled");
+
+-- AddForeignKey
+ALTER TABLE "MobilityAlertRule" ADD CONSTRAINT "MobilityAlertRule_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MobilityAlertRule" ADD CONSTRAINT "MobilityAlertRule_sourceId_fkey" FOREIGN KEY ("sourceId") REFERENCES "MobilityDataSource"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -238,6 +238,7 @@ model Project {
   mobilityDevices        MobilityDevice[]
   mobilityDeviceStatuses MobilityDeviceStatus[]
   mobilityAlerts         MobilityAlert[]
+  mobilityAlertRules     MobilityAlertRule[]
   // Publishable per-stakeholder PWAs — each carves a curated subset
   // of project devices, with its own slug, theme, and visibility.
   mobilityWorlds         MobilityWorld[]
@@ -867,11 +868,19 @@ model MobilityDataSource {
   /// Updated after every page so the dashboard can render a real
   /// progress card instead of a spinner with no signal.
   syncProgress         Json?
+  /// HMAC secret shared with the upstream to verify inbound webhook
+  /// events (Arc C alert engine). Set when the operator hits
+  /// "Register webhook" on the source detail; null until then.
+  webhookSecret        String?
+  /// Opaque id returned by the upstream when the webhook was
+  /// registered. Persisted so we can delete + re-register cleanly.
+  webhookId            String?
   createdAt            DateTime  @default(now())
   updatedAt            DateTime  @updatedAt
 
-  project Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  devices MobilityDevice[]
+  project    Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  devices    MobilityDevice[]
+  alertRules MobilityAlertRule[]
 
   @@index([projectId])
 }
@@ -991,6 +1000,51 @@ model MobilityAlert {
 enum MobilityAlertKind {
   offline
   alarmed
+}
+
+/// Operator-defined rule that turns an incoming webhook event or a
+/// device status field into a `MobilityAlert` row. Rules are project-
+/// scoped; `sourceId` optionally narrows to a single source (radar
+/// rig, DMS group). `kind` picks between two evaluator shapes:
+///
+///   threshold — trigger when a device's status field crosses a
+///               numeric threshold. Example config:
+///                 {subsystem: "radar", field: "occupancy",
+///                  op: "gt", value: 0.7}
+///
+///   event     — trigger on a raw upstream event (typically an
+///               incident post or a status change). Example config:
+///                 {eventType: "incident.posted"}
+///
+/// `targets` lists which worlds' push subscribers should be notified
+/// when the rule fires. Populated by the rule editor UI (Arc C PR3);
+/// dispatch happens on the MobilityAlert insert path.
+model MobilityAlertRule {
+  id        String                @id @default(cuid())
+  projectId String
+  sourceId  String?
+  name      String
+  enabled   Boolean               @default(true)
+  kind      MobilityAlertRuleKind
+  /// Shape depends on `kind`; see model doc. Validated by Zod at the
+  /// API layer, opaque to the DB.
+  config    Json                  @default("{}")
+  /// `{worldIds: string[]}`. Empty = alert row is created but no
+  /// push fans out — still useful for the operator alerts panel.
+  targets   Json                  @default("{}")
+  createdAt DateTime              @default(now())
+  updatedAt DateTime              @updatedAt
+
+  project Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  source  MobilityDataSource? @relation(fields: [sourceId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, enabled])
+  @@index([sourceId, enabled])
+}
+
+enum MobilityAlertRuleKind {
+  threshold
+  event
 }
 
 /// Mobility "world" — a publishable, stakeholder-facing PWA that


### PR DESCRIPTION
## Summary

Arc C PR2 — the **consumer side** of the alert engine. Turns upstream webhook events into `MobilityAlert` rows via operator-defined rules. Independent of #252 (Arc C PR1) at the code level; the two together give you end-to-end trigger-to-alert once merged.

Push fan-out to worlds lands in PR3.

## Schema

- **`MobilityAlertRule`** — project-scoped, `sourceId?` narrows to a single source. `kind` picks between two evaluator shapes:
  - `threshold` — `{subsystem, field, op, value}` on a status field
  - `event` — `{eventType}` on a raw upstream event
  `targets` holds `{worldIds: string[]}` for PR3's push fan-out.
- **`MobilityAlertRuleKind`** enum.
- Two new columns on **`MobilityDataSource`**: `webhookSecret` + `webhookId` (nullable). Set by "Register webhook" flow; cleared on unregister.

## Server plumbing

- **`lib/mobility/alert-rules.ts`** — pure `evaluateRules(event, rules)` with Zod-typed config schemas. Malformed config drops the rule for the evaluation (not an outage).
- **`POST /api/webhooks/inet-atms/[sourceId]`** — inbound consumer. HMAC-SHA256 verify on the raw body against the source's stored secret (constant-time compare via `timingSafeEqual`). Parses event → walks rules → opens alerts. Rules with `sourceId=null` match all sources; scoped rules match only their source.
- **`POST /api/sources/[sourceId]/webhook`** — generates a 24-byte secret, POSTs to the upstream's webhook registry, persists both secret + returned webhook id. Returns the delivery URL + secret so the operator can register manually if the upstream is unreachable.
- **`DELETE /api/sources/[sourceId]/webhook`** — best-effort upstream cleanup + always-clears the local row.
- **`GET|POST /api/projects/[projectId]/alert-rules`** — list/create with discriminated-union body validation.
- **`PATCH|DELETE /api/projects/[projectId]/alert-rules/[ruleId]`**.

## UI touch

`SourcesClient.tsx` — new "Register webhook" / "Webhook ✓" button per source row. Uses a `hasWebhook` boolean from the list endpoint so the secret never crosses to the client.

## Test plan (once #252 also merges)

- [ ] Run `POST /api/demo/scenario/radar-spike` on the mock
- [ ] Create a threshold rule: `{subsystem: "radar", field: "occupancy", op: "gt", value: 0.7}`
- [ ] Register the webhook on the source → mock's webhook registry now has an entry pointing at Mobility
- [ ] Mock's `device.status_changed` event on next scenario POST → Mobility `/api/webhooks/inet-atms/[sourceId]` receives it → alert row inserted
- [ ] Bad HMAC signature → 401
- [ ] Disabled source → 200 with `ignored` note (no retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)