### PR TITLE
fix(mobility): public push endpoints honor auth on gated worlds

### DIFF
--- a/apps/mobility/app/api/public/worlds/[slug]/event/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/event/route.ts
@@ -13,7 +13,7 @@
  */
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { loadPublicWorldBySlug } from "@/lib/mobility/world-resolver";
+import { loadWorldForPushViewer } from "@/lib/mobility/world-resolver";
 import { recordWorldEvent } from "@/lib/mobility/world-events";
 
 type Params = Promise<{ slug: string }>;
@@ -28,7 +28,7 @@ export async function POST(
   { params }: { params: Params },
 ): Promise<NextResponse> {
   const { slug } = await params;
-  const world = await loadPublicWorldBySlug(slug);
+  const world = await loadWorldForPushViewer(slug);
   if (!world) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }

--- a/apps/mobility/app/api/public/worlds/[slug]/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/route.ts
@@ -1,16 +1,17 @@
 /**
- * `GET /api/public/worlds/[slug]` — public world payload.
+ * `GET /api/public/worlds/[slug]` — world payload for the SW's
+ * stale-while-revalidate cache + potential SWR polling on the
+ * client. Session-aware for `authenticated` worlds via
+ * `loadWorldForPushViewer` — same helper the push endpoints use, so
+ * a granted user's SW `fetch` (which forwards same-origin cookies)
+ * receives the payload while anonymous probes still 404.
  *
- * Backs the service worker's stale-while-revalidate strategy so a
- * world that's been visited once is fully usable offline. Shape
- * matches what `WorldViewer` consumes via SSR; on subsequent visits
- * the client could swap to a SWR poll against this endpoint for live
- * updates without re-rendering the whole page. Returns 404 for
- * drafts / `authenticated` worlds so an enumeration attack can't
- * tell which slugs exist.
+ * Cache-Control varies by visibility:
+ *   public / linkOnly → `public, s-maxage=60` (CDN-cacheable)
+ *   authenticated     → `private, no-store` (per-user, never shared)
  */
 import { NextResponse } from "next/server";
-import { loadPublicWorldBySlug } from "@/lib/mobility/world-resolver";
+import { loadWorldForPushViewer } from "@/lib/mobility/world-resolver";
 
 type Params = Promise<{ slug: string }>;
 
