### PR TITLE
feat(mobility): alert → push fan-out + rule editor UI (Arc C PR3)

### DIFF
--- a/apps/mobility/app/(dashboard)/components/DashboardShell.tsx
+++ b/apps/mobility/app/(dashboard)/components/DashboardShell.tsx
@@ -225,7 +225,16 @@ function projectNavGroups(
           label: "Alerts",
           href: `${prefix}/alerts`,
           icon: <Bell size={16} strokeWidth={1.7} />,
-          active: is("/alerts"),
+          active:
+            pathname === `${prefix}/alerts` ||
+            (pathname.startsWith(`${prefix}/alerts/`) &&
+              !pathname.startsWith(`${prefix}/alerts/rules`)),
+        },
+        {
+          label: "Alert rules",
+          href: `${prefix}/alerts/rules`,
+          icon: <ListTodo size={16} strokeWidth={1.7} />,
+          active: is("/alerts/rules"),
         },
       ],
     },

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/RulesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/RulesClient.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import useSWR from "swr";
+import { toast } from "react-toastify";
+import {
+  ArrowLeft,
+  Bell,
+  Loader2,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (r) => {
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  });
+
+// ─── Types (mirror what the server returns) ────────────────────────
+
+type RuleKind = "threshold" | "event";
+type ThresholdOp = "gt" | "gte" | "lt" | "lte" | "eq";
+type UpstreamEventType =
+  | "device.status_changed"
+  | "incident.posted"
+  | "incident.status_changed"
+  | "vds.tick";
+
+interface RuleRow {
+  id: string;
+  name: string;
+  sourceId: string | null;
+  enabled: boolean;
+  kind: RuleKind;
+  config: unknown;
+  targets: { worldIds?: string[] } | null;
+  createdAt: string;
+}
+
+interface ListResponse {
+  rules: RuleRow[];
+}
+
+interface WorldRow {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────
+
+const SUBSYSTEMS = ["radar", "dms", "vsls", "aid", "cctv"] as const;
+
+/** Numeric fields the operator can pick per subsystem for a threshold
+ *  rule. Matches what the mock emits on `device.status_changed`; other
+ *  fields the raw shape exposes just won't fire but that's fine. */
+const FIELDS_BY_SUBSYSTEM: Record<string, string[]> = {
+  radar: ["occupancy", "speed", "volume"],
+  dms: ["shortStatus", "brightness"],
+  vsls: ["speedLimit"],
+  aid: ["eventCount"],
+  cctv: ["connectable"],
+};
+
+const OP_LABELS: Record<ThresholdOp, string> = {
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  eq: "=",
+};
+
+const EVENT_TYPES: UpstreamEventType[] = [
+  "device.status_changed",
+  "incident.posted",
+  "incident.status_changed",
+];
+
+// ─── Component ─────────────────────────────────────────────────────
+
+export function RulesClient({
+  orgId,
+  projectId,
+  projectTitle,
+}: {
+  orgId: string;
+  projectId: string;
+  projectTitle: string;
+}) {
+  const { data, mutate, isLoading } = useSWR<ListResponse>(
+    `/api/projects/${projectId}/alert-rules`,
+    fetcher,
+  );
+  const { data: worldsData } = useSWR<{ worlds: WorldRow[] }>(
+    `/api/worlds?projectId=${projectId}`,
+    fetcher,
+  );
+  const worlds = worldsData?.worlds ?? [];
+  const rules = data?.rules ?? [];
+
+  return (
+    <main className="mx-auto w-full max-w-[1200px] px-6 py-10 md:px-10">
+      <header className="mb-8">
+        <Link
+          href={`/org/${orgId}/projects/${projectId}/alerts`}
+          className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.28em] text-text-tertiary hover:text-text-primary"
+        >
+          <ArrowLeft size={12} />
+          {projectTitle} · Alerts
+        </Link>
+        <h1 className="mt-1 flex items-center gap-2 text-3xl font-light text-text-primary">
+          <Bell size={20} strokeWidth={1.5} className="text-accent" />
+          Alert rules
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm text-text-secondary">
+          Rules turn upstream webhook events into <code>MobilityAlert</code>{" "}
+          rows. Each rule can push a notification to a set of world
+          subscribers when it fires — same delivery pipeline as manual
+          broadcasts.
+        </p>
+      </header>
+
+      <RuleForm
+        projectId={projectId}
+        worlds={worlds}
+        onCreated={() => void mutate()}
+      />
+
+      <section className="mt-8 rounded-2xl border border-line-soft bg-bg">
+        <div className="border-b border-line-soft px-6 py-4">
+          <h2 className="text-lg font-medium text-text-primary">
+            All rules ({rules.length})
+          </h2>
+        </div>
+        {isLoading ? (
+          <p className="px-6 py-8 text-sm text-text-tertiary">Loading…</p>
+        ) : rules.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-text-tertiary">
+            No rules yet. Create one above.
+          </p>
+        ) : (
+          <ul className="divide-y divide-line-soft">
+            {rules.map((r) => (
+              <RuleRowItem
+                key={r.id}
+                rule={r}
+                worlds={worlds}
+                projectId={projectId}
+                onChanged={() => void mutate()}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+// ─── Row ────────────────────────────────────────────────────────────
+
+function RuleRowItem({
+  rule,
+  worlds,
+  projectId,
+  onChanged,
+}: {
+  rule: RuleRow;
+  worlds: WorldRow[];
+  projectId: string;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const worldName = (id: string) =>
+    worlds.find((w) => w.id === id)?.name ?? `world:${id.slice(0, 6)}`;
+
+  const summary = summariseRule(rule);
+  const worldIds = rule.targets?.worldIds ?? [];
+
+  const toggle = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/alert-rules/${rule.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: !rule.enabled }),
+        },
+      );
+      if (!res.ok) {
+        toast.error("Toggle failed");
+        return;
+      }
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!confirm(`Delete rule "${rule.name}"?`)) return;
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/alert-rules/${rule.id}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        toast.error("Delete failed");
+        return;
+      }
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <li className="flex items-start gap-4 px-6 py-4">
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium text-text-primary">{rule.name}</span>
+          {!rule.enabled && (
+            <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+              disabled
+            </span>
+          )}
+        </div>
+        <p className="mt-1 font-mono text-xs text-text-secondary">{summary}</p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {worldIds.length === 0 ? (
+            <span className="text-[11px] text-text-tertiary">
+              No push targets — alert row only.
+            </span>
+          ) : (
+            worldIds.map((id) => (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1 rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent"
+              >
+                {worldName(id)}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        className="rounded-md border border-line-strong px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+      >
+        {rule.enabled ? "Disable" : "Enable"}
+      </button>
+      <button
+        type="button"
+        onClick={remove}
+        disabled={busy}
+        aria-label="Delete rule"
+        className="rounded-md p-1.5 text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
+      >
+        {busy ? (
+          <Loader2 size={14} className="animate-spin" />
+        ) : (
+          <Trash2 size={14} />
+        )}
+      </button>
+    </li>
+  );
+}
+
+function summariseRule(rule: RuleRow): string {
+  if (rule.kind === "threshold") {
+    const c = rule.config as {
+      subsystem?: string;
+      field?: string;
+      op?: ThresholdOp;
+      value?: number;
+    };
+    return `${c.subsystem ?? "?"}.${c.field ?? "?"} ${OP_LABELS[c.op ?? "gt"]} ${c.value ?? "?"}`;
+  }
+  const c = rule.config as { eventType?: string };
+  return `event: ${c.eventType ?? "?"}`;
+}
+
+// ─── Create form ────────────────────────────────────────────────────
+
+function RuleForm({
+  projectId,
+  worlds,
+  onCreated,
+}: {
+  projectId: string;
+  worlds: WorldRow[];
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<RuleKind>("threshold");
+  const [subsystem, setSubsystem] = useState<string>("radar");
+  const [field, setField] = useState<string>("occupancy");
+  const [op, setOp] = useState<ThresholdOp>("gt");
+  const [value, setValue] = useState<string>("0.7");
+  const [eventType, setEventType] = useState<UpstreamEventType>("incident.posted");
+  const [targetWorldIds, setTargetWorldIds] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState(false);
+
+  const fieldsForSubsystem = FIELDS_BY_SUBSYSTEM[subsystem] ?? [];
+  // Keep `field` valid when subsystem changes.
+  const effectiveField = useMemo(() => {
+    if (fieldsForSubsystem.includes(field)) return field;
+    return fieldsForSubsystem[0] ?? "";
+  }, [field, fieldsForSubsystem]);
+
+  const create = async () => {
+    if (!name.trim()) {
+      toast.error("Name is required");
+      return;
+    }
+    const numericValue = Number(value);
+    if (kind === "threshold" && !Number.isFinite(numericValue)) {
+      toast.error("Value must be a number");
+      return;
+    }
+    setBusy(true);
+    try {
+      const body =
+        kind === "threshold"
+          ? {
+              name: name.trim(),
+              kind: "threshold" as const,
+              config: {
+                subsystem,
+                field: effectiveField,
+                op,
+                value: numericValue,
+              },
+              targets: { worldIds: Array.from(targetWorldIds) },
+            }
+          : {
+              name: name.trim(),
+              kind: "event" as const,
+              config: { eventType },
+              targets: { worldIds: Array.from(targetWorldIds) },
+            };
+      const res = await fetch(`/api/projects/${projectId}/alert-rules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        toast.error(json.error ?? "Create failed");
+        return;
+      }
+      toast.success(`Rule "${name.trim()}" created`);
+      setName("");
+      setTargetWorldIds(new Set());
+      onCreated();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-line-soft bg-bg p-6">
+      <h2 className="mb-4 text-lg font-medium text-text-primary">Create a rule</h2>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="text-sm md:col-span-2">
+          <span className="mb-1 block text-text-tertiary">Name</span>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Occupancy above 70%"
+            className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+          />
+        </label>
+
+        <div className="text-sm md:col-span-2">
+          <span className="mb-1 block text-text-tertiary">Kind</span>
+          <div className="inline-flex rounded-md border border-line-soft bg-bg text-xs">
+            <button
+              type="button"
+              onClick={() => setKind("threshold")}
+              className={`px-3 py-1.5 ${
+                kind === "threshold"
+                  ? "bg-surface-2 font-medium text-text-primary"
+                  : "text-text-tertiary hover:text-text-primary"
+              }`}
+            >
+              Threshold
+            </button>
+            <button
+              type="button"
+              onClick={() => setKind("event")}
+              className={`px-3 py-1.5 ${
+                kind === "event"
+                  ? "bg-surface-2 font-medium text-text-primary"
+                  : "text-text-tertiary hover:text-text-primary"
+              }`}
+            >
+              Event
+            </button>
+          </div>
+          <p className="mt-1.5 text-[11px] text-text-tertiary">
+            {kind === "threshold"
+              ? "Trigger when a device's status field crosses a numeric threshold."
+              : "Trigger on a raw upstream event (incident, status change)."}
+          </p>
+        </div>
+
+        {kind === "threshold" ? (
+          <>
+            <label className="text-sm">
+              <span className="mb-1 block text-text-tertiary">Subsystem</span>
+              <select
+                value={subsystem}
+                onChange={(e) => setSubsystem(e.target.value)}
+                className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+              >
+                {SUBSYSTEMS.map((s) => (
+                  <option key={s} value={s}>
+                    {s.toUpperCase()}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">
+              <span className="mb-1 block text-text-tertiary">Field</span>
+              <select
+                value={effectiveField}
+                onChange={(e) => setField(e.target.value)}
+                className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+              >
+                {fieldsForSubsystem.map((f) => (
+                  <option key={f} value={f}>
+                    {f}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">
+              <span className="mb-1 block text-text-tertiary">Operator</span>
+              <select
+                value={op}
+                onChange={(e) => setOp(e.target.value as ThresholdOp)}
+                className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+              >
+                {(Object.keys(OP_LABELS) as ThresholdOp[]).map((k) => (
+                  <option key={k} value={k}>
+                    {OP_LABELS[k]} ({k})
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">
+              <span className="mb-1 block text-text-tertiary">Value</span>
+              <input
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                inputMode="decimal"
+                className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 font-mono text-text-primary"
+              />
+            </label>
+          </>
+        ) : (
+          <label className="text-sm md:col-span-2">
+            <span className="mb-1 block text-text-tertiary">Event type</span>
+            <select
+              value={eventType}
+              onChange={(e) => setEventType(e.target.value as UpstreamEventType)}
+              className="w-full rounded-md border border-line-strong bg-bg px-3 py-2 text-text-primary"
+            >
+              {EVENT_TYPES.map((e) => (
+                <option key={e} value={e}>
+                  {e}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <fieldset className="text-sm md:col-span-2">
+          <legend className="mb-1 text-text-tertiary">
+            Push targets — worlds to notify
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            {worlds.length === 0 ? (
+              <span className="text-[11px] text-text-tertiary">
+                No worlds yet — the rule will still open alert rows.
+              </span>
+            ) : (
+              worlds.map((w) => {
+                const on = targetWorldIds.has(w.id);
+                return (
+                  <button
+                    key={w.id}
+                    type="button"
+                    onClick={() =>
+                      setTargetWorldIds((prev) => {
+                        const next = new Set(prev);
+                        if (on) next.delete(w.id);
+                        else next.add(w.id);
+                        return next;
+                      })
+                    }
+                    className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                      on
+                        ? "border-accent bg-accent-soft text-accent"
+                        : "border-line-soft text-text-secondary hover:border-accent hover:text-accent"
+                    }`}
+                  >
+                    {w.name}
+                    {on && <X size={11} strokeWidth={2.2} />}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </fieldset>
+      </div>
+
+      <div className="mt-6">
+        <button
+          type="button"
+          onClick={create}
+          disabled={busy}
+          className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {busy ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <Plus size={14} />
+          )}
+          Create rule
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/page.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { RulesClient } from "./RulesClient";
+
+type Params = Promise<{ orgId: string; projectId: string }>;
+
+export const metadata = { title: "Alert rules" };
+
+export default async function AlertRulesPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { orgId, projectId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) notFound();
+  const membership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: orgId,
+        userId: session.user.id,
+      },
+    },
+    select: { role: true },
+  });
+  if (!membership) notFound();
+  const project = await prisma.project.findFirst({
+    where: { id: projectId, organizationId: orgId },
+    select: { id: true, title: true },
+  });
+  if (!project) notFound();
+  return (
+    <RulesClient
+      orgId={orgId}
+      projectId={projectId}
+      projectTitle={project.title}
+    />
+  );
+}

--- a/apps/mobility/app/api/webhooks/inet-atms/[sourceId]/route.ts
+++ b/apps/mobility/app/api/webhooks/inet-atms/[sourceId]/route.ts
@@ -17,6 +17,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { evaluateRules, type StoredRule, type UpstreamEvent } from "@/lib/mobility/alert-rules";
+import { openAlertAndDispatch } from "@/lib/mobility/alert-dispatch";
 
 export const runtime = "nodejs";
 
@@ -110,24 +111,30 @@ export async function POST(
   );
 
   let inserted = 0;
+  let pushedCount = 0;
   for (const match of matches) {
     if (!match.externalId) continue;
     const deviceId = deviceIdByExternal.get(match.externalId);
     if (!deviceId) continue;
-    await prisma.mobilityAlert.create({
-      data: {
-        projectId: source.projectId,
-        deviceId,
-        kind: match.alertKind,
-        message: `[${match.ruleName}] ${match.message}`,
-      },
+    const result = await openAlertAndDispatch({
+      projectId: source.projectId,
+      deviceId,
+      ruleId: match.ruleId,
+      ruleName: match.ruleName,
+      kind: match.alertKind,
+      message: match.message,
+      targetWorldIds: match.targetWorldIds,
     });
     inserted += 1;
-    // Arc C PR3 fan-out hook lands here — for now the caller can
-    // read `MobilityAlert` and drive push separately.
+    pushedCount += result.pushed.reduce((a, p) => a + p.delivered, 0);
   }
 
-  return NextResponse.json({ ok: true, matched: matches.length, inserted });
+  return NextResponse.json({
+    ok: true,
+    matched: matches.length,
+    inserted,
+    pushed: pushedCount,
+  });
 }
 
 /** Compare the incoming signature to a re-computed one using

--- a/apps/mobility/lib/mobility/alert-dispatch.ts
+++ b/apps/mobility/lib/mobility/alert-dispatch.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared "open an alert + fan it out to worlds" path. Called by the
+ * webhook consumer for every rule match. Extracted so future
+ * evaluators (offline-for-N-minutes, sustained alarms) reuse the same
+ * insert + dispatch + audit-log logic instead of copy-pasting.
+ */
+import { prisma } from "@/lib/prisma";
+import { pushEnabled, sendPushToWorld } from "./world-push";
+import { recordWorldEvent } from "./world-events";
+import type { MobilityAlertKind } from "@prisma/client";
+
+export interface DispatchInput {
+  projectId: string;
+  deviceId: string;
+  ruleId: string;
+  ruleName: string;
+  kind: MobilityAlertKind;
+  /** Alert body — used both as the row's `message` and the push body. */
+  message: string;
+  /** World ids to fan out to. Empty = alert row only, no push. */
+  targetWorldIds: string[];
+}
+
+export interface DispatchResult {
+  alertId: string;
+  pushed: Array<{
+    worldId: string;
+    attempted: number;
+    delivered: number;
+    pruned: number;
+  }>;
+  pushSkipped: string | null;
+}
+
+/**
+ * Insert a `MobilityAlert` and, when the rule has target worlds,
+ * fan the same message to each world's subscribers. Push errors are
+ * logged and swallowed so a delivery failure doesn't leave the alert
+ * row un-committed. Each fan-out also appends a `broadcast_sent`
+ * event to the world's audit log so rule-fired notifications show up
+ * in the composer's history alongside manual broadcasts.
+ */
+export async function openAlertAndDispatch(
+  input: DispatchInput,
+): Promise<DispatchResult> {
+  const alert = await prisma.mobilityAlert.create({
+    data: {
+      projectId: input.projectId,
+      deviceId: input.deviceId,
+      kind: input.kind,
+      message: `[${input.ruleName}] ${input.message}`,
+    },
+    select: { id: true },
+  });
+
+  if (input.targetWorldIds.length === 0) {
+    return { alertId: alert.id, pushed: [], pushSkipped: "no targets" };
+  }
+  if (!pushEnabled()) {
+    return {
+      alertId: alert.id,
+      pushed: [],
+      pushSkipped: "web push not configured",
+    };
+  }
+
+  // Load slugs so the push URL can deep-link into the world. Missing
+  // world ids (stale rule targets after a world was deleted) are
+  // filtered out silently.
+  const worlds = await prisma.mobilityWorld.findMany({
+    where: { id: { in: input.targetWorldIds } },
+    select: { id: true, slug: true },
+  });
+
+  const pushed: DispatchResult["pushed"] = [];
+  for (const world of worlds) {
+    const url = `/w/${world.slug}`;
+    try {
+      const result = await sendPushToWorld(world.id, {
+        title: input.ruleName,
+        body: input.message,
+        url,
+        tag: `rule:${input.ruleId}`,
+      });
+      pushed.push({ worldId: world.id, ...result });
+      // Mirror the manual-broadcast path so the operator's history
+      // list shows rule-fired notifications too.
+      await recordWorldEvent({
+        worldId: world.id,
+        kind: "broadcast_sent",
+        meta: {
+          title: input.ruleName,
+          url,
+          attempted: result.attempted,
+          delivered: result.delivered,
+          pruned: result.pruned,
+          triggeredByRuleId: input.ruleId,
+        },
+      });
+    } catch (err) {
+      // Push failed for this world — log but keep dispatching to the
+      // others. The alert row is already committed so the operator
+      // sees the event in the alerts panel regardless.
+      console.error(
+        `[alert-dispatch] push to world ${world.id} failed`,
+        err,
+      );
+      pushed.push({
+        worldId: world.id,
+        attempted: 0,
+        delivered: 0,
+        pruned: 0,
+      });
+    }
+  }
+
+  return { alertId: alert.id, pushed, pushSkipped: null };
+}


### PR DESCRIPTION
## Summary

The last PR in the six-arc plan. Closes the loop:

**mock scenario emits event → webhook consumer evaluates rules → matching rule opens an alert AND fans a push notification to every subscriber of its target worlds.**

Independent of any other open PR — all prior arcs are merged.

## What's new

**Dispatch helper (`lib/mobility/alert-dispatch.ts`)**

- `openAlertAndDispatch({projectId, deviceId, ruleId, ruleName, kind, message, targetWorldIds})` — one call for the Prisma insert + world-slug lookup + push fan-out per target.
- Uses the same `sendPushToWorld` + `recordWorldEvent` primitives as the manual composer, so rule-fired notifications show up in the world's broadcast history alongside operator sends. Meta carries a `triggeredByRuleId` marker to distinguish the two.
- Push failures are logged and swallowed — the alert row is already committed so a delivery hiccup doesn't lose the operator signal.

**Webhook consumer wiring**

- `POST /api/webhooks/inet-atms/[sourceId]` calls `openAlertAndDispatch` per rule match. Response body now includes both `inserted` (alert rows) and `pushed` (delivered pushes).

**Rule editor UI (`/alerts/rules`)**

- Create form:
  - Threshold: subsystem picker → field auto-filters to what the subsystem exposes → operator + numeric value inputs
  - Event: single dropdown over `device.status_changed | incident.posted | incident.status_changed`
- Target-world chip multi-select for both kinds (empty targets = alert row only, no push).
- Row actions: enable/disable toggle + delete.
- Nav: new "Alert rules" entry directly under "Alerts" in the project sidebar.

## Test plan (end-to-end)

1. Register the webhook on your source (Sources → "Register webhook")
2. Create a rule: threshold, `radar.occupancy > 0.7`, target = your published world
3. Subscribe to push on `/w/<slug>` in a browser
4. Trigger `POST /api/demo/scenario/radar-spike` on the mock
5. Notification arrives on the subscribed device with the rule name as title
6. Alert row appears in the alerts panel
7. World's broadcast history (composer card) shows the rule-fired notification alongside manual sends

## The six-PR plan recap

| PR | Arc | Status |
|----|-----|--------|
| #249 | A1 teams schema + resolver | merged |
| #250 | A2 teams admin UI + world access | merged |
| #251 | B1 broadcast composer polish | merged |
| #252 | C1 mock scenarios | merged |
| #253 | C2 alert engine + webhook consumer | merged |
| **this** | **C3 alert → push + rule editor** | **open** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)