### PR TITLE
feat(mobility): QR share + per-project AI key + world top nav & settings

### DIFF
--- a/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/CampusReachPageClient.tsx
+++ b/apps/campus/app/(dashboard)/org/[orgId]/maps/[mapId]/reach/CampusReachPageClient.tsx
@@ -1,16 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import useSWR, { mutate as globalMutate } from "swr";
 import { toast } from "react-toastify";
-import QRCode from "qrcode";
 import {
   Bell,
-  Check,
-  Copy,
-  Download,
   History,
-  QrCode,
   Send,
   Users,
 } from "lucide-react";
@@ -19,6 +14,7 @@ import {
   Field,
   Input,
   Panel,
+  QrShare,
   Select,
   Textarea,
 } from "@klorad/design-system";
@@ -127,63 +123,11 @@ export default function CampusReachPageClient({
   const [body, setBody] = useState("");
   const [sending, setSending] = useState(false);
   const [publishBusy, setPublishBusy] = useState(false);
-  const [qrSvg, setQrSvg] = useState<string>("");
-  const [copied, setCopied] = useState(false);
 
   const publicUrl = useMemo(() => {
     if (typeof window === "undefined") return `/campus/${mapId}`;
     return `${window.location.origin}/campus/${mapId}`;
   }, [mapId]);
-
-  // Render the QR client-side when the URL is known. SVG is sharp
-  // at any zoom and downloads as a file the rector can drop into
-  // print or paste into Figma without rasterising. `level: 'M'` is
-  // the sweet spot between resilience and dot density at typical
-  // student-phone scan distance.
-  useEffect(() => {
-    let cancelled = false;
-    QRCode.toString(publicUrl, {
-      type: "svg",
-      errorCorrectionLevel: "M",
-      margin: 1,
-      color: { dark: "#1a1a1a", light: "#ffffff" },
-      width: 240,
-    })
-      .then((svg) => {
-        if (!cancelled) setQrSvg(svg);
-      })
-      .catch(() => {
-        if (!cancelled) setQrSvg("");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [publicUrl]);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(publicUrl);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1800);
-    } catch {
-      toast.error("Couldn't copy the link");
-    }
-  };
-
-  const handleDownloadQr = () => {
-    if (!qrSvg) return;
-    const blob = new Blob([qrSvg], { type: "image/svg+xml;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    // Filename includes the mapId so the rector can save multiple
-    // campus QRs without overwriting in their Downloads folder.
-    a.download = `campus-${mapId}.svg`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  };
 
   const handleTogglePublish = async () => {
     if (!map || publishBusy) return;
@@ -402,62 +346,13 @@ export default function CampusReachPageClient({
 
         {/* ─ Right: the share card ──────────────────────────────── */}
         <aside className="space-y-6">
-          <Panel className="rounded-2xl p-6">
-            <div className="mb-4 flex items-start gap-3">
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-accent">
-                <QrCode size={16} strokeWidth={1.75} aria-hidden />
-              </div>
-              <div className="min-w-0">
-                <h2 className="text-sm font-semibold text-text-primary">
-                  Share to students
-                </h2>
-                <p className="mt-0.5 text-xs text-text-tertiary">
-                  The link + QR you hand out. Survives printing — SVG
-                  download is sharp at any size.
-                </p>
-              </div>
-            </div>
-            <div className="flex flex-col items-center gap-4">
-              <div
-                className="flex h-48 w-48 items-center justify-center rounded-xl bg-white p-2 shadow-sm"
-                aria-label="QR code"
-                dangerouslySetInnerHTML={
-                  qrSvg
-                    ? { __html: qrSvg }
-                    : { __html: "<div style='color:#9ca3af;font-size:11px'>Generating…</div>" }
-                }
-              />
-              <div className="w-full text-center">
-                <div className="truncate font-mono text-xs text-text-secondary">
-                  {publicUrl}
-                </div>
-              </div>
-              <div className="flex w-full flex-col gap-2">
-                <Button size="sm" variant="secondary" onClick={handleCopy}>
-                  {copied ? (
-                    <>
-                      <Check size={12} strokeWidth={1.75} aria-hidden />
-                      Copied
-                    </>
-                  ) : (
-                    <>
-                      <Copy size={12} strokeWidth={1.75} aria-hidden />
-                      Copy URL
-                    </>
-                  )}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={handleDownloadQr}
-                  disabled={!qrSvg}
-                >
-                  <Download size={12} strokeWidth={1.75} aria-hidden />
-                  Download QR
-                </Button>
-              </div>
-            </div>
-          </Panel>
+          <QrShare
+            url={publicUrl}
+            downloadFilename={`campus-${mapId}`}
+            title="Share to students"
+            subtitle="The link + QR you hand out. Survives printing — SVG download is sharp at any size."
+            copyLabel="Copy URL"
+          />
 
           <Panel className="rounded-2xl p-6">
             <div className="mb-3 flex items-start gap-3">

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/settings/SettingsClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/settings/SettingsClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "react-toastify";
 import { ArrowUpRight } from "lucide-react";
+import { AiKeyPanel } from "@/lib/mobility/AiKeyPanel";
 
 interface Initial {
   title: string;
@@ -192,6 +193,11 @@ export function SettingsClient({
             </span>
           )}
         </div>
+      </section>
+
+      {/* Paris AI key */}
+      <section className="mb-8">
+        <AiKeyPanel projectId={projectId} />
       </section>
 
       {/* Danger zone */}

--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
@@ -26,6 +26,7 @@ import {
   Users,
   type LucideIcon,
 } from "lucide-react";
+import { QrShare } from "@klorad/design-system";
 import { subsystemIcon as pickSubsystemIcon } from "@/lib/mobility/subsystem-icon";
 
 type Visibility = "public" | "linkOnly" | "authenticated";
@@ -360,6 +361,15 @@ export function WorldEditor({
       {/* Publish + live URL */}
       <PublishCard world={world} />
 
+      {/* Share — QR code for the world's public URL. Only surfaces
+          once the world is published, since sharing a draft URL
+          just serves a 404 to whoever scans it. */}
+      {world.isPublished && (
+        <section className="mb-6">
+          <ShareCard slug={world.slug} />
+        </section>
+      )}
+
       {/* Stats */}
       <StatsCard stats={stats} />
 
@@ -603,6 +613,28 @@ function PublishCard({ world }: { world: World }) {
         </div>
       ) : null}
     </section>
+  );
+}
+
+/* ───────────────────── Share (QR) ──────────────────────────────── */
+
+function ShareCard({ slug }: { slug: string }) {
+  // The public URL uses the browser origin so the QR points at the
+  // deploy the operator is actually looking at (staging vs prod)
+  // without env-var plumbing. SSR falls back to a relative-ish path
+  // that never actually renders — the primitive is client-only, so
+  // the useMemo runs post-mount.
+  const publicUrl = useMemo(() => {
+    if (typeof window === "undefined") return `/w/${slug}`;
+    return `${window.location.origin}/w/${slug}`;
+  }, [slug]);
+  return (
+    <QrShare
+      url={publicUrl}
+      downloadFilename={`world-${slug}`}
+      title="Share this world"
+      subtitle="Scan or copy the link — the QR downloads as an SVG for print."
+    />
   );
 }
 

--- a/apps/mobility/app/(public)/w/[slug]/MobilitySettingsMenu.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/MobilitySettingsMenu.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { signOut, useSession } from "next-auth/react";
+import {
+  Bell,
+  BellOff,
+  ChevronDown,
+  LogIn,
+  LogOut,
+  Settings,
+  User as UserIcon,
+} from "lucide-react";
+
+interface Props {
+  slug: string;
+}
+
+type NotificationState = "loading" | "unsupported" | "denied" | "off" | "on";
+
+async function findWorldRegistration(
+  slug: string,
+): Promise<ServiceWorkerRegistration | null> {
+  const scope = new URL(`/w/${slug}/`, window.location.origin).href;
+  const all = await navigator.serviceWorker.getRegistrations();
+  return all.find((r) => r.scope === scope) ?? null;
+}
+
+/**
+ * Settings dropdown mounted in the world's top nav. Serves three
+ * jobs in one condensed surface:
+ *
+ * 1. **Identity** — shows the signed-in user (name/email) or a
+ *    Sign-in link that comes back to this world on completion.
+ * 2. **Notifications toggle** — reads the current push subscription
+ *    state, offers Enable / Disable + falls back to a "Blocked by
+ *    browser" hint when Notification.permission === "denied". Uses
+ *    the same VAPID key + subscribe endpoint as the floating
+ *    PushOptIn pill on the Map tab; both stay in sync via the
+ *    browser's subscription store.
+ * 3. **Sign out** — one-click, returns to the world's public root.
+ *
+ * The menu closes on outside-click and Escape. Positioned below
+ * the trigger with `right-0` so it never overflows the viewport on
+ * narrow phones.
+ */
+export function MobilitySettingsMenu({ slug }: Props) {
+  const { data: session, status: authStatus } = useSession();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const [notifState, setNotifState] = useState<NotificationState>("loading");
+  const [notifBusy, setNotifBusy] = useState(false);
+
+  // Read the current subscription state on mount. We poll this on
+  // every open so the toggle reflects changes made from the
+  // floating PushOptIn pill without a full page refresh.
+  const readState = useCallback(async () => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+      setNotifState("unsupported");
+      return;
+    }
+    if (Notification.permission === "denied") {
+      setNotifState("denied");
+      return;
+    }
+    try {
+      const reg = await findWorldRegistration(slug);
+      if (!reg) {
+        setNotifState("unsupported");
+        return;
+      }
+      const sub = await reg.pushManager.getSubscription();
+      setNotifState(sub ? "on" : "off");
+    } catch {
+      setNotifState("unsupported");
+    }
+  }, [slug]);
+
+  useEffect(() => {
+    void readState();
+  }, [readState]);
+
+  useEffect(() => {
+    if (!open) return;
+    void readState();
+    const onDocClick = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, readState]);
+
+  const toggleNotifications = async () => {
+    if (notifBusy) return;
+    setNotifBusy(true);
+    try {
+      if (notifState === "on") {
+        // Unsubscribe.
+        const reg = await findWorldRegistration(slug);
+        const sub = await reg?.pushManager.getSubscription();
+        if (sub) {
+          await fetch(`/api/public/worlds/${slug}/unsubscribe`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ endpoint: sub.endpoint }),
+          }).catch(() => undefined);
+          await sub.unsubscribe();
+        }
+        setNotifState("off");
+        return;
+      }
+      // Subscribe.
+      if (Notification.permission === "default") {
+        const perm = await Notification.requestPermission();
+        if (perm !== "granted") {
+          setNotifState(perm === "denied" ? "denied" : "off");
+          return;
+        }
+      }
+      const keyRes = await fetch(`/api/public/worlds/${slug}/vapid-public-key`);
+      if (!keyRes.ok) {
+        setNotifState("unsupported");
+        return;
+      }
+      const { publicKey } = (await keyRes.json()) as { publicKey: string };
+      const reg = await findWorldRegistration(slug);
+      if (!reg) {
+        setNotifState("unsupported");
+        return;
+      }
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey) as unknown as BufferSource,
+      });
+      const subJson = sub.toJSON();
+      const p256dh = subJson.keys?.p256dh ?? "";
+      const auth = subJson.keys?.auth ?? "";
+      if (!p256dh || !auth || !sub.endpoint) {
+        await sub.unsubscribe();
+        return;
+      }
+      const res = await fetch(`/api/public/worlds/${slug}/subscribe`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ endpoint: sub.endpoint, p256dh, auth }),
+      });
+      if (!res.ok) {
+        await sub.unsubscribe();
+        return;
+      }
+      setNotifState("on");
+    } catch (err) {
+      console.warn("[MobilitySettingsMenu] notification toggle failed", err);
+    } finally {
+      setNotifBusy(false);
+    }
+  };
+
+  const signInHref = `/auth/signin?callbackUrl=${encodeURIComponent(`/w/${slug}`)}`;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Settings"
+        className="inline-flex items-center gap-1 rounded-full border border-[var(--w-border,#e6e6ea)] bg-white px-2.5 py-1.5 text-[var(--w-fg,#1a1a1a)] transition-colors hover:border-[var(--w-accent,#0ea5e9)]"
+      >
+        <Settings size={14} strokeWidth={1.8} />
+        <ChevronDown size={12} strokeWidth={2} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-[calc(100%+6px)] z-50 w-64 overflow-hidden rounded-2xl border border-[var(--w-border,#e6e6ea)] bg-white shadow-lg"
+        >
+          {/* Identity */}
+          <div className="border-b border-[var(--w-border,#e6e6ea)] px-4 py-3">
+            {authStatus === "loading" ? (
+              <p className="text-xs text-[var(--w-fg-muted,#6b6b6b)]">…</p>
+            ) : session?.user ? (
+              <div className="flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--w-page,#f5f5f7)] text-[var(--w-accent,#0ea5e9)]"
+                >
+                  <UserIcon size={14} strokeWidth={1.8} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-[var(--w-fg,#1a1a1a)]">
+                    {session.user.name ?? session.user.email ?? "Signed in"}
+                  </span>
+                  {session.user.name && session.user.email && (
+                    <span className="block truncate text-[10px] text-[var(--w-fg-muted,#6b6b6b)]">
+                      {session.user.email}
+                    </span>
+                  )}
+                </span>
+              </div>
+            ) : (
+              <Link
+                href={signInHref}
+                className="inline-flex items-center gap-2 text-sm font-medium text-[var(--w-accent,#0ea5e9)]"
+                onClick={() => setOpen(false)}
+              >
+                <LogIn size={14} strokeWidth={1.8} />
+                Sign in
+              </Link>
+            )}
+          </div>
+
+          {/* Notifications */}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => void toggleNotifications()}
+            disabled={
+              notifBusy ||
+              notifState === "loading" ||
+              notifState === "unsupported" ||
+              notifState === "denied"
+            }
+            className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--w-page,#f5f5f7)] disabled:opacity-60"
+          >
+            <span className="flex items-center gap-2">
+              <span
+                aria-hidden
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--w-page,#f5f5f7)]"
+              >
+                {notifState === "on" ? (
+                  <Bell size={13} strokeWidth={2} className="text-[var(--w-accent,#0ea5e9)]" />
+                ) : (
+                  <BellOff size={13} strokeWidth={2} className="text-[var(--w-fg-muted,#6b6b6b)]" />
+                )}
+              </span>
+              <span className="text-sm text-[var(--w-fg,#1a1a1a)]">
+                Notifications
+              </span>
+            </span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--w-fg-muted,#6b6b6b)]">
+              {notifState === "on"
+                ? "On"
+                : notifState === "denied"
+                  ? "Blocked"
+                  : notifState === "unsupported"
+                    ? "N/A"
+                    : notifBusy
+                      ? "…"
+                      : "Off"}
+            </span>
+          </button>
+
+          {/* Sign out */}
+          {session?.user && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                void signOut({ callbackUrl: `/w/${slug}` }).then(() => {
+                  router.refresh();
+                });
+              }}
+              className="flex w-full items-center gap-3 border-t border-[var(--w-border,#e6e6ea)] px-4 py-3 text-left transition-colors hover:bg-[var(--w-page,#f5f5f7)]"
+            >
+              <span
+                aria-hidden
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--w-page,#f5f5f7)]"
+              >
+                <LogOut size={13} strokeWidth={2} className="text-[var(--w-fg-muted,#6b6b6b)]" />
+              </span>
+              <span className="text-sm text-[var(--w-fg,#1a1a1a)]">Sign out</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Duplicated from PushOptIn — kept local so this menu can subscribe
+ *  without importing across a client-component boundary that also
+ *  ships the map viewer. Small enough that it's not worth extracting
+ *  to a shared util yet. */
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const normalised = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(normalised);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i);
+  return out;
+}