@@ -19,10 +20,14 @@ export async function GET(
   { params }: { params: Params },
 ): Promise<NextResponse> {
   const { slug } = await params;
-  const world = await loadPublicWorldBySlug(slug);
+  const world = await loadWorldForPushViewer(slug);
   if (!world) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
+  const cacheControl =
+    world.visibility === "authenticated"
+      ? "private, no-store, max-age=0"
+      : "public, max-age=60, s-maxage=60";
   return NextResponse.json(
     {
       world: {
@@ -37,10 +42,6 @@ export async function GET(
         customIcons: world.customIcons,
       },
     },
-    {
-      headers: {
-        "Cache-Control": "public, max-age=60, s-maxage=60",
-      },
-    },
+    { headers: { "Cache-Control": cacheControl } },
   );
 }

--- a/apps/mobility/app/api/public/worlds/[slug]/subscribe/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/subscribe/route.ts
@@ -17,7 +17,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { loadPublicWorldBySlug } from "@/lib/mobility/world-resolver";
+import { loadWorldForPushViewer } from "@/lib/mobility/world-resolver";
 import { recordWorldEvent } from "@/lib/mobility/world-events";
 
 type Params = Promise<{ slug: string }>;
@@ -34,7 +34,7 @@ export async function POST(
   { params }: { params: Params },
 ): Promise<NextResponse> {
   const { slug } = await params;
-  const world = await loadPublicWorldBySlug(slug);
+  const world = await loadWorldForPushViewer(slug);
   if (!world) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }

--- a/apps/mobility/app/api/public/worlds/[slug]/unsubscribe/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/unsubscribe/route.ts
@@ -10,7 +10,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { loadPublicWorldBySlug } from "@/lib/mobility/world-resolver";
+import { loadWorldForPushViewer } from "@/lib/mobility/world-resolver";
 import { recordWorldEvent } from "@/lib/mobility/world-events";
 
 type Params = Promise<{ slug: string }>;
@@ -25,7 +25,7 @@ export async function POST(
   { params }: { params: Params },
 ): Promise<NextResponse> {
   const { slug } = await params;
-  const world = await loadPublicWorldBySlug(slug);
+  const world = await loadWorldForPushViewer(slug);
   if (!world) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }

--- a/apps/mobility/app/api/public/worlds/[slug]/vapid-public-key/route.ts
+++ b/apps/mobility/app/api/public/worlds/[slug]/vapid-public-key/route.ts
@@ -2,18 +2,18 @@
  * `GET /api/public/worlds/[slug]/vapid-public-key`
  *
  * Returns the VAPID public key the world's PWA needs to subscribe to
- * push. Anonymous endpoint — the key is safe to expose by design
- * (clients couldn't sign pushes without the private key). We still
- * tie it to a world resolver call so a draft / unknown slug 404s the
- * same way the manifest does, keeping the existence of unpublished
- * worlds hidden from probes.
+ * push. Anonymous for public / linkOnly worlds; session-gated for
+ * `authenticated` worlds (via `loadWorldForPushViewer`). The key is
+ * safe to expose by design — clients couldn't sign pushes without
+ * the private key. Draft / unknown slugs 404 the same way the
+ * manifest does, keeping unpublished worlds hidden from probes.
  *
- * Returns `404` when push isn't configured server-side too — that
- * way the client treats "push is off" the same as "world is gated":
- * no opt-in shown.
+ * Distinct status codes so the client can differentiate:
+ *   404 → world not found or viewer lacks access
+ *   503 → push not configured server-side (no VAPID env vars)
  */
 import { NextResponse } from "next/server";
-import { loadPublicWorldBySlug } from "@/lib/mobility/world-resolver";
+import { loadWorldForPushViewer } from "@/lib/mobility/world-resolver";
 import { getVapidPublicKey } from "@/lib/mobility/world-push";
 
 type Params = Promise<{ slug: string }>;
@@ -23,13 +23,13 @@ export async function GET(
   { params }: { params: Params },
 ): Promise<NextResponse> {
   const { slug } = await params;
-  const world = await loadPublicWorldBySlug(slug);
+  const world = await loadWorldForPushViewer(slug);
   if (!world) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
   const key = getVapidPublicKey();
   if (!key) {
-    return NextResponse.json({ error: "push_disabled" }, { status: 404 });
+    return NextResponse.json({ error: "push_disabled" }, { status: 503 });
   }
   return NextResponse.json(
     { publicKey: key },

--- a/apps/mobility/lib/mobility/world-resolver.ts
+++ b/apps/mobility/lib/mobility/world-resolver.ts
@@ -14,6 +14,7 @@
  * with everything trimmed to what a stakeholder sees. Internal source
  * URLs and curation flags never leave the dashboard tier.
  */
+import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { resolveDeviceStyles } from "./device-style-resolver";
 
@@ -154,6 +155,78 @@ export async function loadPublicWorldBySlug(
   });
   if (!world) return null;
   if (world.visibility === "authenticated") return null;
+  return await toPublicWorld(world);
+}
+
+/**
+ * Session-aware variant used by the `/api/public/worlds/[slug]/…`
+ * push endpoints (vapid key, subscribe, unsubscribe, event beacon).
+ *
+ * `loadPublicWorldBySlug` hides `authenticated` worlds from
+ * anonymous callers so probes can't enumerate slug existence — but
+ * that also locks out signed-in users who *have* been granted
+ * access via `MobilityWorldPrincipal`. This variant lets those users
+ * through by consulting the same rules `resolveWorldForViewer`
+ * applies to the page-level render:
+ *
+ *   - not found / draft → null
+ *   - public / linkOnly → world
+ *   - authenticated + org owner → world
+ *   - authenticated + granted principal → world
+ *   - authenticated + anon-or-not-granted → null
+ *
+ * Null-return semantics stay identical to `loadPublicWorldBySlug`
+ * so callers keep their existing 404-when-null branch. Errors on
+ * session read are treated as "no session" — never throw from a
+ * publicly-reachable endpoint.
+ */
+export async function loadWorldForPushViewer(
+  slug: string,
+): Promise<PublicWorld | null> {
+  const world = await prisma.mobilityWorld.findFirst({
+    where: { slug, isPublished: true },
+    include: worldInclude,
+  });
+  if (!world) return null;
+  if (world.visibility !== "authenticated") {
+    return await toPublicWorld(world);
+  }
+
+  let viewerId: string | null = null;
+  try {
+    const session = await auth();
+    viewerId = (session?.user?.id as string | undefined) ?? null;
+  } catch {
+    viewerId = null;
+  }
+  if (!viewerId) return null;
+
+  const ownerMembership = await prisma.organizationMember.findUnique({
+    where: {
+      organizationId_userId: {
+        organizationId: world.project.organizationId,
+        userId: viewerId,
+      },
+    },
+    select: { role: true },
+  });
+  if (ownerMembership?.role === "owner") {
+    return await toPublicWorld(world);
+  }
+  const grant = await prisma.mobilityWorldPrincipal.findFirst({
+    where: {
+      worldId: world.id,
+      OR: [
+        { kind: "user", userId: viewerId },
+        {
+          kind: "team",
+          team: { members: { some: { userId: viewerId } } },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+  if (!grant) return null;
   return await toPublicWorld(world);
 }
 


### PR DESCRIPTION
## The bug

`https://mobility.klorad.com/api/public/worlds/egnatia-east/vapid-public-key` returned 404 when the world was set to `authenticated` visibility.

Root cause: **intentional but stale**. `loadPublicWorldBySlug` returns null for authenticated worlds so anonymous probes can't enumerate slug existence — but that also locked out signed-in users who had access via `MobilityWorldPrincipal` grants (from #250).

## Fix

- **New helper** `loadWorldForPushViewer(slug)` in `world-resolver.ts` — reads the session, applies the same access rules `resolveWorldForViewer` uses on the page render. Null-return semantics identical to the old helper.
- **Endpoints migrated** to the new helper:
  - `GET  /api/public/worlds/[slug]/vapid-public-key` — now also returns **503** (not 404) when VAPID env vars are missing, so it's distinguishable from a missing world.
  - `POST /api/public/worlds/[slug]/subscribe`
  - `POST /api/public/worlds/[slug]/unsubscribe`
  - `POST /api/public/worlds/[slug]/event`
  - `GET  /api/public/worlds/[slug]` — cache-control now varies: `public, s-maxage=60` for public/linkOnly (CDN-cacheable), `private, no-store` for authenticated (per-user).
- **Anonymous behaviour unchanged**: authenticated worlds still 404 for anon callers so probes can't enumerate.

## Test plan

- [ ] `curl` vapid endpoint on a public world → 200
- [ ] `curl` vapid endpoint on an authenticated world without cookies → 404
- [ ] Same request in a logged-in browser (with a grant) → 200
- [ ] Same request in a logged-in browser without a grant → 404 (not 403 — leak-preserving)
- [ ] Unset VAPID env vars in Vercel → 503 instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)