### PR TITLE
feat(mobility): durable alerts panel + acknowledge/close UI

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/AlertsClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/AlertsClient.tsx
@@ -3,20 +3,30 @@
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 import Link from "next/link";
+import { toast } from "react-toastify";
 import {
   ArrowRight,
   Bell,
+  Check,
   CheckCircle2,
   Database,
+  Loader2,
   RefreshCcw,
+  RotateCcw,
   ShieldOff,
   WifiOff,
+  X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { subsystemIcon } from "@/lib/mobility/subsystem-icon";
 
-interface AlertRow {
-  deviceId: string;
+// ─── Types (mirror the server response) ────────────────────────────
+
+type AlertKind = "offline" | "alarmed";
+type StateFilter = "open" | "acknowledged" | "closed" | "all";
+
+interface AlertDevice {
+  id: string;
   externalDeviceId: string;
   subsystem: string;
   name: string;
@@ -25,14 +35,26 @@ interface AlertRow {
   crossRoad: string | null;
   direction: string | null;
   agency: string | null;
-  kind: "offline" | "alarmed";
-  message: string | null;
-  observedAt: string;
+}
+
+interface AlertRow {
+  id: string;
+  kind: AlertKind;
+  message: string;
+  openedAt: string;
+  closedAt: string | null;
+  acknowledgedAt: string | null;
+  acknowledgedBy: {
+    id: string;
+    name: string | null;
+    email: string | null;
+  } | null;
+  device: AlertDevice;
 }
 
 interface AlertsResponse {
+  state: StateFilter;
   alerts: AlertRow[];
-  totalIncluded: number;
 }
 
 const fetcher = (url: string) =>
@@ -41,7 +63,7 @@ const fetcher = (url: string) =>
     return r.json();
   });
 
-type KindFilter = "all" | "offline" | "alarmed";
+// ─── Component ─────────────────────────────────────────────────────
 
 export function AlertsClient({
   orgId,
@@ -52,28 +74,23 @@ export function AlertsClient({
   projectId: string;
   projectTitle: string;
 }) {
-  const { data, isLoading } = useSWR<AlertsResponse>(
-    `/api/projects/${projectId}/alerts`,
+  const [state, setState] = useState<StateFilter>("open");
+  const { data, isLoading, mutate } = useSWR<AlertsResponse>(
+    `/api/projects/${projectId}/alerts?state=${state}`,
     fetcher,
     { refreshInterval: 15_000 },
   );
   const alerts = useMemo(() => data?.alerts ?? [], [data]);
-  const total = data?.totalIncluded ?? 0;
 
-  const [kind, setKind] = useState<KindFilter>("all");
-  const filtered = useMemo(
-    () => (kind === "all" ? alerts : alerts.filter((a) => a.kind === kind)),
-    [alerts, kind],
-  );
-
-  const counts = useMemo(
-    () => ({
+  const counts = useMemo(() => {
+    // Only meaningful when the filter is `open`; in other filters we
+    // don't have the full picture, so we skip the split.
+    return {
       total: alerts.length,
       offline: alerts.filter((a) => a.kind === "offline").length,
       alarmed: alerts.filter((a) => a.kind === "alarmed").length,
-    }),
-    [alerts],
-  );
+    };
+  }, [alerts]);
 
   return (
     <main className="mx-auto w-full max-w-[1280px] px-6 py-10 md:px-10">
@@ -86,26 +103,24 @@ export function AlertsClient({
             Alerts.
           </h1>
           <p className="mt-3 max-w-2xl text-base text-text-secondary">
-            Live feed of devices currently offline or carrying an alarm
-            condition, derived from the ATMS status proxy. Scoped to your
-            included fleet ({total.toLocaleString()} devices), refreshed
-            every 15 seconds.
+            Durable alert rows opened by the rule engine. Acknowledge to mark
+            as seen; close when the underlying condition is resolved.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-3">
+          <Link
+            href={`/org/${orgId}/projects/${projectId}/alerts/rules`}
+            className="inline-flex items-center gap-1.5 rounded-md border border-line-strong px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent hover:text-accent"
+          >
+            Manage rules
+            <ArrowRight size={14} strokeWidth={1.8} />
+          </Link>
           <Link
             href={`/org/${orgId}/projects/${projectId}/devices`}
             className="inline-flex items-center gap-1.5 rounded-md border border-line-strong px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent hover:text-accent"
           >
             <Database size={14} strokeWidth={1.8} aria-hidden />
             Devices
-          </Link>
-          <Link
-            href={`/org/${orgId}/projects/${projectId}`}
-            className="inline-flex items-center gap-1.5 rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-contrast transition-opacity hover:opacity-90"
-          >
-            Open console
-            <ArrowRight size={14} strokeWidth={1.8} />
           </Link>
         </div>
       </header>
@@ -114,34 +129,35 @@ export function AlertsClient({
       <section className="mb-8 grid grid-cols-1 gap-3 md:grid-cols-3">
         <StatTile
           icon={Bell}
-          label="Open alerts"
+          label={state === "open" ? "Open" : state === "acknowledged" ? "Acknowledged" : state === "closed" ? "Closed" : "All"}
           value={counts.total}
-          tone={counts.total > 0 ? "alarm" : "calm"}
+          tone={counts.total > 0 && state === "open" ? "alarm" : "muted"}
         />
         <StatTile
           icon={WifiOff}
           label="Offline"
           value={counts.offline}
-          tone={counts.offline > 0 ? "alarm" : "muted"}
+          tone={counts.offline > 0 && state === "open" ? "alarm" : "muted"}
         />
         <StatTile
           icon={ShieldOff}
           label="Alarmed"
           value={counts.alarmed}
-          tone={counts.alarmed > 0 ? "alarm" : "muted"}
+          tone={counts.alarmed > 0 && state === "open" ? "alarm" : "muted"}
         />
       </section>
 
-      {/* Filter chips + refresh tag */}
+      {/* State filter + refresh tag */}
       <section className="mb-4 flex flex-wrap items-center gap-3 rounded-2xl border border-line-soft bg-bg p-3">
         <ChipGroup
-          value={kind}
+          value={state}
           options={[
-            { value: "all", label: "All open" },
-            { value: "offline", label: "Offline", icon: WifiOff },
-            { value: "alarmed", label: "Alarmed", icon: ShieldOff },
+            { value: "open", label: "Open" },
+            { value: "acknowledged", label: "Acknowledged" },
+            { value: "closed", label: "Closed" },
+            { value: "all", label: "All" },
           ]}
-          onChange={(v) => setKind(v as KindFilter)}
+          onChange={(v) => setState(v as StateFilter)}
         />
         <span className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
           <RefreshCcw size={11} strokeWidth={1.8} aria-hidden />
@@ -156,35 +172,18 @@ export function AlertsClient({
             Loading…
           </p>
         </SectionCard>
-      ) : filtered.length === 0 ? (
-        <SectionCard>
-          <div className="px-6 py-16 text-center">
-            <CheckCircle2
-              size={32}
-              strokeWidth={1.5}
-              className="mx-auto text-emerald-500"
-              aria-hidden
-            />
-            <h2 className="mt-4 text-lg font-medium text-text-primary">
-              {alerts.length === 0
-                ? "Network is quiet."
-                : "No alerts match this filter."}
-            </h2>
-            <p className="mt-1 text-sm text-text-secondary">
-              {alerts.length === 0
-                ? "All included devices are online and clear of alarms."
-                : "Try All open."}
-            </p>
-          </div>
-        </SectionCard>
+      ) : alerts.length === 0 ? (
+        <EmptyState state={state} orgId={orgId} projectId={projectId} />
       ) : (
         <SectionCard>
           <ul className="divide-y divide-line-soft">
-            {filtered.map((a) => (
+            {alerts.map((a) => (
               <AlertItem
-                key={a.deviceId + a.observedAt}
+                key={a.id}
                 alert={a}
-                openHref={`/org/${orgId}/projects/${projectId}?device=${a.deviceId}`}
+                projectId={projectId}
+                onChanged={() => void mutate()}
+                openHref={`/org/${orgId}/projects/${projectId}?device=${a.device.id}`}
               />
             ))}
           </ul>
@@ -194,32 +193,67 @@ export function AlertsClient({
   );
 }
 
-/* ─── Row ──────────────────────────────────────────────────────────── */
+// ─── Row ────────────────────────────────────────────────────────────
 
 function AlertItem({
   alert,
+  projectId,
+  onChanged,
   openHref,
 }: {
   alert: AlertRow;
+  projectId: string;
+  onChanged: () => void;
   openHref: string;
 }) {
-  const SubsystemIcon: LucideIcon = subsystemIcon(alert.subsystem);
-  const kindIcon = alert.kind === "offline" ? WifiOff : ShieldOff;
-  const KindIcon = kindIcon;
+  const SubsystemIcon: LucideIcon = subsystemIcon(alert.device.subsystem);
+  const KindIcon = alert.kind === "offline" ? WifiOff : ShieldOff;
+  const [busy, setBusy] = useState(false);
+
+  const isClosed = alert.closedAt !== null;
+  const isAcked = alert.acknowledgedAt !== null && !isClosed;
+
+  const patch = async (action: "ack" | "unack" | "close" | "reopen") => {
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/alerts/${alert.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action }),
+        },
+      );
+      if (!res.ok) {
+        toast.error("Update failed");
+        return;
+      }
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
-    <li className="grid items-center gap-3 px-5 py-4 md:grid-cols-[auto_1fr_auto_auto] md:gap-4">
+    <li
+      className={`grid items-center gap-3 px-5 py-4 md:grid-cols-[auto_1fr_auto_auto] md:gap-4 ${
+        isClosed ? "opacity-60" : ""
+      }`}
+    >
       <span
         aria-hidden
         className={`flex h-9 w-9 items-center justify-center rounded-full ${
-          alert.kind === "offline"
-            ? "bg-red-500/10 text-red-600"
-            : "bg-yellow-500/10 text-yellow-600"
+          isClosed
+            ? "bg-surface-2 text-text-tertiary"
+            : alert.kind === "offline"
+              ? "bg-red-500/10 text-red-600"
+              : "bg-yellow-500/10 text-yellow-600"
         }`}
       >
         <KindIcon size={14} strokeWidth={1.8} />
       </span>
       <div className="min-w-0">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <SubsystemIcon
             size={12}
             strokeWidth={1.8}
@@ -227,34 +261,138 @@ function AlertItem({
             aria-hidden
           />
           <span className="truncate text-sm font-medium text-text-primary">
-            {alert.customLabel ?? alert.name}
+            {alert.device.customLabel ?? alert.device.name}
           </span>
           <KindPill kind={alert.kind} />
+          {isClosed && (
+            <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.18em] text-text-tertiary">
+              closed
+            </span>
+          )}
+          {isAcked && (
+            <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.18em] text-emerald-600">
+              acknowledged
+            </span>
+          )}
         </div>
         <p className="mt-0.5 truncate text-xs text-text-tertiary">
-          {alert.subsystem.toUpperCase()} · {alert.externalDeviceId}
-          {alert.primaryRoad && ` · ${alert.primaryRoad}`}
-          {alert.direction && ` (${alert.direction})`}
-          {alert.message && (
-            <span className="text-text-secondary"> — {alert.message}</span>
-          )}
+          {alert.device.subsystem.toUpperCase()} · {alert.device.externalDeviceId}
+          {alert.device.primaryRoad && ` · ${alert.device.primaryRoad}`}
+          {alert.device.direction && ` (${alert.device.direction})`}
         </p>
+        <p className="mt-1 text-xs text-text-secondary">{alert.message}</p>
+        {alert.acknowledgedBy && (
+          <p className="mt-0.5 text-[10px] text-text-tertiary">
+            Acknowledged by{" "}
+            {alert.acknowledgedBy.name ?? alert.acknowledgedBy.email ?? "unknown"}
+            {alert.acknowledgedAt && ` · ${relativeFrom(alert.acknowledgedAt)}`}
+          </p>
+        )}
       </div>
       <span className="text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
-        {relativeFrom(alert.observedAt)}
+        {relativeFrom(alert.openedAt)}
       </span>
-      <Link
-        href={openHref}
-        className="inline-flex items-center gap-1 rounded-md border border-line-strong px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:border-accent hover:text-accent"
-      >
-        Open
-        <ArrowRight size={12} strokeWidth={1.8} />
-      </Link>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {isClosed ? (
+          <button
+            type="button"
+            onClick={() => patch("reopen")}
+            disabled={busy}
+            className="inline-flex items-center gap-1 rounded-md border border-line-strong px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+          >
+            <RotateCcw size={12} strokeWidth={1.8} />
+            Reopen
+          </button>
+        ) : (
+          <>
+            {isAcked ? (
+              <button
+                type="button"
+                onClick={() => patch("unack")}
+                disabled={busy}
+                aria-label="Unacknowledge"
+                title="Unacknowledge"
+                className="inline-flex items-center gap-1 rounded-md border border-line-soft px-2.5 py-1.5 text-xs font-medium text-text-tertiary transition-colors hover:border-text-primary hover:text-text-primary disabled:opacity-50"
+              >
+                <X size={12} strokeWidth={1.8} />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => patch("ack")}
+                disabled={busy}
+                className="inline-flex items-center gap-1 rounded-md border border-line-strong px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+              >
+                <Check size={12} strokeWidth={1.8} />
+                Ack
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => patch("close")}
+              disabled={busy}
+              className="inline-flex items-center gap-1 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-contrast transition-colors hover:bg-accent-hover disabled:opacity-50"
+            >
+              {busy ? <Loader2 size={12} className="animate-spin" /> : "Close"}
+            </button>
+          </>
+        )}
+        <Link
+          href={openHref}
+          className="inline-flex items-center gap-1 rounded-md border border-line-soft px-2.5 py-1.5 text-xs font-medium text-text-tertiary transition-colors hover:border-accent hover:text-accent"
+        >
+          <ArrowRight size={12} strokeWidth={1.8} />
+        </Link>
+      </div>
     </li>
   );
 }
 
-/* ─── Tiny shared primitives ───────────────────────────────────────── */
+// ─── Empty state ────────────────────────────────────────────────────
+
+function EmptyState({
+  state,
+  orgId,
+  projectId,
+}: {
+  state: StateFilter;
+  orgId: string;
+  projectId: string;
+}) {
+  return (
+    <SectionCard>
+      <div className="px-6 py-16 text-center">
+        <CheckCircle2
+          size={32}
+          strokeWidth={1.5}
+          className="mx-auto text-emerald-500"
+          aria-hidden
+        />
+        <h2 className="mt-4 text-lg font-medium text-text-primary">
+          {state === "open"
+            ? "No open alerts."
+            : state === "acknowledged"
+              ? "No acknowledged alerts."
+              : state === "closed"
+                ? "No closed alerts."
+                : "No alerts have fired yet."}
+        </h2>
+        <p className="mt-1 text-sm text-text-secondary">
+          Alerts are opened by rules matching upstream webhook events.{" "}
+          <Link
+            href={`/org/${orgId}/projects/${projectId}/alerts/rules`}
+            className="text-accent hover:underline"
+          >
+            Create a rule
+          </Link>{" "}
+          to start.
+        </p>
+      </div>
+    </SectionCard>
+  );
+}
+
+// ─── Tiny shared primitives ───────────────────────────────────────
 
 function SectionCard({ children }: { children: React.ReactNode }) {
   return (
@@ -335,7 +473,7 @@ function ChipGroup<T extends string>({
   );
 }
 
-function KindPill({ kind }: { kind: "offline" | "alarmed" }) {
+function KindPill({ kind }: { kind: AlertKind }) {
   const cls =
     kind === "offline"
       ? "bg-red-500/10 text-red-600"

--- a/apps/mobility/app/api/projects/[projectId]/alerts/[alertId]/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/alerts/[alertId]/route.ts
@@ -1,0 +1,76 @@
+/**
+ * PATCH /api/projects/[projectId]/alerts/[alertId]
+ *   Body: `{ action: "ack" | "unack" | "close" | "reopen" }`.
+ *   Mutates `acknowledgedAt` / `acknowledgedById` / `closedAt`
+ *   accordingly. Requires project `write` — the alerts panel is
+ *   operator-only.
+ *
+ * Kept as a single mutation surface (not a REST-purist collection of
+ * micro-endpoints) because the operator UI toggles these two flags
+ * from a single row of buttons.
+ */
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ projectId: string; alertId: string }>;
+
+const Body = z.object({
+  action: z.enum(["ack", "unack", "close", "reopen"]),
+});
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId, alertId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  const session = await auth();
+  const userId = session?.user?.id as string | undefined;
+
+  const alert = await prisma.mobilityAlert.findFirst({
+    where: { id: alertId, projectId },
+    select: { id: true },
+  });
+  if (!alert) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const now = new Date();
+  const patch =
+    parsed.data.action === "ack"
+      ? { acknowledgedAt: now, acknowledgedById: userId ?? null }
+      : parsed.data.action === "unack"
+        ? { acknowledgedAt: null, acknowledgedById: null }
+        : parsed.data.action === "close"
+          ? { closedAt: now }
+          : { closedAt: null };
+
+  const updated = await prisma.mobilityAlert.update({
+    where: { id: alertId },
+    data: patch,
+    select: {
+      id: true,
+      acknowledgedAt: true,
+      acknowledgedById: true,
+      closedAt: true,
+    },
+  });
+  return NextResponse.json(updated);
+}

--- a/apps/mobility/app/api/projects/[projectId]/alerts/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/alerts/route.ts
@@ -1,153 +1,110 @@
 /**
  * GET /api/projects/[projectId]/alerts
- * Live alerts feed for the operator dashboard. v1 derives alerts on
- * the fly from the source's current status, scoped to devices the
- * operator has flagged `included`. No durable alert engine yet:
+ * Operator alerts feed. Reads durable `MobilityAlert` rows opened by
+ * the rule engine (`lib/mobility/alert-dispatch.openAlertAndDispatch`)
+ * rather than deriving on the fly from device status.
  *
- *   1. List the project's included devices.
- *   2. Build the connector for each device's source (memoised per
- *      source so we don't re-decrypt + re-configure on every call).
- *   3. Bulk-fetch status per source via `getStatus(devices[])`.
- *   4. Filter to `online === false || alarm != null`.
+ * Query params:
+ *   ?state=open (default) | acknowledged | closed | all
  *
- * In fixture mode this serves the seeded alerts (CCTV 991 offline,
- * DMS 891 fault). In live mode it proxies through to the ATMS.
+ * v1 caps at 200 rows — plenty for a demo tenant. Future: pagination
+ * once a real tenant outgrows a single-day span.
  *
- * Capped at 100 devices per project to keep the cost of an
- * anonymous-ish read bounded; tenants who outgrow this graduate to
- * the durable MobilityAlert engine in a follow-up arc.
+ * The previous derived-from-status implementation moved to the
+ * durable path when the rule engine landed; a periodic "device
+ * offline for N minutes" sweeper (which would also open
+ * `MobilityAlert` rows) is a follow-up arc.
  */
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireProjectAccess } from "@/lib/authz";
-import {
-  buildConnector,
-  decryptCredentials,
-  type DataSourceConfigJson,
-} from "@/lib/mobility/data-source";
 
 type Params = Promise<{ projectId: string }>;
 
-interface AlertRow {
-  deviceId: string;
-  externalDeviceId: string;
-  subsystem: string;
-  name: string;
-  customLabel: string | null;
-  primaryRoad: string | null;
-  crossRoad: string | null;
-  direction: string | null;
-  agency: string | null;
-  kind: "offline" | "alarmed";
-  message: string | null;
-  observedAt: string;
-}
+type StateFilter = "open" | "acknowledged" | "closed" | "all";
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Params },
 ): Promise<NextResponse> {
   const { projectId } = await params;
   const denied = await requireProjectAccess(projectId, "read");
   if (denied) return denied;
 
-  const devices = await prisma.mobilityDevice.findMany({
-    where: { projectId, included: true },
-    orderBy: { lastSeenAt: "desc" },
-    take: 100,
+  const url = new URL(req.url);
+  const state = normaliseState(url.searchParams.get("state"));
+
+  const rows = await prisma.mobilityAlert.findMany({
+    where: {
+      projectId,
+      ...(state === "open"
+        ? { closedAt: null, acknowledgedAt: null }
+        : state === "acknowledged"
+          ? { closedAt: null, NOT: { acknowledgedAt: null } }
+          : state === "closed"
+            ? { NOT: { closedAt: null } }
+            : {}),
+    },
+    orderBy: { openedAt: "desc" },
+    take: 200,
     select: {
       id: true,
-      externalDeviceId: true,
-      sourceId: true,
-      subsystem: true,
-      name: true,
-      customLabel: true,
-      primaryRoad: true,
-      crossRoad: true,
-      direction: true,
-      agency: true,
+      kind: true,
+      message: true,
+      openedAt: true,
+      closedAt: true,
+      acknowledgedAt: true,
+      acknowledgedById: true,
+      device: {
+        select: {
+          id: true,
+          externalDeviceId: true,
+          subsystem: true,
+          name: true,
+          customLabel: true,
+          primaryRoad: true,
+          crossRoad: true,
+          direction: true,
+          agency: true,
+        },
+      },
     },
   });
 
-  if (devices.length === 0) {
-    return NextResponse.json({ alerts: [], totalIncluded: 0 });
-  }
-
-  // Group device ids by source so we can batch one connector call
-  // per source, not per device.
-  const bySource = new Map<string, typeof devices>();
-  for (const d of devices) {
-    const arr = bySource.get(d.sourceId) ?? [];
-    arr.push(d);
-    bySource.set(d.sourceId, arr);
-  }
-
-  const sources = await prisma.mobilityDataSource.findMany({
-    where: { id: { in: Array.from(bySource.keys()) }, enabled: true },
-    select: {
-      id: true,
-      connectorId: true,
-      config: true,
-      credentialsEncrypted: true,
-    },
-  });
-
-  const alerts: AlertRow[] = [];
-  await Promise.all(
-    sources.map(async (source) => {
-      let connector;
-      try {
-        connector = await buildConnector({
-          connectorId: source.connectorId,
-          config: source.config as DataSourceConfigJson,
-          credentials: decryptCredentials(source.credentialsEncrypted),
-        });
-      } catch {
-        return;
-      }
-      const items = bySource.get(source.id) ?? [];
-      // Pack the connector-side ids the same way ingest did
-      // (`<subsystem>:<externalId>`). Devices that don't round-trip
-      // through the packId convention are skipped.
-      const packed = items.map((d) => `${d.subsystem}:${d.externalDeviceId}`);
-      let statuses: Awaited<ReturnType<typeof connector.getStatus>>;
-      try {
-        statuses = await connector.getStatus(packed);
-      } catch {
-        return;
-      }
-      for (const d of items) {
-        const key = `${d.subsystem}:${d.externalDeviceId}`;
-        const s = statuses[key] as
-          | { online: boolean; alarm: string | null; observedAt: string }
-          | undefined;
-        if (!s) continue;
-        const offline = !s.online;
-        const alarmed = !!s.alarm;
-        if (!offline && !alarmed) continue;
-        alerts.push({
-          deviceId: d.id,
-          externalDeviceId: d.externalDeviceId,
-          subsystem: d.subsystem,
-          name: d.name,
-          customLabel: d.customLabel,
-          primaryRoad: d.primaryRoad,
-          crossRoad: d.crossRoad,
-          direction: d.direction,
-          agency: d.agency,
-          kind: offline ? "offline" : "alarmed",
-          message: s.alarm,
-          observedAt: s.observedAt,
-        });
-      }
-    }),
+  // Fetch acknowledger display names in one round-trip.
+  const ackIds = Array.from(
+    new Set(rows.map((r) => r.acknowledgedById).filter((s): s is string => !!s)),
   );
+  const users = ackIds.length
+    ? await prisma.user.findMany({
+        where: { id: { in: ackIds } },
+        select: { id: true, name: true, email: true },
+      })
+    : [];
+  const userById = new Map(users.map((u) => [u.id, u]));
 
-  // Sort: offline before alarmed, then most recent observation first.
-  alerts.sort((a, b) => {
-    if (a.kind !== b.kind) return a.kind === "offline" ? -1 : 1;
-    return Date.parse(b.observedAt) - Date.parse(a.observedAt);
+  return NextResponse.json({
+    state,
+    alerts: rows.map((r) => ({
+      id: r.id,
+      kind: r.kind,
+      message: r.message,
+      openedAt: r.openedAt.toISOString(),
+      closedAt: r.closedAt?.toISOString() ?? null,
+      acknowledgedAt: r.acknowledgedAt?.toISOString() ?? null,
+      acknowledgedBy: r.acknowledgedById
+        ? {
+            id: r.acknowledgedById,
+            name: userById.get(r.acknowledgedById)?.name ?? null,
+            email: userById.get(r.acknowledgedById)?.email ?? null,
+          }
+        : null,
+      device: r.device,
+    })),
   });
+}
 
-  return NextResponse.json({ alerts, totalIncluded: devices.length });
+function normaliseState(raw: string | null): StateFilter {
+  if (raw === "acknowledged" || raw === "closed" || raw === "all") return raw;
+  return "open";
 }


### PR DESCRIPTION
## Summary

Closes the loop on the alert-engine work. Rules from #254 write durable `MobilityAlert` rows, but the alerts panel still derived everything on the fly from device status — so rule-fired alerts had no operator-visible home. Panel now reads durable rows and lets the operator triage them.

## Endpoint refactor (`GET /api/projects/[projectId]/alerts`)

- Reads `MobilityAlert` joined to `MobilityDevice` (was: per-device connector fan-out of `getStatus`).
- Query param `?state=open|acknowledged|closed|all` — defaults to `open`. Capped at 200 rows; pagination lands when a real tenant outgrows it.
- Denormalises the acknowledger's display name in one lookup so the row can show "Acknowledged by <name>".

## New endpoint (`PATCH /api/projects/[projectId]/alerts/[alertId]`)

Body `{action: "ack" | "unack" | "close" | "reopen"}`. Single mutation surface (not per-flag routes) because the operator UI toggles both from one row of buttons. Ack stamps the session user's id + timestamp; close stamps just the timestamp.

## Client rewrite (`AlertsClient.tsx`)

- State filter chips (Open / Acknowledged / Closed / All).
- Per-row: Ack → Unack toggle, Close, Reopen (when closed). Closed rows dim to 60% so the eye skips past them.
- Row shows "Acknowledged by <name> · 3m ago" once acked.
- Empty state deep-links into the rule editor rather than saying "network is quiet" — the rule engine is the trigger source now.
- "Manage rules" button in the header alongside the existing Devices button.

## Test plan

- [ ] Trigger a scenario on the mock (`POST /api/demo/scenario/radar-spike`) with a matching rule + webhook registered → alert appears in Open filter
- [ ] Ack → row moves to Acknowledged filter, chip flips to green
- [ ] Unack → row returns to Open
- [ ] Close → row moves to Closed filter, dims
- [ ] Reopen → row returns to Open
- [ ] Non-project-write user cannot PATCH (403)

## Follow-up not in this PR

A periodic "device offline for N minutes" sweeper would open `MobilityAlert` rows for conditions the rule engine can't see (rules only fire on discrete webhook events). Land that when we outgrow rule-only coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)