### PR TITLE
feat(mobility): rule preview — test threshold before saving

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/RulesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/RulesClient.tsx
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import {
   ArrowLeft,
   Bell,
+  FlaskConical,
   Loader2,
   Plus,
   Trash2,
@@ -286,6 +287,27 @@ function summariseRule(rule: RuleRow): string {
   return `event: ${c.eventType ?? "?"}`;
 }
 
+// ─── Rule preview response ─────────────────────────────────────────
+
+interface PreviewSample {
+  deviceId: string;
+  externalDeviceId: string;
+  name: string;
+  observed: number | null;
+  matched: boolean;
+}
+
+type PreviewResult =
+  | {
+      kind: "threshold";
+      previewSupported: true;
+      sampled: number;
+      matched: number;
+      samples: PreviewSample[];
+      note?: string;
+    }
+  | { kind: "event"; previewSupported: false; note: string };
+
 // ─── Create form ────────────────────────────────────────────────────
 
 function RuleForm({
@@ -306,6 +328,8 @@ function RuleForm({
   const [eventType, setEventType] = useState<UpstreamEventType>("incident.posted");
   const [targetWorldIds, setTargetWorldIds] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState(false);
+  const [previewBusy, setPreviewBusy] = useState(false);
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
 
   const fieldsForSubsystem = FIELDS_BY_SUBSYSTEM[subsystem] ?? [];
   // Keep `field` valid when subsystem changes.
@@ -313,6 +337,46 @@ function RuleForm({
     if (fieldsForSubsystem.includes(field)) return field;
     return fieldsForSubsystem[0] ?? "";
   }, [field, fieldsForSubsystem]);
+
+  const runPreview = async () => {
+    const numericValue = Number(value);
+    if (kind === "threshold" && !Number.isFinite(numericValue)) {
+      toast.error("Value must be a number");
+      return;
+    }
+    setPreviewBusy(true);
+    setPreview(null);
+    try {
+      const body =
+        kind === "threshold"
+          ? {
+              kind: "threshold" as const,
+              config: {
+                subsystem,
+                field: effectiveField,
+                op,
+                value: numericValue,
+              },
+            }
+          : { kind: "event" as const, config: { eventType } };
+      const res = await fetch(
+        `/api/projects/${projectId}/alert-rules/test`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      const json = (await res.json()) as PreviewResult | { error?: string };
+      if (!res.ok) {
+        toast.error((json as { error?: string }).error ?? "Preview failed");
+        return;
+      }
+      setPreview(json as PreviewResult);
+    } finally {
+      setPreviewBusy(false);
+    }
+  };
 
   const create = async () => {
     if (!name.trim()) {
@@ -523,7 +587,7 @@ function RuleForm({
         </fieldset>
       </div>
 
-      <div className="mt-6">
+      <div className="mt-6 flex flex-wrap items-center gap-3">
         <button
           type="button"
           onClick={create}
@@ -537,7 +601,112 @@ function RuleForm({
           )}
           Create rule
         </button>
+        <button
+          type="button"
+          onClick={runPreview}
+          disabled={previewBusy}
+          title="Preview whether the rule would fire against the current fleet, without saving."
+          className="inline-flex items-center gap-2 rounded-md border border-line-strong px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+        >
+          {previewBusy ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <FlaskConical size={14} />
+          )}
+          Preview matches
+        </button>
       </div>
+
+      {preview && <PreviewPanel result={preview} onDismiss={() => setPreview(null)} />}
     </section>
+  );
+}
+
+function PreviewPanel({
+  result,
+  onDismiss,
+}: {
+  result: PreviewResult;
+  onDismiss: () => void;
+}) {
+  if (result.previewSupported === false) {
+    return (
+      <div className="mt-4 flex items-start gap-3 rounded-md border border-line-soft bg-surface-2 px-4 py-3 text-xs text-text-secondary">
+        <FlaskConical size={13} className="mt-0.5 text-text-tertiary" />
+        <p className="flex-1">{result.note}</p>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss preview"
+          className="text-text-tertiary hover:text-text-primary"
+        >
+          <X size={13} />
+        </button>
+      </div>
+    );
+  }
+  const { sampled, matched, samples } = result;
+  const anyMatched = matched > 0;
+  return (
+    <div className="mt-4 rounded-md border border-line-soft bg-surface-2 px-4 py-3 text-xs">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-text-primary">
+          <span
+            className={`font-medium ${
+              anyMatched ? "text-accent" : "text-text-secondary"
+            }`}
+          >
+            {matched} of {sampled}
+          </span>{" "}
+          {matched === 1 ? "device would fire" : "devices would fire"} right now
+          {sampled === 20 && (
+            <span className="text-text-tertiary"> (sampled)</span>
+          )}
+          {result.note && (
+            <span className="text-text-tertiary"> — {result.note}</span>
+          )}
+        </p>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss preview"
+          className="text-text-tertiary hover:text-text-primary"
+        >
+          <X size={13} />
+        </button>
+      </div>
+      {samples.length > 0 && (
+        <ul className="divide-y divide-line-soft rounded border border-line-soft bg-bg">
+          {samples.slice(0, 8).map((s) => (
+            <li
+              key={s.deviceId}
+              className="flex items-center gap-3 px-3 py-1.5"
+            >
+              <span
+                aria-hidden
+                className={`h-1.5 w-1.5 rounded-full ${
+                  s.matched ? "bg-accent" : "bg-line-strong"
+                }`}
+              />
+              <span className="flex-1 truncate text-text-primary">
+                {s.name}
+              </span>
+              <span className="font-mono text-[10px] text-text-tertiary">
+                {s.observed === null
+                  ? "—"
+                  : Number.isInteger(s.observed)
+                    ? s.observed
+                    : s.observed.toFixed(3)}
+              </span>
+            </li>
+          ))}
+          {samples.length > 8 && (
+            <li className="px-3 py-1.5 text-center text-[10px] text-text-tertiary">
+              +{samples.length - 8} more
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/apps/mobility/app/api/projects/[projectId]/alert-rules/test/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/alert-rules/test/route.ts
@@ -1,0 +1,163 @@
+/**
+ * POST /api/projects/[projectId]/alert-rules/test
+ *   Preview whether a proposed rule would fire against the project's
+ *   current fleet, without persisting anything. Threshold rules sample
+ *   up to 20 devices matching the target subsystem, poll their live
+ *   status via the connector, and evaluate the same threshold logic
+ *   the webhook consumer uses. Event rules return a note explaining
+ *   that they only fire on incoming events — not on current state.
+ *
+ * Body mirrors `RuleBody` (discriminated on `kind`).
+ *
+ * Requires project `read` — this only proxies status, never writes.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+import {
+  RuleBody,
+  evaluateThresholdOnStatus,
+} from "@/lib/mobility/alert-rules";
+import {
+  buildConnector,
+  decryptCredentials,
+  type DataSourceConfigJson,
+} from "@/lib/mobility/data-source";
+
+type Params = Promise<{ projectId: string }>;
+
+const SAMPLE_LIMIT = 20;
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "read");
+  if (denied) return denied;
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = RuleBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.kind === "event") {
+    return NextResponse.json({
+      kind: "event",
+      previewSupported: false,
+      note:
+        "Event rules fire on inbound webhook events, not on current state. Trigger a matching scenario on the mock to test.",
+    });
+  }
+
+  const cfg = parsed.data.config;
+
+  const devices = await prisma.mobilityDevice.findMany({
+    where: { projectId, subsystem: cfg.subsystem },
+    orderBy: { lastSeenAt: "desc" },
+    take: SAMPLE_LIMIT,
+    select: {
+      id: true,
+      externalDeviceId: true,
+      sourceId: true,
+      subsystem: true,
+      name: true,
+      customLabel: true,
+    },
+  });
+
+  if (devices.length === 0) {
+    return NextResponse.json({
+      kind: "threshold",
+      previewSupported: true,
+      sampled: 0,
+      matched: 0,
+      samples: [],
+      note: `No synced devices in subsystem "${cfg.subsystem}" yet.`,
+    });
+  }
+
+  // Group by source so we make one connector call per source.
+  const bySource = new Map<string, typeof devices>();
+  for (const d of devices) {
+    const arr = bySource.get(d.sourceId) ?? [];
+    arr.push(d);
+    bySource.set(d.sourceId, arr);
+  }
+
+  const sources = await prisma.mobilityDataSource.findMany({
+    where: { id: { in: Array.from(bySource.keys()) }, enabled: true },
+    select: {
+      id: true,
+      connectorId: true,
+      config: true,
+      credentialsEncrypted: true,
+    },
+  });
+
+  const samples: Array<{
+    deviceId: string;
+    externalDeviceId: string;
+    name: string;
+    observed: number | null;
+    matched: boolean;
+  }> = [];
+
+  await Promise.all(
+    sources.map(async (source) => {
+      let connector;
+      try {
+        connector = await buildConnector({
+          connectorId: source.connectorId,
+          config: source.config as DataSourceConfigJson,
+          credentials: decryptCredentials(source.credentialsEncrypted),
+        });
+      } catch {
+        return;
+      }
+      const items = bySource.get(source.id) ?? [];
+      const packed = items.map((d) => `${d.subsystem}:${d.externalDeviceId}`);
+      let statuses: Awaited<ReturnType<typeof connector.getStatus>>;
+      try {
+        statuses = await connector.getStatus(packed);
+      } catch {
+        return;
+      }
+      for (const d of items) {
+        const key = `${d.subsystem}:${d.externalDeviceId}`;
+        const s = statuses[key] as
+          | { raw?: Record<string, unknown> }
+          | undefined;
+        const outcome = evaluateThresholdOnStatus(s?.raw, cfg);
+        samples.push({
+          deviceId: d.id,
+          externalDeviceId: d.externalDeviceId,
+          name: d.customLabel ?? d.name,
+          observed: outcome.observed,
+          matched: outcome.matched,
+        });
+      }
+    }),
+  );
+
+  // Matches first — the operator's eye should land on hits.
+  samples.sort((a, b) => Number(b.matched) - Number(a.matched));
+  const matched = samples.filter((s) => s.matched).length;
+
+  return NextResponse.json({
+    kind: "threshold",
+    previewSupported: true,
+    sampled: samples.length,
+    matched,
+    samples,
+  });
+}

--- a/apps/mobility/lib/mobility/alert-rules.ts
+++ b/apps/mobility/lib/mobility/alert-rules.ts
@@ -150,11 +150,8 @@ function matchThreshold(
   msg: string;
 } | null {
   if ((event.payload.subsystem ?? "") !== cfg.subsystem) return null;
-  const status = event.payload.status;
-  if (!status || typeof status !== "object") return null;
-  const raw = (status as Record<string, unknown>)[cfg.field];
-  if (typeof raw !== "number") return null;
-  if (!compare(raw, cfg.op, cfg.value)) return null;
+  const outcome = evaluateThresholdOnStatus(event.payload.status, cfg);
+  if (!outcome.matched) return null;
   return {
     externalId:
       typeof event.payload.externalId === "string"
@@ -163,8 +160,27 @@ function matchThreshold(
           ? event.payload.deviceId
           : null,
     subsystem: cfg.subsystem,
-    msg: `${cfg.subsystem}.${cfg.field} ${cfg.op} ${cfg.value} (observed ${raw})`,
+    msg: `${cfg.subsystem}.${cfg.field} ${cfg.op} ${cfg.value} (observed ${outcome.observed})`,
   };
+}
+
+/** Reusable threshold evaluator — shared with the rule "Preview
+ *  matches" endpoint so the button shows exactly what a webhook
+ *  event would fire. Returns both the observed value and a boolean
+ *  so the preview can distinguish "field not present" from "field
+ *  present but below threshold". */
+export function evaluateThresholdOnStatus(
+  status: unknown,
+  cfg: ThresholdConfig,
+): { observed: number | null; matched: boolean } {
+  if (!status || typeof status !== "object") {
+    return { observed: null, matched: false };
+  }
+  const raw = (status as Record<string, unknown>)[cfg.field];
+  if (typeof raw !== "number") {
+    return { observed: null, matched: false };
+  }
+  return { observed: raw, matched: compare(raw, cfg.op, cfg.value) };
 }
 
 function matchEvent(event: UpstreamEvent): {


### PR DESCRIPTION
## Summary

Follow-up polish on the rule editor from #254. Adds a "Preview matches" button next to "Create rule" so an operator can see if a threshold would fire against the current fleet without committing anything.

Independent of #255 (durable alerts panel) — touches different files.

## Endpoint (`POST /api/projects/[projectId]/alert-rules/test`)

- Body mirrors `RuleBody` — same discriminated union the create endpoint validates against.
- **Threshold rules**: samples up to 20 devices matching the target subsystem, polls their live status via the connector, evaluates each observation against the threshold and returns `{sampled, matched, samples[]}`. Sample includes the observed value so the operator can see how close a non-match was to firing.
- **Event rules**: returns `{previewSupported: false, note}` — there's no "current state" for an event rule; the operator has to trigger a matching scenario instead.
- Requires project `read` — proxies status, never writes.

## Shared evaluator

Extracted `evaluateThresholdOnStatus(status, cfg)` from the webhook consumer's `matchThreshold` so both paths use the same compare logic. Guarantees the preview shows exactly what an inbound event would fire.

## UI

- "Preview matches" secondary button alongside the primary "Create rule" action.
- Result panel below the form: hit-rate summary + up to 8 sample rows with device name, observed value, and a matched/not dot. Dismissible so the operator can iterate the form and re-run.

## Test plan

- [ ] Create form → set radar.occupancy > 0.7 → Preview → 0 matches (rush-hour off), each sample shows the observed 0.3-ish value
- [ ] Trigger `POST /api/demo/scenario/radar-spike` on the mock, wait 5s
- [ ] Re-run Preview → 1 match (the spiked radar shows 0.85)
- [ ] Switch to Event kind → Preview → returns "not supported" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)