### PR TITLE
fix(mobility): push subscribe uses SW by scope, not .ready (fixes actual hang)

### DIFF
--- a/apps/mobility/app/(public)/w/[slug]/PushOptIn.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/PushOptIn.tsx
@@ -35,6 +35,28 @@ interface Props {
 const SW_READY_TIMEOUT_MS = 10_000;
 const PUSH_SUBSCRIBE_TIMEOUT_MS = 15_000;
 
+/** Find the SW registration for our world regardless of whether it
+ *  *controls* the current page. `navigator.serviceWorker.ready`
+ *  waits for a SW that controls the URL, but Next.js strips
+ *  trailing slashes so the canonical page URL is `/w/<slug>` while
+ *  `RegisterWorldSW` registers with scope `/w/<slug>/`. The scope
+ *  doesn't cover the current URL, so `ready` waits forever.
+ *
+ *  `pushManager.subscribe` doesn't require page control — it just
+ *  needs a valid registration — so we look it up by scope. Falls
+ *  back to `.ready` if no matching registration exists yet (first
+ *  load, before the register call resolved) which the caller wraps
+ *  in a timeout. */
+async function findWorldRegistration(
+  slug: string,
+): Promise<ServiceWorkerRegistration> {
+  const scope = new URL(`/w/${slug}/`, window.location.origin).href;
+  const all = await navigator.serviceWorker.getRegistrations();
+  const match = all.find((r) => r.scope === scope);
+  if (match) return match;
+  return navigator.serviceWorker.ready;
+}
+
 /**
  * Push notification opt-in for one world. Renders a small floating
  * button that mirrors the browser's permission state.
@@ -62,7 +84,7 @@ export function PushOptIn({ slug, primary }: Props) {
     (async () => {
       try {
         const reg = await withTimeout(
-          navigator.serviceWorker.ready,
+          findWorldRegistration(slug),
           SW_READY_TIMEOUT_MS,
         );
         const existing = await reg.pushManager.getSubscription();
@@ -80,7 +102,7 @@ export function PushOptIn({ slug, primary }: Props) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [slug]);
 
   const subscribe = useCallback(async () => {
     setStatus("subscribing");
@@ -112,7 +134,7 @@ export function PushOptIn({ slug, primary }: Props) {
 
       step = "sw-not-ready";
       const reg = await withTimeout(
-        navigator.serviceWorker.ready,
+        findWorldRegistration(slug),
         SW_READY_TIMEOUT_MS,
       ).catch((err) => {
         step = "sw-timeout";
@@ -169,7 +191,7 @@ export function PushOptIn({ slug, primary }: Props) {
     setStatus("unsubscribing");
     try {
       const reg = await withTimeout(
-        navigator.serviceWorker.ready,
+        findWorldRegistration(slug),
         SW_READY_TIMEOUT_MS,
       );
       const sub = await reg.pushManager.getSubscription();


### PR DESCRIPTION
## The actual bug

Stacked on #259 which turned the silent hang into a diagnosable `Retry (SW)` + console log:

```
[PushOptIn] subscribe failed at step: sw-timeout
Error: Timed out after 10000ms
```

`navigator.serviceWorker.ready` hangs because **no SW controls the current page URL**:

- `RegisterWorldSW.tsx` registers with scope `/w/<slug>/` (trailing slash)
- Next.js strips trailing slashes → canonical page URL is `/w/<slug>` (verified via `curl -I`)
- Scope `/w/<slug>/` doesn't contain URL `/w/<slug>` → no SW controls the page → `.ready` waits forever for one that will never exist

## Fix

`pushManager.subscribe` / `getSubscription` / `unsubscribe` don't need the SW to *control* the current page — they just need a valid `ServiceWorkerRegistration` object.

New `findWorldRegistration(slug)`:
- Walks `navigator.serviceWorker.getRegistrations()` and returns the one whose `.scope` matches our world's scope
- Falls back to `.ready` only if the scope match returns nothing (edge case: first paint before `RegisterWorldSW`'s async register resolves) — caller still wraps in the 10 s timeout from #259

Applied at all three await points (initial state check, subscribe, unsubscribe). No changes to Next.js routing or SW registration scope — least invasive.

## Base: stacks on #259

Base branch is `fix/mobility-push-optin-diagnostic` (#259) since both PRs touch `PushOptIn.tsx`. Retargets to `main` automatically after #259 merges.

## Test plan

- [ ] Deploy → hit `/w/egnatia-east` → click Enable alerts → within a couple seconds either "Alerts on" (green) or a distinct red retry state (subscribe/server, not SW anymore)
- [ ] Whatever the browser complains about now shows in console — no more silent hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)