### PR TITLE
fix(mobility): validate VAPID public key shape before serving it

### DIFF
--- a/apps/mobility/lib/mobility/world-push.ts
+++ b/apps/mobility/lib/mobility/world-push.ts
@@ -27,6 +27,12 @@ function ensureConfigured(): boolean {
   const privateKey = process.env.VAPID_PRIVATE_KEY;
   const subject = process.env.VAPID_SUBJECT;
   if (!publicKey || !privateKey || !subject) return false;
+  if (!isValidVapidPublicKey(publicKey)) {
+    console.warn(
+      "[world-push] NEXT_PUBLIC_VAPID_PUBLIC_KEY is set but doesn't look like a P-256 point (65 decoded bytes, 0x04 prefix). Push disabled.",
+    );
+    return false;
+  }
   webpush.setVapidDetails(subject, publicKey, privateKey);
   configured = true;
   return true;
@@ -36,8 +42,36 @@ export function pushEnabled(): boolean {
   return ensureConfigured();
 }
 
+/** Only exposes the key when it's structurally valid. Prevents a
+ *  misconfigured Vercel env (e.g. someone pasting the env var name
+ *  as the value) from being served to browsers, which just makes
+ *  `pushManager.subscribe` hang silently in Chrome. */
 export function getVapidPublicKey(): string | null {
-  return process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? null;
+  const key = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  if (!key || !isValidVapidPublicKey(key)) return null;
+  return key;
+}
+
+/** Validate the base64url shape of a VAPID public key. A valid key
+ *  is exactly 65 bytes when decoded (0x04 uncompressed prefix +
+ *  32-byte X + 32-byte Y for a P-256 point) and its base64url form
+ *  is ~87 chars. Rejects both empty / null and the "someone pasted
+ *  the env var name as the value" failure mode that used to slip
+ *  through and hang the client. */
+export function isValidVapidPublicKey(raw: string): boolean {
+  if (!raw || raw.length < 80 || raw.length > 100) return false;
+  // Base64url uses `-_` in place of `+/`; also accept the standard
+  // form and padded variants because `web-push generate-vapid-keys`
+  // and hand-copies sometimes drop or add `=`.
+  if (!/^[A-Za-z0-9\-_+/=]+$/.test(raw)) return false;
+  try {
+    const pad = "=".repeat((4 - (raw.length % 4)) % 4);
+    const normalised = (raw + pad).replace(/-/g, "+").replace(/_/g, "/");
+    const bytes = Buffer.from(normalised, "base64");
+    return bytes.length === 65 && bytes[0] === 0x04;
+  } catch {
+    return false;
+  }
 }
 
 export interface WorldPushPayload {


### PR DESCRIPTION
## The wasted 90 minutes

Push subscription hung silently on `mobility.klorad.com`. No error, no timeout, just "Working…" forever. We eventually curled the endpoint:

```
$ curl https://mobility.klorad.com/api/public/worlds/…/vapid-public-key
{"publicKey":"NEXT_PUBLIC_VAPID_PUBLIC_KEY"}
```

The Vercel env var **value** was literally set to the env var **name**. Chrome accepted the malformed applicationServerKey without throwing — `pushManager.subscribe` hung indefinitely.

## Fix

- **`isValidVapidPublicKey(raw)`** — decodes the base64url and checks it's a 65-byte P-256 point (0x04 prefix + 32-byte X + 32-byte Y). Length + charset are cheap guards before the decode.
- **`getVapidPublicKey()`** returns null for anything that fails validation — vapid endpoint now returns 503/404 instead of shipping garbage that hangs browsers.
- **`ensureConfigured()`** rejects malformed keys with a `console.warn` so redeploys print the diagnostic in server logs.

## How to fix a live deployment when this fires

Vercel dashboard → Project → Settings → Environment Variables → `NEXT_PUBLIC_VAPID_PUBLIC_KEY` → set the **value** to the actual key (a ~87-char base64url string), not the variable name. Same for `VAPID_PRIVATE_KEY` and `VAPID_SUBJECT`. Redeploy.

Generate a fresh pair if needed: `npx web-push generate-vapid-keys --json`.

## Follow-up worth doing

- Port the same validation to `apps/campus/lib/push.ts` — same env, same failure mode possible there.
- Small `PushOptIn` client rewrite (uncommitted locally) that adds 15 s timeouts around `serviceWorker.ready` and `pushManager.subscribe` + a red "Retry (SW/subscribe)" button so the client shows an error state instead of a silent spinner. Say the word and I'll ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)