### PR TITLE
feat(mobility): device-scoped notifications + Alerts tab + Paris scroll fix

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/worlds/[worldId]/WorldEditor.tsx
@@ -377,7 +377,10 @@ export function WorldEditor({
       <ThemeCard world={world} />
 
       {/* Broadcast */}
-      <BroadcastCard world={world} />
+      <BroadcastCard
+        world={world}
+        worldDevices={devicePool.filter((d) => selected.has(d.id))}
+      />
 
       {/* Device picker */}
       <section className="rounded-2xl border border-line-soft bg-surface-1/40 p-5">
@@ -967,11 +970,39 @@ function ThemePreview({
 
 /* ───────────────────── Broadcast composer ─────────────────────── */
 
-function BroadcastCard({ world }: { world: World }) {
+function BroadcastCard({
+  world,
+  worldDevices,
+}: {
+  world: World;
+  /** Devices currently assigned to this world (upstream `Device`
+   *  pool ∩ `selected`). The composer's target picker only offers
+   *  these — you can't link a notification to a device that isn't
+   *  in the world. */
+  worldDevices: Device[];
+}) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [sending, setSending] = useState(false);
+  const [targetIds, setTargetIds] = useState<Set<string>>(() => new Set());
+  const [targetQuery, setTargetQuery] = useState("");
+  const [targetOpen, setTargetOpen] = useState(false);
   const router = useRouter();
+
+  const filteredDevices = useMemo(() => {
+    const q = targetQuery.trim().toLowerCase();
+    if (!q) return worldDevices;
+    return worldDevices.filter((d) =>
+      `${d.name} ${d.subsystem} ${d.primaryRoad ?? ""} ${d.crossRoad ?? ""}`
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [worldDevices, targetQuery]);
+
+  const selectedDevices = useMemo(
+    () => worldDevices.filter((d) => targetIds.has(d.id)),
+    [worldDevices, targetIds],
+  );
 
   const canSend =
     world.isPublished &&
@@ -979,6 +1010,13 @@ function BroadcastCard({ world }: { world: World }) {
     title.trim().length > 0 &&
     body.trim().length > 0 &&
     !sending;
+
+  const previewUrl =
+    selectedDevices.length > 0
+      ? `/w/${world.slug}?devices=${selectedDevices
+          .map((d) => encodeURIComponent(d.id))
+          .join(",")}`
+      : `/w/${world.slug}`;
 
   async function send(e: React.FormEvent) {
     e.preventDefault();
@@ -988,10 +1026,20 @@ function BroadcastCard({ world }: { world: World }) {
       const res = await fetch(`/api/worlds/${world.id}/broadcast`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ title: title.trim(), body: body.trim() }),
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          deviceIds: Array.from(targetIds),
+        }),
       });
       const data = (await res.json().catch(() => null)) as
-        | { ok?: boolean; attempted?: number; delivered?: number; pruned?: number; error?: string }
+        | {
+            ok?: boolean;
+            attempted?: number;
+            delivered?: number;
+            pruned?: number;
+            error?: string;
+          }
         | null;
       if (!res.ok) {
         throw new Error(data?.error ?? "Broadcast failed");
@@ -1001,6 +1049,9 @@ function BroadcastCard({ world }: { world: World }) {
       );
       setTitle("");
       setBody("");
+      setTargetIds(new Set());
+      setTargetQuery("");
+      setTargetOpen(false);
       router.refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Broadcast failed");
@@ -1016,6 +1067,8 @@ function BroadcastCard({ world }: { world: World }) {
     reason = "No subscribers yet — visit the world and enable alerts to test.";
   }
 
+  const canPickDevices = worldDevices.length > 0;
+
   return (
     <section className="mb-6 rounded-2xl border border-line-soft bg-surface-1/40 p-5">
       <div className="flex items-center justify-between gap-3">
@@ -1029,8 +1082,9 @@ function BroadcastCard({ world }: { world: World }) {
         </span>
       </div>
       <p className="mt-1 text-xs text-text-secondary">
-        Push a one-shot alert to every subscriber of this world. Use sparingly —
-        repeat broadcasts collapse on the device.
+        Push a one-shot alert to every subscriber of this world. Link one or
+        more devices to have the notification open the map with those pins
+        highlighted.
       </p>
 
       <form onSubmit={send} className="mt-4 space-y-3">
@@ -1056,6 +1110,120 @@ function BroadcastCard({ world }: { world: World }) {
             className="mt-1 block w-full rounded-md border border-line-soft bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent focus:outline-none"
           />
         </label>
+
+        {/* Device link — pick which of the world's devices this alert
+            relates to. Tapping the notification opens the visitor map
+            with those pins highlighted and the camera fit-to-bounds. */}
+        <div>
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-medium text-text-secondary">
+              Link to devices{" "}
+              <span className="text-[10px] font-normal text-text-tertiary">
+                (optional)
+              </span>
+            </p>
+            {canPickDevices ? (
+              <button
+                type="button"
+                onClick={() => setTargetOpen((o) => !o)}
+                className="text-[11px] font-medium text-accent hover:underline"
+              >
+                {targetOpen ? "Hide" : selectedDevices.length > 0 ? "Change" : "Choose"}
+              </button>
+            ) : null}
+          </div>
+
+          {selectedDevices.length > 0 ? (
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
+              {selectedDevices.map((d) => (
+                <span
+                  key={d.id}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-line-soft bg-bg px-2 py-0.5 text-[11px] text-text-primary"
+                >
+                  <SubsystemIcon subsystem={d.subsystem} />
+                  <span className="max-w-[140px] truncate">{d.name}</span>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${d.name}`}
+                    onClick={() =>
+                      setTargetIds((prev) => {
+                        const next = new Set(prev);
+                        next.delete(d.id);
+                        return next;
+                      })
+                    }
+                    className="text-text-tertiary hover:text-text-primary"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-1 text-[11px] text-text-tertiary">
+              {canPickDevices
+                ? "None picked — the notification opens the map without a highlight."
+                : "This world has no devices assigned yet. Save some below to link alerts to them."}
+            </p>
+          )}
+
+          {targetOpen && canPickDevices ? (
+            <div className="mt-2 rounded-lg border border-line-soft bg-bg">
+              <div className="flex items-center gap-2 border-b border-line-soft px-3 py-1.5">
+                <Search size={12} className="text-text-tertiary" />
+                <input
+                  value={targetQuery}
+                  onChange={(e) => setTargetQuery(e.target.value)}
+                  placeholder="Search name, road, subsystem…"
+                  className="w-full bg-transparent py-1 text-xs outline-none placeholder:text-text-tertiary"
+                />
+              </div>
+              <ul className="max-h-56 overflow-y-auto">
+                {filteredDevices.length === 0 ? (
+                  <li className="px-3 py-3 text-center text-[11px] text-text-tertiary">
+                    No matches.
+                  </li>
+                ) : (
+                  filteredDevices.map((d) => {
+                    const checked = targetIds.has(d.id);
+                    return (
+                      <li key={d.id}>
+                        <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-xs hover:bg-surface-2">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() =>
+                              setTargetIds((prev) => {
+                                const next = new Set(prev);
+                                if (checked) next.delete(d.id);
+                                else next.add(d.id);
+                                return next;
+                              })
+                            }
+                            className="h-3 w-3 accent-[color:var(--accent,#0ea5e9)]"
+                          />
+                          <SubsystemIcon subsystem={d.subsystem} />
+                          <span className="flex-1 truncate">{d.name}</span>
+                          <span className="truncate text-[10px] text-text-tertiary">
+                            {d.primaryRoad ?? d.subsystem}
+                          </span>
+                        </label>
+                      </li>
+                    );
+                  })
+                )}
+              </ul>
+            </div>
+          ) : null}
+
+          {selectedDevices.length > 0 ? (
+            <p className="mt-1.5 truncate text-[10px] text-text-tertiary">
+              Opens →{" "}
+              <code className="font-mono">{previewUrl}</code>
+            </p>
+          ) : null}
+        </div>
+
         <div className="flex items-center justify-between">
           {reason ? (
             <p className="text-[11px] text-text-tertiary">{reason}</p>

--- a/apps/mobility/app/(public)/w/[slug]/MobilityBottomNav.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/MobilityBottomNav.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Map as MapIcon, List, Sparkles } from "lucide-react";
+import { Bell, List, Map as MapIcon, Sparkles } from "lucide-react";
 import {
   MobileBottomNav,
   type MobileBottomNavItem,
@@ -13,18 +13,20 @@ interface Props {
   slug: string;
 }
 
-type TabKey = "map" | "devices" | "paris";
+type TabKey = "map" | "devices" | "paris" | "notifications";
 
 const ITEMS: MobileBottomNavItem[] = [
   { key: "map", label: "Map", icon: MapIcon },
   { key: "devices", label: "Devices", icon: List },
   { key: "paris", label: "Paris", icon: Sparkles },
+  { key: "notifications", label: "Alerts", icon: Bell },
 ];
 
 function resolveActiveTab(pathname: string, slug: string): TabKey {
   const base = `/w/${slug}`;
   if (pathname.startsWith(`${base}/devices`)) return "devices";
   if (pathname.startsWith(`${base}/paris`)) return "paris";
+  if (pathname.startsWith(`${base}/notifications`)) return "notifications";
   return "map";
 }
 
@@ -59,6 +61,8 @@ export function MobilityBottomNav({ slug }: Props) {
         return `/w/${slug}/devices`;
       case "paris":
         return `/w/${slug}/paris`;
+      case "notifications":
+        return `/w/${slug}/notifications`;
     }
   };
 

--- a/apps/mobility/app/(public)/w/[slug]/MobilityTopNav.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/MobilityTopNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { List, Map as MapIcon, Sparkles } from "lucide-react";
+import { Bell, List, Map as MapIcon, Sparkles } from "lucide-react";
 import { KloradMark } from "@klorad/design-system";
 import { MobilitySettingsMenu } from "./MobilitySettingsMenu";
 
@@ -15,20 +15,20 @@ interface Props {
   logoUrl: string | null;
 }
 
+type TabKey = "map" | "devices" | "paris" | "notifications";
+
 interface NavLink {
-  key: "map" | "devices" | "paris";
+  key: TabKey;
   label: string;
   href: string;
   icon: React.ComponentType<{ size?: number; strokeWidth?: number; className?: string }>;
 }
 
-function resolveActiveTab(
-  pathname: string,
-  slug: string,
-): "map" | "devices" | "paris" {
+function resolveActiveTab(pathname: string, slug: string): TabKey {
   const base = `/w/${slug}`;
   if (pathname.startsWith(`${base}/devices`)) return "devices";
   if (pathname.startsWith(`${base}/paris`)) return "paris";
+  if (pathname.startsWith(`${base}/notifications`)) return "notifications";
   return "map";
 }
 
@@ -65,6 +65,12 @@ export function MobilityTopNav({ slug, worldName, logoUrl }: Props) {
       label: "Paris",
       href: `/w/${slug}/paris`,
       icon: Sparkles,
+    },
+    {
+      key: "notifications",
+      label: "Alerts",
+      href: `/w/${slug}/notifications`,
+      icon: Bell,
     },
   ];
 

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -182,10 +182,26 @@ function buildIconExpression(
   ] as unknown as mapboxgl.ExpressionSpecification;
 }
 
+/** Filter that highlights every id in `ids`. Mapbox `in` with a
+ *  `literal` array is the cheap way — no re-adding the layer when
+ *  the set changes, just `setFilter`. Empty set → matches nothing. */
+function buildSelectionFilter(
+  ids: string[],
+): mapboxgl.FilterSpecification {
+  if (ids.length === 0) {
+    return ["==", ["get", "id"], NO_SELECTION];
+  }
+  return [
+    "in",
+    ["get", "id"],
+    ["literal", ids],
+  ] as unknown as mapboxgl.FilterSpecification;
+}
+
 function setupDeviceLayers(
   map: MapboxMap,
   primary: string,
-  selectedId: string | null,
+  highlightIds: string[],
   data: GeoJSON.FeatureCollection<GeoJSON.Point>,
   iconExpression: mapboxgl.ExpressionSpecification,
   onClusterClick: (clusterId: number, coords: [number, number]) => void,
@@ -228,12 +244,14 @@ function setupDeviceLayers(
     paint: { "text-color": "#ffffff" },
   });
   // Selection halo — drawn beneath the symbol so the icon sits on
-  // top crisply when a visitor picks a device.
+  // top crisply. Covers both the single tap-selected pin and any
+  // externally-highlighted devices from `?devices=<id,id,...>` (used
+  // by notification deep-links).
   map.addLayer({
     id: SELECTED_LAYER,
     type: "circle",
     source: SOURCE_ID,
-    filter: ["==", ["get", "id"], selectedId ?? NO_SELECTION],
+    filter: buildSelectionFilter(highlightIds),
     paint: {
       "circle-color": primary,
       "circle-opacity": 0.28,
@@ -332,23 +350,39 @@ export function WorldViewer({
    *  same map state on load. */
   const initialUrlStateRef = useRef<{
     device: string | null;
+    devices: string[];
     lng: number | null;
     lat: number | null;
     zoom: number | null;
   } | null>(null);
   if (initialUrlStateRef.current === null) {
     const dev = searchParams?.get("device") ?? null;
+    const devicesParam = searchParams?.get("devices") ?? "";
+    const devices = devicesParam
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
     const lng = parseFloat(searchParams?.get("lng") ?? "");
     const lat = parseFloat(searchParams?.get("lat") ?? "");
     const zoom = parseFloat(searchParams?.get("z") ?? "");
     initialUrlStateRef.current = {
       device: dev,
+      devices,
       lng: Number.isFinite(lng) ? lng : null,
       lat: Number.isFinite(lat) ? lat : null,
       zoom: Number.isFinite(zoom) ? zoom : null,
     };
   }
   const initialUrlState = initialUrlStateRef.current;
+
+  /** Highlight set from `?devices=` — used by notification deep-links.
+   *  Stays constant once mounted; visitor taps only mutate
+   *  `selectedId`. Combined with `selectedId` when computing the halo
+   *  filter so a visitor tapping a different pin doesn't wipe the
+   *  externally-supplied highlight. */
+  const [highlightIds] = useState<Set<string>>(
+    () => new Set(initialUrlState.devices),
+  );
 
   const mapEl = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapboxMap | null>(null);
@@ -442,10 +476,17 @@ export function WorldViewer({
 
   const attachLayers = useCallback(
     (map: MapboxMap) => {
+      const currentFilterIds = Array.from(
+        new Set(
+          [latestSelectedRef.current, ...highlightIds].filter(
+            (id): id is string => Boolean(id),
+          ),
+        ),
+      );
       setupDeviceLayers(
         map,
         primary,
-        latestSelectedRef.current,
+        currentFilterIds,
         latestDataRef.current,
         latestIconExpressionRef.current,
         (clusterId, coords) => {
@@ -463,7 +504,7 @@ export function WorldViewer({
       );
       layersReadyRef.current = true;
     },
-    [primary],
+    [primary, highlightIds],
   );
 
   // Init map once. Camera + selection may be seeded from the URL so
@@ -494,11 +535,24 @@ export function WorldViewer({
       void loadDeviceIconsIntoMap(map, customIconsRef.current).then(() => {
         attachLayers(map);
         if (urlCam) {
-          // Camera already seeded — nothing else to do.
+          // Camera already seeded from URL — no auto-frame.
           return;
         }
-        // No shared-link camera. Prefer a seeded device selection over
-        // the fit-to-all fallback so `?device=<id>` lands close-up.
+        // Deep-link priority:
+        //   1. ?devices=X,Y,Z — fit bounds around the highlighted set
+        //      (notification tap-through lands here).
+        //   2. ?device=<id>   — close-up on that one pin.
+        //   3. Fall back to fit-all.
+        if (highlightIds.size > 0) {
+          const highlightDevices = devices.filter(
+            (d) =>
+              highlightIds.has(d.id) && d.lat != null && d.lng != null,
+          );
+          if (highlightDevices.length > 0) {
+            fitToDevices(map, highlightDevices);
+            return;
+          }
+        }
         const seed = initialUrlState.device
           ? devices.find(
               (d) =>
@@ -671,12 +725,15 @@ export function WorldViewer({
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !layersReadyRef.current) return;
-    map.setFilter(SELECTED_LAYER, [
-      "==",
-      ["get", "id"],
-      selectedId ?? NO_SELECTION,
-    ]);
-  }, [selectedId]);
+    const ids = Array.from(
+      new Set(
+        [selectedId, ...highlightIds].filter(
+          (id): id is string => Boolean(id),
+        ),
+      ),
+    );
+    map.setFilter(SELECTED_LAYER, buildSelectionFilter(ids));
+  }, [selectedId, highlightIds]);
 
   if (!mapboxToken) {
     return (
@@ -696,6 +753,10 @@ export function WorldViewer({
 
   return (
     <main
+      // `data-mapbox` opts this surface out of `MobilityPullToRefresh`
+      // so a downward pan on the map doesn't trigger `router.refresh`.
+      // Selector match happens in the DS `PullToRefresh` primitive.
+      data-mapbox
       className="relative w-full overflow-hidden"
       // Height reserves 3.5rem for the sticky top nav so the map fits
       // exactly between the top nav and the viewport bottom — without

--- a/apps/mobility/app/(public)/w/[slug]/notifications/NotificationsList.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/notifications/NotificationsList.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Link from "next/link";
+import { Bell, MapPin } from "lucide-react";
+import { subsystemDescriptor } from "@/lib/mobility/subsystem-icon";
+
+interface NotificationItem {
+  id: string;
+  title: string;
+  body: string;
+  targetPath: string | null;
+  deviceIds: string[];
+  createdAtIso: string;
+}
+
+interface Props {
+  slug: string;
+  worldName: string;
+  items: NotificationItem[];
+  /** id → { name, subsystem } lookup for rendering device chips. Any
+   *  id missing from the map was probably deleted after the alert
+   *  fired — surface a neutral chip so the row still makes sense. */
+  deviceMap: Record<string, { name: string; subsystem: string }>;
+}
+
+/**
+ * Visitor notifications feed. One row per broadcast the operator
+ * sent to this world, most recent first. Rows carry:
+ *   - date (relative + absolute tooltip)
+ *   - title + body
+ *   - device chips (from `deviceIds`) — visual context for what
+ *     the alert was about
+ *   - "View on map" link → `targetPath` (points at `/w/<slug>?devices=…`
+ *     for device-scoped alerts, plain `/w/<slug>` otherwise)
+ */
+export function NotificationsList({
+  slug,
+  worldName,
+  items,
+  deviceMap,
+}: Props) {
+  return (
+    <main className="mx-auto flex max-w-[760px] flex-col gap-4 px-4 pb-32 pt-6 md:px-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-[var(--w-fg,#1a1a1a)]">
+          Notifications
+        </h1>
+        <p className="mt-1 text-sm text-[var(--w-fg-muted,#6b6b6b)]">
+          Every alert sent to {worldName}. Tap a row to open the map at the
+          affected devices.
+        </p>
+      </header>
+
+      {items.length === 0 ? (
+        <div className="mt-8 rounded-2xl border border-dashed border-[var(--w-border,#e6e6ea)] bg-white/60 p-8 text-center">
+          <Bell
+            size={20}
+            strokeWidth={1.5}
+            className="mx-auto text-[var(--w-fg-muted,#6b6b6b)]"
+          />
+          <p className="mt-3 text-sm font-medium text-[var(--w-fg,#1a1a1a)]">
+            No notifications yet
+          </p>
+          <p className="mt-1 text-[11px] text-[var(--w-fg-muted,#6b6b6b)]">
+            Operator alerts and lane-closure announcements will appear here.
+          </p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-[var(--w-border,#e6e6ea)] rounded-2xl border border-[var(--w-border,#e6e6ea)] bg-white">
+          {items.map((n) => {
+            const href = n.targetPath ?? `/w/${slug}`;
+            const knownDevices = n.deviceIds
+              .map((id) => ({ id, meta: deviceMap[id] }))
+              .filter((d) => d.meta);
+            return (
+              <li key={n.id}>
+                <Link
+                  href={href}
+                  className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-[var(--w-page,#f5f5f7)]"
+                >
+                  <span
+                    aria-hidden
+                    className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--w-accent-soft,rgba(14,165,233,0.12))] text-[var(--w-accent,#0ea5e9)]"
+                  >
+                    <Bell size={14} strokeWidth={2} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-2">
+                      <p className="truncate text-sm font-semibold text-[var(--w-fg,#1a1a1a)]">
+                        {n.title}
+                      </p>
+                      <time
+                        dateTime={n.createdAtIso}
+                        title={new Date(n.createdAtIso).toLocaleString()}
+                        className="ml-auto shrink-0 text-[10px] uppercase tracking-[0.18em] text-[var(--w-fg-muted,#6b6b6b)]"
+                      >
+                        {relativeFrom(n.createdAtIso)}
+                      </time>
+                    </div>
+                    <p className="mt-1 text-[13px] text-[var(--w-fg-soft,#3d3d3d)]">
+                      {n.body}
+                    </p>
+
+                    {knownDevices.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {knownDevices.slice(0, 6).map(({ id, meta }) => {
+                          const desc = subsystemDescriptor(meta!.subsystem);
+                          const Icon = desc.icon;
+                          return (
+                            <span
+                              key={id}
+                              className="inline-flex max-w-[180px] items-center gap-1 truncate rounded-full border border-[var(--w-border,#e6e6ea)] bg-white px-2 py-0.5 text-[10px] text-[var(--w-fg-muted,#6b6b6b)]"
+                            >
+                              <Icon size={9} strokeWidth={2} />
+                              <span className="truncate">{meta!.name}</span>
+                            </span>
+                          );
+                        })}
+                        {knownDevices.length > 6 ? (
+                          <span className="inline-flex items-center rounded-full bg-[var(--w-page,#f5f5f7)] px-2 py-0.5 text-[10px] text-[var(--w-fg-muted,#6b6b6b)]">
+                            +{knownDevices.length - 6} more
+                          </span>
+                        ) : null}
+                      </div>
+                    ) : null}
+
+                    {n.deviceIds.length > 0 ? (
+                      <p className="mt-2 inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.18em] text-[var(--w-accent,#0ea5e9)]">
+                        <MapPin size={9} strokeWidth={2} />
+                        View on map
+                      </p>
+                    ) : null}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </main>
+  );
+}
+
+function relativeFrom(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return "—";
+  const diff = Date.now() - ts;
+  if (diff < 0) return "just now";
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/apps/mobility/app/(public)/w/[slug]/notifications/loading.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/notifications/loading.tsx
@@ -1,0 +1,32 @@
+/**
+ * Suspense fallback for the Notifications tab — 6 placeholder rows
+ * mirroring the real feed so bottom-nav taps paint instantly.
+ */
+export default function NotificationsLoading() {
+  return (
+    <main
+      aria-hidden
+      className="mx-auto flex max-w-[760px] flex-col gap-4 px-4 pb-32 pt-6 md:px-6"
+    >
+      <header>
+        <div className="h-7 w-40 animate-pulse rounded-md bg-[var(--w-page,#eef1f6)]" />
+        <div className="mt-2 h-4 w-64 animate-pulse rounded-md bg-[var(--w-page,#eef1f6)]" />
+      </header>
+      <ul className="divide-y divide-[var(--w-border,#e6e6ea)] rounded-2xl border border-[var(--w-border,#e6e6ea)] bg-white">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <li key={i} className="flex items-start gap-3 px-4 py-3">
+            <div className="mt-0.5 h-8 w-8 shrink-0 animate-pulse rounded-full bg-[var(--w-page,#eef1f6)]" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-3/5 animate-pulse rounded-md bg-[var(--w-page,#eef1f6)]" />
+              <div className="h-3 w-full animate-pulse rounded-md bg-[var(--w-page,#eef1f6)]" />
+              <div className="flex gap-1">
+                <div className="h-4 w-20 animate-pulse rounded-full bg-[var(--w-page,#eef1f6)]" />
+                <div className="h-4 w-24 animate-pulse rounded-full bg-[var(--w-page,#eef1f6)]" />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/mobility/app/(public)/w/[slug]/notifications/page.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/notifications/page.tsx
@@ -1,0 +1,97 @@
+import { notFound, redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/auth";
+import { resolveWorldForViewer } from "@/lib/mobility/world-resolver";
+import { WorldAccessDenied } from "../WorldAccessDenied";
+import { NotificationsList } from "./NotificationsList";
+
+type Params = Promise<{ slug: string }>;
+
+/**
+ * `/w/[slug]/notifications` — visitor-facing feed of every broadcast
+ * ever sent to this world. Renders server-side (no client fetch) so
+ * the first paint has real data.
+ *
+ * Access follows the same rules as the map (`resolveWorldForViewer`):
+ *   public + linkOnly → anyone
+ *   authenticated     → sign-in gate + org/principal check
+ *
+ * Each row includes the deviceIds the alert was scoped to so the
+ * client can render a "View on map" deep-link back to
+ * `/w/<slug>?devices=id1,id2` — the notification's original tap
+ * target.
+ */
+export default async function NotificationsPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { slug } = await params;
+  const session = await auth();
+  const viewerId = (session?.user?.id as string | undefined) ?? null;
+  const result = await resolveWorldForViewer(slug, viewerId);
+
+  if (result.kind === "not_found") notFound();
+  if (result.kind === "needs_signin") {
+    const callback = encodeURIComponent(`/w/${slug}/notifications`);
+    redirect(`/auth/signin?callbackUrl=${callback}`);
+  }
+  if (result.kind === "no_access") {
+    return <WorldAccessDenied slug={slug} />;
+  }
+
+  const world = result.world;
+
+  // The resolver returns the shape needed for the map viewer but not
+  // the raw MobilityWorld id — grab it here for the Broadcast filter.
+  const worldRow = await prisma.mobilityWorld.findFirst({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!worldRow) notFound();
+
+  const rows = await prisma.broadcast.findMany({
+    where: { worldId: worldRow.id },
+    orderBy: { createdAt: "desc" },
+    take: 100,
+    select: {
+      id: true,
+      title: true,
+      body: true,
+      targetPath: true,
+      deviceIds: true,
+      createdAt: true,
+    },
+  });
+
+  // Preload the world's devices so the client can render chips with
+  // real names instead of raw IDs. Keeps the notifications page
+  // self-contained (no follow-up fetch on tap).
+  const deviceIdSet = new Set<string>();
+  for (const r of rows) for (const id of r.deviceIds) deviceIdSet.add(id);
+  const devices = deviceIdSet.size
+    ? await prisma.mobilityDevice.findMany({
+        where: { id: { in: Array.from(deviceIdSet) } },
+        select: { id: true, name: true, subsystem: true },
+      })
+    : [];
+  const deviceMap = Object.fromEntries(
+    devices.map((d) => [d.id, { name: d.name, subsystem: d.subsystem }]),
+  );
+
+  return (
+    <NotificationsList
+      slug={world.slug}
+      worldName={world.name}
+      items={rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        body: r.body,
+        targetPath: r.targetPath,
+        deviceIds: r.deviceIds,
+        createdAtIso: r.createdAt.toISOString(),
+      }))}
+      deviceMap={deviceMap}
+    />
+  );
+}

--- a/apps/mobility/app/(public)/w/[slug]/paris/ParisPanel.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/paris/ParisPanel.tsx
@@ -28,8 +28,18 @@ interface Props {
  */
 export function ParisPanel({ slug, worldId, worldName }: Props) {
   return (
-    <div className="pb-32">
+    // Bounded viewport height — top nav is 3.5rem, mobile bottom nav
+    // is ~3.5rem + safe-area. The DS panel takes this container's
+    // full height and scrolls its own thread; the input pins to the
+    // bottom of this box, not to the document. That's the fix that
+    // stops the whole page from scrolling on long conversations.
+    <div
+      className="w-full"
+      style={{ height: "calc(100dvh - 3.5rem)" }}
+    >
       <AssistantPanel<ParisToolAction>
+        layout="fill"
+        inputBottomPadding="pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-3"
         endpoint="/api/paris"
         extraBody={{ worldId }}
         heroTitle="Hi, I'm Paris."

--- a/apps/mobility/app/api/worlds/[worldId]/broadcast/route.ts
+++ b/apps/mobility/app/api/worlds/[worldId]/broadcast/route.ts
@@ -1,12 +1,17 @@
 /**
  * `POST /api/worlds/[worldId]/broadcast`
- *   Body: { title, body, url?, tag? }
+ *   Body: { title, body, deviceIds?, url?, tag? }
  *
  * Operator-only — fan-outs an ad-hoc push to every subscriber of the
- * world. v1 use cases: maintenance announcements, weather advisories,
- * verifying the push pipeline end-to-end. PR5 layers analytics + open
- * counters; the durable alert engine (auto-fanout from `MobilityAlert`)
- * is its own follow-up arc.
+ * world and persists a `Broadcast` row so the visitor's notifications
+ * history page has something to render.
+ *
+ * `deviceIds`, when set, are validated against the world's device
+ * list and baked into the push URL as `?devices=id1,id2` — the map
+ * uses that param to highlight those pins + fit-to-bounds. The
+ * visitor tapping the notification lands on the map with the
+ * relevant devices already selected. Empty / omitted `deviceIds`
+ * degrades to a plain `/w/<slug>` link.
  *
  * Requires `write` access on the project — this is a stakeholder-
  * visible action, so it's gated to operators, not the wider org.
@@ -14,6 +19,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { auth } from "@/auth";
 import { requireProjectAccess } from "@/lib/authz";
 import { pushEnabled, sendPushToWorld } from "@/lib/mobility/world-push";
 import { recordWorldEvent } from "@/lib/mobility/world-events";
@@ -23,6 +29,7 @@ type Params = Promise<{ worldId: string }>;
 const Body = z.object({
   title: z.string().min(1).max(80),
   body: z.string().min(1).max(280),
+  deviceIds: z.array(z.string().min(1)).max(50).optional(),
   url: z.string().min(1).max(500).optional(),
   tag: z.string().max(40).optional(),
 });
@@ -72,11 +79,57 @@ export async function POST(
     );
   }
 
+  // Validate device IDs against the world's device set so an operator
+  // can't inject an id from a neighbouring world (or a stale id from
+  // a deleted device — the visitor map would then hunt for a pin that
+  // isn't in the geojson). Order is preserved from the client payload.
+  let deviceIds: string[] = [];
+  if (parsed.data.deviceIds && parsed.data.deviceIds.length > 0) {
+    const requested = Array.from(new Set(parsed.data.deviceIds));
+    const rows = await prisma.mobilityWorldDevice.findMany({
+      where: { worldId, deviceId: { in: requested } },
+      select: { deviceId: true },
+    });
+    const allowed = new Set(rows.map((r) => r.deviceId));
+    deviceIds = requested.filter((id) => allowed.has(id));
+  }
+
+  // Deep-link the notification back to the map — the SW's
+  // `notificationclick` handler navigates to this URL on tap, and
+  // `WorldViewer` reads `?devices=` to highlight + fit-to-bounds.
+  const targetPath =
+    parsed.data.url
+      ?? (deviceIds.length > 0
+        ? `/w/${world.slug}?devices=${deviceIds.map(encodeURIComponent).join(",")}`
+        : `/w/${world.slug}`);
+
+  const session = await auth();
+  const senderId = (session?.user?.id as string | undefined) ?? null;
+
   const result = await sendPushToWorld(worldId, {
     title: parsed.data.title,
     body: parsed.data.body,
-    url: parsed.data.url ?? `/w/${world.slug}`,
+    url: targetPath,
     tag: parsed.data.tag,
+  });
+
+  // Persist a history row so the visitor `/w/<slug>/notifications`
+  // feed and the operator's own audit page have something to render.
+  // Counters are stamped from the push result; the tap-through count
+  // (`opened`) is bumped separately by the SW's click handler.
+  await prisma.broadcast.create({
+    data: {
+      projectId: world.projectId,
+      worldId,
+      title: parsed.data.title,
+      body: parsed.data.body,
+      targetPath,
+      deviceIds,
+      senderId,
+      attempted: result.attempted,
+      delivered: result.delivered,
+      pruned: result.pruned,
+    },
   });
 
   await recordWorldEvent({
@@ -87,8 +140,9 @@ export async function POST(
       attempted: result.attempted,
       delivered: result.delivered,
       pruned: result.pruned,
+      deviceCount: deviceIds.length,
     },
   });
 
-  return NextResponse.json({ ok: true, ...result });
+  return NextResponse.json({ ok: true, ...result, deviceIds });
 }

--- a/packages/design-system/src/components/assistant-panel.tsx
+++ b/packages/design-system/src/components/assistant-panel.tsx
@@ -58,6 +58,30 @@ export interface AssistantPanelProps<TAction = unknown> {
    *  KlioSourceCards; Mobility: ParisSourceCards). Return `null` to
    *  hide the row for a turn with no actions. */
   renderActions?: (actions: TAction[]) => ReactNode;
+  /**
+   * Layout mode.
+   *
+   *   flow (default) — the panel is a normal flex column in the
+   *     document. Input uses `sticky` positioning; the document
+   *     scrolls. Right for a page that's mostly hero + a few
+   *     messages, or when the panel is embedded alongside other
+   *     content.
+   *   fill — the panel fills its parent's height. The thread grows
+   *     to fill available space and scrolls internally; the input
+   *     is pinned at the bottom of the panel (never leaves the
+   *     viewport). Right for a dedicated "chat" tab like Mobility's
+   *     Paris route. The parent must supply a bounded height (e.g.
+   *     `h-[calc(100dvh-3.5rem)]`).
+   */
+  layout?: "flow" | "fill";
+  /**
+   * Extra bottom padding on the input container. Only used in `fill`
+   * layout to reserve room for a mobile bottom nav — passed as a
+   * Tailwind arbitrary padding class (e.g. `pb-[3.5rem]`) or plain
+   * class string. Ignored in flow layout, which uses `sticky`
+   * positioning with a hard-coded safe-area offset.
+   */
+  inputBottomPadding?: string;
 }
 
 /**
@@ -89,6 +113,8 @@ export function AssistantPanel<TAction = unknown>({
   poweredByLabel = "Powered by Claude · Klorad",
   unavailableCopy = "Sorry — the assistant is unavailable right now.",
   renderActions,
+  layout = "flow",
+  inputBottomPadding,
 }: AssistantPanelProps<TAction>) {
   const [messages, setMessages] = useState<AssistantMessage<TAction>[]>([]);
   const [input, setInput] = useState("");
@@ -144,124 +170,166 @@ export function AssistantPanel<TAction = unknown>({
     }
   };
 
-  return (
-    <section className="mx-auto flex max-w-[760px] flex-col gap-6 px-4 pt-6 md:px-6">
-      {messages.length === 0 ? (
-        <div>
-          <span
-            aria-hidden
-            className="inline-flex h-12 w-12 items-center justify-center rounded-2xl text-white"
-            style={{ background: "var(--brand-primary-fill, #4a3fac)" }}
-          >
-            <Sparkles size={22} strokeWidth={1.75} />
-          </span>
-          <h1 className="mt-5 text-3xl font-semibold tracking-tight text-[var(--brand-text,#1a1a1a)] md:text-4xl">
-            {heroTitle}
-          </h1>
-          <p className="mt-2 max-w-lg text-sm leading-relaxed text-[var(--brand-text-muted,#6b6b6b)]">
-            {heroSubtitle}
-          </p>
+  const isFill = layout === "fill";
 
-          {suggestions.length > 0 && (
-            <ul className="mt-6 space-y-2.5">
-              {suggestions.map((s) => (
-                <li key={s.label}>
-                  <button
-                    type="button"
-                    onClick={() => void send(s.prompt)}
-                    disabled={sending}
-                    className="group flex w-full items-center gap-3 rounded-full border border-[var(--brand-line,#e6e6ea)] bg-white px-4 py-3 text-left text-sm font-medium text-[var(--brand-text,#1a1a1a)] transition-colors hover:border-[var(--brand-primary,#534ab7)] disabled:opacity-60"
-                  >
-                    <span
-                      aria-hidden
-                      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--brand-primary,#534ab7)] transition-colors group-hover:text-white"
-                      style={{
-                        background: "var(--brand-page, #f5f5f7)",
-                      }}
-                    >
-                      <ArrowRight size={14} strokeWidth={2} />
-                    </span>
-                    <span className="flex-1">{s.label}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      ) : null}
+  const hero = (
+    <div>
+      <span
+        aria-hidden
+        className="inline-flex h-12 w-12 items-center justify-center rounded-2xl text-white"
+        style={{ background: "var(--brand-primary-fill, #4a3fac)" }}
+      >
+        <Sparkles size={22} strokeWidth={1.75} />
+      </span>
+      <h1 className="mt-5 text-3xl font-semibold tracking-tight text-[var(--brand-text,#1a1a1a)] md:text-4xl">
+        {heroTitle}
+      </h1>
+      <p className="mt-2 max-w-lg text-sm leading-relaxed text-[var(--brand-text-muted,#6b6b6b)]">
+        {heroSubtitle}
+      </p>
 
-      {messages.length > 0 ? (
-        <div
-          ref={threadRef}
-          className="flex flex-col gap-3 overflow-y-auto rounded-2xl bg-white p-4 text-sm shadow-sm"
-          style={{ maxHeight: "min(60vh, 420px)" }}
-        >
-          {messages.map((m, i) => (
-            <div
-              key={i}
-              className={m.role === "user" ? "self-end" : "self-start"}
-            >
-              {m.role === "user" ? (
+      {suggestions.length > 0 && (
+        <ul className="mt-6 space-y-2.5">
+          {suggestions.map((s) => (
+            <li key={s.label}>
+              <button
+                type="button"
+                onClick={() => void send(s.prompt)}
+                disabled={sending}
+                className="group flex w-full items-center gap-3 rounded-full border border-[var(--brand-line,#e6e6ea)] bg-white px-4 py-3 text-left text-sm font-medium text-[var(--brand-text,#1a1a1a)] transition-colors hover:border-[var(--brand-primary,#534ab7)] disabled:opacity-60"
+              >
                 <span
-                  className="inline-block max-w-[85%] rounded-2xl px-3.5 py-2 text-sm text-white"
+                  aria-hidden
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--brand-primary,#534ab7)] transition-colors group-hover:text-white"
                   style={{
-                    backgroundColor: "var(--brand-primary-fill, #4a3fac)",
+                    background: "var(--brand-page, #f5f5f7)",
                   }}
                 >
-                  {m.text}
+                  <ArrowRight size={14} strokeWidth={2} />
                 </span>
-              ) : (
-                <div className="max-w-[85%]">
-                  <div
-                    className="whitespace-pre-wrap rounded-2xl px-3.5 py-2 leading-relaxed text-[var(--brand-text,#1a1a1a)]"
-                    style={{ background: "var(--brand-page, #f5f5f7)" }}
-                  >
-                    {m.text}
-                  </div>
-                  {renderActions && m.actions && m.actions.length > 0
-                    ? renderActions(m.actions)
-                    : null}
-                </div>
-              )}
-            </div>
+                <span className="flex-1">{s.label}</span>
+              </button>
+            </li>
           ))}
-          {sending ? (
-            <div
-              className="self-start rounded-2xl px-3.5 py-2 text-xs text-[var(--brand-text-muted,#6b6b6b)]"
-              style={{ background: "var(--brand-page, #f5f5f7)" }}
+        </ul>
+      )}
+    </div>
+  );
+
+  const thread = (
+    <div
+      ref={threadRef}
+      // Fill mode owns its scroll via `flex-1 overflow-y-auto` on the
+      // wrapper — the thread itself is just a flex column with no cap.
+      // Flow mode keeps the historic behaviour: a bounded thread box
+      // that scrolls internally within the page's document scroll.
+      className={
+        isFill
+          ? "flex flex-col gap-3 rounded-2xl bg-white p-4 text-sm shadow-sm"
+          : "flex flex-col gap-3 overflow-y-auto rounded-2xl bg-white p-4 text-sm shadow-sm"
+      }
+      style={isFill ? undefined : { maxHeight: "min(60vh, 420px)" }}
+    >
+      {messages.map((m, i) => (
+        <div
+          key={i}
+          className={m.role === "user" ? "self-end" : "self-start"}
+        >
+          {m.role === "user" ? (
+            <span
+              className="inline-block max-w-[85%] rounded-2xl px-3.5 py-2 text-sm text-white"
+              style={{
+                backgroundColor: "var(--brand-primary-fill, #4a3fac)",
+              }}
             >
-              …
+              {m.text}
+            </span>
+          ) : (
+            <div className="max-w-[85%]">
+              <div
+                className="whitespace-pre-wrap rounded-2xl px-3.5 py-2 leading-relaxed text-[var(--brand-text,#1a1a1a)]"
+                style={{ background: "var(--brand-page, #f5f5f7)" }}
+              >
+                {m.text}
+              </div>
+              {renderActions && m.actions && m.actions.length > 0
+                ? renderActions(m.actions)
+                : null}
             </div>
-          ) : null}
+          )}
+        </div>
+      ))}
+      {sending ? (
+        <div
+          className="self-start rounded-2xl px-3.5 py-2 text-xs text-[var(--brand-text-muted,#6b6b6b)]"
+          style={{ background: "var(--brand-page, #f5f5f7)" }}
+        >
+          …
         </div>
       ) : null}
+    </div>
+  );
 
-      <div className="sticky bottom-[calc(env(safe-area-inset-bottom)+5.25rem)] mx-auto w-full max-w-[760px] md:bottom-6">
-        <div className="flex items-center gap-2 rounded-full border border-[var(--brand-line,#e6e6ea)] bg-white px-4 py-2 shadow-sm">
-          <input
-            ref={inputRef}
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={onKeyDown}
-            placeholder={placeholder}
-            disabled={sending}
-            className="min-w-0 flex-1 bg-transparent text-sm text-[var(--brand-text,#1a1a1a)] outline-none placeholder:text-[var(--brand-text-muted,#6b6b6b)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-primary,#534ab7)] disabled:opacity-60"
-          />
-          <button
-            type="button"
-            onClick={() => void send(input)}
-            disabled={sending || !input.trim()}
-            aria-label="Send"
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white transition-opacity hover:opacity-90 disabled:opacity-40"
-            style={{ backgroundColor: "var(--brand-primary-fill, #4a3fac)" }}
-          >
-            <ArrowUp size={16} strokeWidth={2} />
-          </button>
+  const inputBar = (
+    <div className="flex items-center gap-2 rounded-full border border-[var(--brand-line,#e6e6ea)] bg-white px-4 py-2 shadow-sm">
+      <input
+        ref={inputRef}
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        disabled={sending}
+        className="min-w-0 flex-1 bg-transparent text-sm text-[var(--brand-text,#1a1a1a)] outline-none placeholder:text-[var(--brand-text-muted,#6b6b6b)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-primary,#534ab7)] disabled:opacity-60"
+      />
+      <button
+        type="button"
+        onClick={() => void send(input)}
+        disabled={sending || !input.trim()}
+        aria-label="Send"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+        style={{ backgroundColor: "var(--brand-primary-fill, #4a3fac)" }}
+      >
+        <ArrowUp size={16} strokeWidth={2} />
+      </button>
+    </div>
+  );
+
+  const poweredBy = (
+    <p className="mt-2 text-center text-[10px] text-[var(--brand-text-muted,#6b6b6b)]">
+      {poweredByLabel}
+    </p>
+  );
+
+  if (isFill) {
+    // Fill mode — the panel is a full-height flex column. The parent
+    // MUST supply a bounded height (e.g. `h-[calc(100dvh-3.5rem)]`);
+    // without one, the panel collapses to its content height and the
+    // scroll semantics fall back to flow mode implicitly.
+    return (
+      <section className="mx-auto flex h-full max-w-[760px] flex-col px-4 md:px-6">
+        <div className="flex-1 min-h-0 overflow-y-auto py-6">
+          {messages.length === 0 ? hero : thread}
         </div>
-        <p className="mt-2 text-center text-[10px] text-[var(--brand-text-muted,#6b6b6b)]">
-          {poweredByLabel}
-        </p>
+        <div
+          className={`shrink-0 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] ${
+            inputBottomPadding ?? ""
+          }`}
+        >
+          {inputBar}
+          {poweredBy}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto flex max-w-[760px] flex-col gap-6 px-4 pt-6 md:px-6">
+      {messages.length === 0 ? hero : null}
+      {messages.length > 0 ? thread : null}
+      <div className="sticky bottom-[calc(env(safe-area-inset-bottom)+5.25rem)] mx-auto w-full max-w-[760px] md:bottom-6">
+        {inputBar}
+        {poweredBy}
       </div>
     </section>
   );

--- a/packages/prisma/migrations/20260718120000_mobility_broadcast_devices/migration.sql
+++ b/packages/prisma/migrations/20260718120000_mobility_broadcast_devices/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "Broadcast"
+    ADD COLUMN "worldId" TEXT,
+    ADD COLUMN "deviceIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "Broadcast_worldId_createdAt_idx" ON "Broadcast"("worldId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Broadcast"
+    ADD CONSTRAINT "Broadcast_worldId_fkey"
+    FOREIGN KEY ("worldId") REFERENCES "MobilityWorld"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -692,7 +692,12 @@ model ProjectMember {
   @@index([userId])
 }
 
-/// One row per push broadcast the rector sends from the Reach screen.
+/// One row per push broadcast.
+///   Campus:   sent from the Reach screen (rector → all subscribers).
+///   Mobility: sent from a MobilityWorld's operator dashboard
+///             (`worldId` set, `deviceIds` optional — the devices the
+///             alert relates to; the visitor sees them highlighted on
+///             the map when they tap the notification).
 /// Stores enough context to render the history feed (title/body/target
 /// + counts) without keeping the literal device endpoint list around.
 /// `senderId` is nullable so deleting a user doesn't orphan or lose
@@ -700,14 +705,22 @@ model ProjectMember {
 model Broadcast {
   id         String   @id @default(cuid())
   projectId  String
+  /// Optional link back to a MobilityWorld. Set for mobility
+  /// broadcasts; null for campus. Powers the visitor
+  /// `/w/<slug>/notifications` history feed.
+  worldId    String?
   /// Notification title shown on the device.
   title      String
   /// Notification body shown on the device.
   body       String
-  /// Path relative to the campus root, e.g. "/events". Stored without
-  /// the `/campus/<mapId>` prefix so deep-links don't break if the
-  /// consumer URL scheme changes.
+  /// Deep-link path — campus stores e.g. "/events"; mobility stores
+  /// e.g. "/w/<slug>?devices=id1,id2" so the SW `notificationclick`
+  /// handler can open the map with those pins highlighted.
   targetPath String?
+  /// Mobility-only: the world's device IDs the alert relates to. Used
+  /// by the visitor notifications page to render context chips and
+  /// derive the map deep-link. Empty for campus broadcasts.
+  deviceIds  String[] @default([])
   /// The user that triggered the broadcast.
   senderId   String?
   /// How many subscriptions we attempted to deliver to.
@@ -726,10 +739,12 @@ model Broadcast {
   clickToken String?
   createdAt  DateTime @default(now())
 
-  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  sender  User?   @relation("BroadcastsSent", fields: [senderId], references: [id], onDelete: SetNull)
+  project Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  sender  User?          @relation("BroadcastsSent", fields: [senderId], references: [id], onDelete: SetNull)
+  world   MobilityWorld? @relation(fields: [worldId], references: [id], onDelete: Cascade)
 
   @@index([projectId, createdAt])
+  @@index([worldId, createdAt])
 }
 
 /// the two keys the Push API hands the browser, scoped to a Project.
@@ -1098,6 +1113,9 @@ model MobilityWorld {
   /// Populated with a mix of `user` and `team` rows resolved at
   /// viewer time.
   principals        MobilityWorldPrincipal[]
+  /// Push broadcasts sent to this world (mobility-scoped Broadcast
+  /// rows). Populates the visitor `/w/<slug>/notifications` feed.
+  broadcasts        Broadcast[]
 
   @@unique([projectId, slug])
   @@index([projectId])


### PR DESCRIPTION
## Summary

Composer picks devices → notification carries them → visitor taps → map opens with those pins highlighted. Plus a persistent visitor Alerts feed and two follow-up fixes from the previous polish round.

**Composer** (operator dashboard, `WorldEditor`):
- New "Link to devices" section under title/body. Multi-select with search, chips inline, deep-link preview.
- Empty selection = notification opens the plain map (backwards-compatible).

**Push flow**:
- `POST /api/worlds/[id]/broadcast` accepts `deviceIds`, validates against the world's device set, computes tap URL `/w/<slug>?devices=id1,id2`, persists a `Broadcast` row. The service worker's existing `notificationclick` handler opens that URL — no SW changes needed.

**Map (`WorldViewer`)**:
- Reads `?devices=id1,id2,id3` on mount; halo layer highlights every listed pin (mapbox `in` filter) and camera fits-to-bounds around them. Coexists with the single-select `?device=<id>` from user taps — tapping a pin opens its drawer without wiping the notification's highlight.

**Notifications page**:
- New route `/w/<slug>/notifications` — server-rendered feed, most recent first. Each row shows relative time, title/body, device chips (real names, resolved server-side from `deviceIds`), and "View on map" affordance. Empty state included. `loading.tsx` for instant nav.
- Access follows the same public/linkOnly/authenticated rules as the map.

**Bottom + top nav**:
- 4th tab "Alerts" (Bell icon).

**Prisma**:
- `Broadcast.worldId` (optional FK, cascade) + `deviceIds String[]`, `MobilityWorld.broadcasts` inverse, `Broadcast_worldId_createdAt_idx` index.
- Migration `20260718120000_mobility_broadcast_devices` — plain ALTER TABLE, safe on prod (defaults to null/empty for existing campus rows).

**Paris scroll fix**:
- DS `AssistantPanel` gains `layout: "flow" | "fill"`. `flow` (default) keeps the historic sticky-input campus behaviour. `fill` makes the panel fill its parent's height; hero/thread scroll internally, input pins to the bottom of the panel (not the document). ParisPanel now wraps the DS panel in a `calc(100dvh - 3.5rem)` container so the whole page no longer scrolls on long conversations.

**Pull-to-refresh on map**:
- `WorldViewer` `<main>` now carries `data-mapbox` so `MobilityPullToRefresh`'s opt-out selector matches. Panning the map no longer triggers `router.refresh()`.

## Test plan

- [ ] Operator: open a world → Broadcast card shows "Link to devices" section
- [ ] With no devices assigned to the world: shows helpful hint, no picker
- [ ] With devices: click "Choose" → picker opens with search; pick 2-3 → chips appear + preview URL shows `/w/<slug>?devices=id1,id2,id3`
- [ ] Send → toast confirms; `Broadcast` row persists with `worldId` + `deviceIds`
- [ ] Visitor: `/w/<slug>?devices=<id>,<id>` renders with those pins haloed, camera fit-to-bounds
- [ ] Tap another pin → drawer opens, existing highlight stays
- [ ] Push notification: send from composer with devices linked → open on device → tap → map opens with pins highlighted
- [ ] Bottom nav has 4 tabs; "Alerts" tab lists past broadcasts with date + chips + "View on map" link
- [ ] Tap a row → deep-links back to the map with the pins highlighted
- [ ] Paris tab: send long messages → thread scrolls internally, input pinned above bottom nav, page itself does not scroll
- [ ] Map tab: pan downward on the map → no page refresh triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)