--- a/apps/mobility/app/(public)/w/[slug]/MobilityTopNav.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/MobilityTopNav.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { List, Map as MapIcon, Sparkles } from "lucide-react";
+import { KloradMark } from "@klorad/design-system";
+import { MobilitySettingsMenu } from "./MobilitySettingsMenu";
+
+interface Props {
+  slug: string;
+  /** World display name — shown next to the logo. */
+  worldName: string;
+  /** Optional per-world logo URL from `MobilityWorld.theme.logoUrl`.
+   *  When present, replaces the KloradMark + world name lockup. */
+  logoUrl: string | null;
+}
+
+interface NavLink {
+  key: "map" | "devices" | "paris";
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number; className?: string }>;
+}
+
+function resolveActiveTab(
+  pathname: string,
+  slug: string,
+): "map" | "devices" | "paris" {
+  const base = `/w/${slug}`;
+  if (pathname.startsWith(`${base}/devices`)) return "devices";
+  if (pathname.startsWith(`${base}/paris`)) return "paris";
+  return "map";
+}
+
+/**
+ * Mobility's top nav — sticky white bar that persists across tab
+ * routes so the world feels like a native app rather than a
+ * multi-page site. Mirrors Campus's `ConsumerNav` pattern:
+ *
+ *   - Left: world logo (from `theme.logoUrl`) + name, links to Map.
+ *   - Centre (desktop only): inline Map / Devices / Paris links.
+ *     Active link picks up the world's accent colour.
+ *   - Right: `MobilitySettingsMenu` dropdown — identity,
+ *     notifications toggle, sign in/out.
+ *
+ * On mobile the tab links collapse and the bottom nav takes over
+ * (`MobileBottomNav` in the layout with `md:hidden`). This keeps
+ * the top bar tight enough for a phone header without losing the
+ * settings + logo affordances.
+ */
+export function MobilityTopNav({ slug, worldName, logoUrl }: Props) {
+  const pathname = usePathname() ?? `/w/${slug}`;
+  const active = resolveActiveTab(pathname, slug);
+
+  const links: NavLink[] = [
+    { key: "map", label: "Map", href: `/w/${slug}`, icon: MapIcon },
+    {
+      key: "devices",
+      label: "Devices",
+      href: `/w/${slug}/devices`,
+      icon: List,
+    },
+    {
+      key: "paris",
+      label: "Paris",
+      href: `/w/${slug}/paris`,
+      icon: Sparkles,
+    },
+  ];
+
+  return (
+    <header className="sticky top-0 z-30 border-b border-[var(--w-border,#e6e6ea)] bg-white">
+      <div className="mx-auto flex h-14 max-w-[1280px] items-center justify-between gap-4 px-4 md:px-6">
+        <Link
+          href={`/w/${slug}`}
+          className="flex shrink-0 items-center gap-2"
+          aria-label={`${worldName} home`}
+        >
+          {logoUrl ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={logoUrl}
+              alt={worldName}
+              className="h-9 max-w-[180px] rounded-lg object-contain"
+            />
+          ) : (
+            <>
+              <KloradMark className="h-8 w-8" />
+              <span className="text-base font-medium text-[var(--w-fg,#1a1a1a)]">
+                {worldName}
+              </span>
+            </>
+          )}
+        </Link>
+
+        <nav
+          aria-label="Primary"
+          className="hidden items-center gap-1 md:flex"
+        >
+          {links.map((l) => {
+            const isActive = active === l.key;
+            const Icon = l.icon;
+            return (
+              <Link
+                key={l.key}
+                href={l.href}
+                aria-current={isActive ? "page" : undefined}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-[var(--w-accent,#0ea5e9)] text-[var(--w-accent-contrast,#ffffff)]"
+                    : "text-[var(--w-fg-muted,#6b6b6b)] hover:text-[var(--w-fg,#1a1a1a)]"
+                }`}
+              >
+                <Icon size={13} strokeWidth={1.8} />
+                {l.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <MobilitySettingsMenu slug={slug} />
+      </div>
+    </header>
+  );
+}

--- a/apps/mobility/app/(public)/w/[slug]/layout.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/layout.tsx
@@ -6,6 +6,7 @@ import { RegisterWorldSW } from "./RegisterWorldSW";
 import { WorldBeacon } from "./WorldBeacon";
 import { MobilityBottomNav } from "./MobilityBottomNav";
 import { MobilityPullToRefresh } from "./MobilityPullToRefresh";
+import { MobilityTopNav } from "./MobilityTopNav";
 
 type Params = Promise<{ slug: string }>;
 
@@ -97,8 +98,24 @@ export default async function WorldPublicLayout({
   params: Params;
 }) {
   const { slug } = await params;
+  // World name + logo drive the top-nav branding. Draft / gated
+  // worlds return null from the anonymous resolver; the top nav
+  // falls back to the slug in that case so the header still
+  // renders (the page-level access-denied surface takes over
+  // below).
+  const world = await loadPublicWorldBySlug(slug);
+  const logoUrl =
+    world && typeof world.theme.logoUrl === "string"
+      ? world.theme.logoUrl
+      : null;
+  const worldName = world?.name ?? slug;
   return (
     <>
+      <MobilityTopNav
+        slug={slug}
+        worldName={worldName}
+        logoUrl={logoUrl}
+      />
       {children}
       <MobilityBottomNav slug={slug} />
       <MobilityPullToRefresh />

--- a/apps/mobility/app/api/paris/route.ts
+++ b/apps/mobility/app/api/paris/route.ts
@@ -14,6 +14,7 @@
  */
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+import { decryptSecret, secretsEnabled } from "@klorad/secrets";
 import { prisma } from "@/lib/prisma";
 import {
   PARIS_TOOLS,
@@ -31,6 +32,29 @@ interface RequestBody {
 
 const MAX_TOOL_ITERATIONS = 5;
 const MODEL = "claude-sonnet-4-6";
+
+/** Per-project key first (stored encrypted on `Project`), env-var
+ *  fallback second. Decrypt failures (rotated `SECRETS_KEY`, stale
+ *  ciphertext) log but fall through so the assistant stays usable
+ *  on the platform key. Same shape as Campus's `resolveAnthropicKey`. */
+async function resolveAnthropicKey(
+  projectId: string,
+): Promise<string | undefined> {
+  if (secretsEnabled()) {
+    try {
+      const project = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { anthropicApiKeyEncrypted: true },
+      });
+      if (project?.anthropicApiKeyEncrypted) {
+        return decryptSecret(project.anthropicApiKeyEncrypted);
+      }
+    } catch (err) {
+      console.error("[paris] per-project key lookup failed", err);
+    }
+  }
+  return process.env.ANTHROPIC_API_KEY ?? undefined;
+}
 
 /** System prompt — kept short and behaviour-focused. Paris is a
  *  read-only concierge; the tool list is the contract for what it
@@ -80,10 +104,13 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = await resolveAnthropicKey(world.projectId);
   if (!apiKey) {
     return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY not set" },
+      {
+        error:
+          "No Anthropic key configured — set one in the project's AI settings or the ANTHROPIC_API_KEY env var.",
+      },
       { status: 503 },
     );
   }

--- a/apps/mobility/app/api/projects/[projectId]/ai-settings/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/ai-settings/route.ts
@@ -1,0 +1,116 @@
+/**
+ * GET   /api/projects/[projectId]/ai-settings — returns
+ *         `{ hasKey, masked, secretsEnabled }`. Never plaintext.
+ * PATCH /api/projects/[projectId]/ai-settings — body
+ *         `{ apiKey: string | null }`. String encrypts + stores;
+ *         `null` clears (falls back to platform env var). Requires
+ *         `SECRETS_KEY` to encrypt.
+ *
+ * Same pattern as Campus's `/api/maps/[mapId]/ai-settings` — the
+ * `Project.anthropicApiKeyEncrypted` column is shared across both
+ * apps (schema is in `packages/prisma`), so no migration needed
+ * for Mobility.
+ */
+import { NextResponse } from "next/server";
+import {
+  decryptSecret,
+  encryptSecret,
+  maskSecret,
+  secretsEnabled,
+} from "@klorad/secrets";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ projectId: string }>;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "read");
+  if (denied) return denied;
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { anthropicApiKeyEncrypted: true },
+  });
+  if (!project) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let masked: string | null = null;
+  if (project.anthropicApiKeyEncrypted && secretsEnabled()) {
+    try {
+      masked = maskSecret(decryptSecret(project.anthropicApiKeyEncrypted));
+    } catch (err) {
+      console.error("[ai-settings] decrypt failed", err);
+    }
+  }
+
+  return NextResponse.json({
+    hasKey: Boolean(project.anthropicApiKeyEncrypted),
+    masked,
+    secretsEnabled: secretsEnabled(),
+  });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (body.apiKey === null) {
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { anthropicApiKeyEncrypted: null },
+    });
+    return NextResponse.json({ ok: true, hasKey: false, masked: null });
+  }
+
+  if (!secretsEnabled()) {
+    return NextResponse.json(
+      {
+        error:
+          "SECRETS_KEY isn't set on the server — needed to encrypt at-rest secrets.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "apiKey is required" },
+      { status: 400 },
+    );
+  }
+  if (!apiKey.startsWith("sk-ant-")) {
+    return NextResponse.json(
+      { error: "Anthropic keys start with sk-ant-" },
+      { status: 400 },
+    );
+  }
+
+  const encrypted = encryptSecret(apiKey);
+  await prisma.project.update({
+    where: { id: projectId },
+    data: { anthropicApiKeyEncrypted: encrypted },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    hasKey: true,
+    masked: maskSecret(apiKey),
+  });
+}

--- a/apps/mobility/app/api/projects/[projectId]/ai-settings/test/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/ai-settings/test/route.ts
@@ -1,0 +1,84 @@
+/**
+ * POST /api/projects/[projectId]/ai-settings/test
+ *
+ * Hits Claude Haiku with a 1-token budget to confirm an API key
+ * actually works. Body: `{ apiKey?: string }`.
+ *   - With `apiKey`: tests the supplied key (paste-and-test before Save).
+ *   - Without: tests the stored key.
+ *
+ * Returns `{ ok: true }` or `{ ok: false, error }` — the latter is
+ * HTTP 200 so the client can render inline feedback without
+ * tripping fetch-error handling.
+ */
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { decryptSecret, secretsEnabled } from "@klorad/secrets";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ projectId: string }>;
+
+export async function POST(
+  req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    // Empty body is fine — falls through to the stored-key path.
+  }
+
+  let apiKey =
+    typeof body.apiKey === "string" && body.apiKey.trim().length > 0
+      ? body.apiKey.trim()
+      : "";
+
+  if (!apiKey) {
+    if (!secretsEnabled()) {
+      return NextResponse.json(
+        { ok: false, error: "SECRETS_KEY isn't set on the server." },
+        { status: 200 },
+      );
+    }
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { anthropicApiKeyEncrypted: true },
+    });
+    if (!project?.anthropicApiKeyEncrypted) {
+      return NextResponse.json(
+        { ok: false, error: "No key stored yet." },
+        { status: 200 },
+      );
+    }
+    try {
+      apiKey = decryptSecret(project.anthropicApiKeyEncrypted);
+    } catch {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Stored ciphertext didn't decrypt — was SECRETS_KEY rotated?",
+        },
+        { status: 200 },
+      );
+    }
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+    await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 1,
+      messages: [{ role: "user", content: "ping" }],
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Anthropic call failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 200 });
+  }
+}

--- a/apps/mobility/lib/mobility/AiKeyPanel.tsx
+++ b/apps/mobility/lib/mobility/AiKeyPanel.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { Bot, Eye, EyeOff, RotateCw, Trash2 } from "lucide-react";
+import { Button, Field, Input, Panel } from "@klorad/design-system";
+
+interface Props {
+  projectId: string;
+}
+
+interface Status {
+  hasKey: boolean;
+  masked: string | null;
+  secretsEnabled: boolean;
+}
+
+/**
+ * Anthropic API-key admin panel for a Mobility project. Powers the
+ * per-world Paris assistant — usage + billing stay scoped to this
+ * project's key rather than the platform env var.
+ *
+ * Mirrors Campus's `AiKeyPanel` behaviour: masked display, save /
+ * test / remove buttons, disabled state when `SECRETS_KEY` is
+ * absent. Backend at `/api/projects/[projectId]/ai-settings`.
+ *
+ * Follow-up: extract the shared component to
+ * `@klorad/design-system` and thread the endpoint URL + intro
+ * copy through as props — Campus and Mobility both drop their
+ * duplicated copies. Not this arc.
+ */
+export function AiKeyPanel({ projectId }: Props) {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [draft, setDraft] = useState("");
+  const [reveal, setReveal] = useState(false);
+  const [busy, setBusy] = useState<"save" | "test" | "remove" | null>(null);
+
+  useEffect(() => {
+    void fetch(`/api/projects/${projectId}/ai-settings`)
+      .then((r) => r.json())
+      .then((s: Status) => setStatus(s))
+      .catch(() => undefined);
+  }, [projectId]);
+
+  const save = async () => {
+    const apiKey = draft.trim();
+    if (!apiKey) {
+      toast.error("Paste a key first.");
+      return;
+    }
+    setBusy("save");
+    try {
+      const res = await fetch(`/api/projects/${projectId}/ai-settings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Save failed");
+      setStatus({
+        hasKey: body.hasKey,
+        masked: body.masked,
+        secretsEnabled: true,
+      });
+      setDraft("");
+      setReveal(false);
+      toast.success("Key saved");
+    } catch (e) {
+      console.error(e);
+      toast.error(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const test = async () => {
+    setBusy("test");
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/ai-settings/test`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(draft.trim() ? { apiKey: draft.trim() } : {}),
+        },
+      );
+      const body = (await res.json()) as { ok: boolean; error?: string };
+      if (body.ok) toast.success("Key works.");
+      else toast.error(body.error ?? "Key failed.");
+    } catch (e) {
+      console.error(e);
+      toast.error("Test failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const remove = async () => {
+    if (
+      !confirm(
+        "Remove the stored key? Paris will fall back to the platform key (or refuse if none is set).",
+      )
+    ) {
+      return;
+    }
+    setBusy("remove");
+    try {
+      const res = await fetch(`/api/projects/${projectId}/ai-settings`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: null }),
+      });
+      if (!res.ok) throw new Error("Remove failed");
+      setStatus({
+        hasKey: false,
+        masked: null,
+        secretsEnabled: status?.secretsEnabled ?? false,
+      });
+      toast.success("Key removed");
+    } catch (e) {
+      console.error(e);
+      toast.error("Remove failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Panel className="rounded-2xl p-6">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent">
+          <Bot size={18} strokeWidth={1.75} />
+        </span>
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary">
+            Anthropic API key
+          </h3>
+          <p className="mt-1 text-sm text-text-secondary">
+            Powers Paris — the read-only assistant that answers &quot;what&apos;s
+            happening on this world&apos;s map&quot;. Usage + cost stay scoped to
+            this project&apos;s key. Get one at{" "}
+            <a
+              href="https://console.anthropic.com/settings/keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline"
+            >
+              console.anthropic.com
+            </a>
+            . The key is encrypted at rest and never returned to the browser
+            in plaintext.
+          </p>
+        </div>
+      </div>
+
+      {status === null ? (
+        <p className="mt-4 text-xs text-text-tertiary">Loading…</p>
+      ) : (
+        <>
+          {!status.secretsEnabled ? (
+            <p className="mt-4 rounded-lg bg-red-50 p-3 text-xs text-red-600">
+              <code className="font-mono">SECRETS_KEY</code> isn&apos;t set on
+              the server — saving a key is disabled. Generate one with{" "}
+              <code className="font-mono">openssl rand -hex 32</code> and add
+              it to <code>.env.local</code>, then restart.
+            </p>
+          ) : null}
+
+          {status.hasKey && status.masked ? (
+            <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-solid border-line-soft bg-surface-2 px-3 py-2.5">
+              <span className="flex items-center gap-2 font-mono text-xs text-text-secondary">
+                <Bot size={14} strokeWidth={1.75} className="text-accent" />
+                {status.masked}
+              </span>
+              <button
+                type="button"
+                onClick={() => void remove()}
+                disabled={busy !== null}
+                className="inline-flex items-center gap-1 rounded-md p-1 text-text-tertiary transition-colors hover:bg-surface-1 hover:text-red-600 disabled:opacity-40"
+                aria-label="Remove key"
+              >
+                <Trash2 size={14} strokeWidth={1.75} />
+              </button>
+            </div>
+          ) : null}
+
+          <Field
+            label={status.hasKey ? "Replace with a new key" : "Add a key"}
+            className="mt-4"
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type={reveal ? "text" : "password"}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="sk-ant-…"
+                disabled={!status.secretsEnabled || busy !== null}
+                autoComplete="off"
+                className="flex-1 font-mono"
+              />
+              <button
+                type="button"
+                onClick={() => setReveal((r) => !r)}
+                aria-label={reveal ? "Hide" : "Reveal"}
+                className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-solid border-line-soft text-text-tertiary transition-colors hover:border-accent hover:text-accent"
+              >
+                {reveal ? (
+                  <EyeOff size={14} strokeWidth={1.75} />
+                ) : (
+                  <Eye size={14} strokeWidth={1.75} />
+                )}
+              </button>
+            </div>
+          </Field>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              onClick={() => void save()}
+              disabled={!status.secretsEnabled || !draft.trim() || busy !== null}
+            >
+              {busy === "save" ? "Saving…" : "Save key"}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => void test()}
+              disabled={busy !== null || (!draft.trim() && !status.hasKey)}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <RotateCw
+                  size={14}
+                  strokeWidth={1.75}
+                  className={busy === "test" ? "animate-spin" : ""}
+                />
+                {busy === "test" ? "Testing…" : "Test"}
+              </span>
+            </Button>
+          </div>
+        </>
+      )}
+    </Panel>
+  );
+}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "culori": "^4.0.2",
     "next-themes": "^0.4.6",
+    "qrcode": "^1.5.4",
     "tailwind-merge": "^3.6.0"
   },
   "peerDependencies": {
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@types/culori": "^4.0.1",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^3.4.14",

--- a/packages/design-system/src/components/qr-share.tsx
+++ b/packages/design-system/src/components/qr-share.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import QRCode from "qrcode";
+import { Check, Copy, Download } from "lucide-react";
+
+export interface QrShareProps {
+  /**
+   * URL to encode. Verticals typically pass the public-facing URL of
+   * the resource being shared (`${origin}/campus/<token>` for a
+   * Campus, `${origin}/w/<slug>` for a Mobility world).
+   */
+  url: string;
+  /**
+   * Filename (without extension) used when the visitor clicks
+   * "Download QR". A `.svg` is appended by the primitive. Example:
+   * `campus-<mapId>` or `mobility-<slug>`.
+   */
+  downloadFilename?: string;
+  /** Panel title. Default: "Share". */
+  title?: string;
+  /** Panel subtitle. Default: "Scan the QR or copy the link". */
+  subtitle?: string;
+  /** Copy-button label. Default: "Copy link". */
+  copyLabel?: string;
+  /** Download-button label. Default: "Download QR". */
+  downloadLabel?: string;
+  /** Pixel size of the rendered QR. Default: 240. */
+  size?: number;
+  /**
+   * Foreground colour for the QR dots. Default: `--brand-fg` var
+   * falling back to `#1a1a1a`. Kept as a hex string so the qrcode
+   * library can serialise it verbatim into the SVG.
+   */
+  darkColor?: string;
+  /** Background colour. Default: white. */
+  lightColor?: string;
+}
+
+/**
+ * "Share" card that renders a QR code for a URL + a copy-link
+ * button + a download-SVG button. SVG stays sharp at any zoom,
+ * downloads clean into print / Figma / a physical poster without
+ * rasterising.
+ *
+ * All computation is client-only (uses `navigator.clipboard`,
+ * `URL.createObjectURL`, and the browser's atob). Renders a
+ * skeleton until the QR resolves so SSR doesn't ship an empty
+ * white square.
+ *
+ * Palette comes from the standard `--brand-*` CSS custom
+ * properties (see `InstallPrompt` for the full list).
+ */
+export function QrShare({
+  url,
+  downloadFilename = "share",
+  title = "Share",
+  subtitle = "Scan the QR or copy the link",
+  copyLabel = "Copy link",
+  downloadLabel = "Download QR",
+  size = 240,
+  darkColor = "#1a1a1a",
+  lightColor = "#ffffff",
+}: QrShareProps) {
+  const [svg, setSvg] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    QRCode.toString(url, {
+      type: "svg",
+      // `M` is the sweet spot between resilience + dot density at
+      // typical phone-scan distance.
+      errorCorrectionLevel: "M",
+      margin: 1,
+      color: { dark: darkColor, light: lightColor },
+      width: size,
+    })
+      .then((s) => {
+        if (!cancelled) setSvg(s);
+      })
+      .catch(() => {
+        if (!cancelled) setSvg("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url, darkColor, lightColor, size]);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // Older browsers / non-secure contexts — silently no-op; the
+      // URL is still visible in the panel for a manual copy.
+    }
+  };
+
+  const downloadQr = () => {
+    if (!svg) return;
+    const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = href;
+    a.download = `${downloadFilename}.svg`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(href);
+  };
+
+  return (
+    <div className="rounded-2xl border border-[var(--brand-line,#e6e6ea)] bg-white p-5">
+      <header className="mb-4">
+        <h3 className="text-sm font-semibold text-[var(--brand-text,#1a1a1a)]">
+          {title}
+        </h3>
+        <p className="mt-1 text-xs text-[var(--brand-text-muted,#6b6b6b)]">
+          {subtitle}
+        </p>
+      </header>
+
+      <div
+        className="mx-auto flex items-center justify-center rounded-xl bg-white p-3"
+        style={{
+          width: size + 24,
+          height: size + 24,
+          border: "1px solid var(--brand-line, #e6e6ea)",
+        }}
+      >
+        {svg ? (
+          <div
+            aria-label={`QR code for ${url}`}
+            style={{ width: size, height: size }}
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        ) : (
+          <div
+            aria-hidden
+            className="animate-pulse rounded-md bg-[var(--brand-line,#e6e6ea)]"
+            style={{ width: size, height: size }}
+          />
+        )}
+      </div>
+
+      <p className="mt-4 truncate text-center font-mono text-xs text-[var(--brand-text-muted,#6b6b6b)]">
+        {url}
+      </p>
+
+      <div className="mt-4 flex flex-wrap justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => void copyLink()}
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--brand-line,#e6e6ea)] px-3 py-1.5 text-xs font-medium text-[var(--brand-text,#1a1a1a)] transition-colors hover:border-[var(--brand-primary,#534ab7)] hover:text-[var(--brand-primary,#534ab7)]"
+        >
+          {copied ? (
+            <>
+              <Check size={13} strokeWidth={2} />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy size={13} strokeWidth={2} />
+              {copyLabel}
+            </>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={downloadQr}
+          disabled={!svg}
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--brand-line,#e6e6ea)] px-3 py-1.5 text-xs font-medium text-[var(--brand-text,#1a1a1a)] transition-colors hover:border-[var(--brand-primary,#534ab7)] hover:text-[var(--brand-primary,#534ab7)] disabled:opacity-40"
+        >
+          <Download size={13} strokeWidth={2} />
+          {downloadLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -92,6 +92,7 @@ export {
   type AssistantSuggestion,
   type AssistantMessage,
 } from "./components/assistant-panel";
+export { QrShare, type QrShareProps } from "./components/qr-share";
 export { Dock, type DockProps } from "./components/dock";
 export {
   Workbench,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,6 +920,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -933,6 +936,9 @@ importers:
       '@types/culori':
         specifier: ^4.0.1
         version: 4.0.1
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.7
@@ -14028,7 +14034,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14069,7 +14075,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14088,6 +14094,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -14097,6 +14114,35 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):


### PR DESCRIPTION
## Summary

One arc covering four features on the mobility world consumer app + admin, all following the "primitives in DS, thin app wrappers" pattern.

### 1. QR share (`QrShare` in `@klorad/design-system`)

- Extracts Campus's inline QR card as a generic primitive. Props: `url`, `downloadFilename`, `title/subtitle/copyLabel/downloadLabel`, `size`, `dark/lightColor`. Uses `qrcode` npm package.
- Mobility mounts it in `WorldEditor` behind an `isPublished` guard.
- Campus refactored to consume it: **-55 / +10 LOC** deleted from `CampusReachPageClient` (dead `QRCode` / `Copy` / `Check` / `Download` / `QrCode` imports + `qrSvg` / `handleCopy` / `handleDownloadQr` gone).

### 2. Per-project Anthropic key for Paris

- Column (`Project.anthropicApiKeyEncrypted`) is already on the shared Prisma schema — no migration.
- New endpoints: `GET|PATCH /api/projects/[projectId]/ai-settings` + `POST /api/projects/[projectId]/ai-settings/test`. Same shape as Campus's `/ai-settings`.
- Paris (`/api/paris`) now calls `resolveAnthropicKey(projectId)` — per-project decrypted key first, `ANTHROPIC_API_KEY` env fallback second. Decrypt failures fall through so a rotated `SECRETS_KEY` doesn't kill the assistant.
- `AiKeyPanel` (masked display + save/test/remove buttons) mounted in the project Settings page. Duplicated from Campus for shipping speed — a shared DS panel is a natural follow-up.

### 3. Top nav (`MobilityTopNav`) + settings menu (`MobilitySettingsMenu`)

Mirrors Campus's `ConsumerNav` two-lane pattern so `/w/<slug>` feels the same across mobile / desktop.

- **Top bar** — sticky white, world logo (from `theme.logoUrl`) or `KloradMark` + world name lockup. Inline Map / Devices / Paris tabs on desktop. Bottom nav stays as-is with `md:hidden`.
- **Settings dropdown**:
  - Identity block — signed-in user (name + email) or a "Sign in" link that returns to the world on completion.
  - Notifications toggle — Enable / Disable pushed subscription via the same VAPID key + subscribe endpoint the floating `PushOptIn` pill uses; falls back to "Blocked" / "N/A" when browser permission is denied or the API is unsupported.
  - Sign out — returns to the world root.
  - Outside-click + Escape close.

The floating `PushOptIn` on the Map tab stays put — both controls operate on the same subscription store, so toggling either syncs the other.

## Test plan

- [ ] `/w/<slug>` on mobile: top bar + bottom nav both visible, tabs work
- [ ] Same URL on desktop: top bar with inline tabs, bottom nav hidden
- [ ] World with `theme.logoUrl` — logo replaces `KloradMark` + name
- [ ] Settings menu → Sign in link brings you back to the world after signin
- [ ] Settings menu → Notifications toggle enables/disables push (same state as floating pill)
- [ ] Settings menu → Sign out returns to `/w/<slug>` anonymous
- [ ] `WorldEditor` on a published world shows the QR share card; hides for drafts
- [ ] Project Settings page → AI key panel; save + test + remove all work
- [ ] Paris tab responds without an env var when a per-project key is set
- [ ] Reach page on Campus still shows QR (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)