### PR TITLE
feat(mock-inet): interactive demo control panel + one-click reset

### DIFF
--- a/apps/mock-inet/app/DemoControlPanel.tsx
+++ b/apps/mock-inet/app/DemoControlPanel.tsx
@@ -1,0 +1,692 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * Interactive demo control panel — the "sell it in a click" surface.
+ *
+ * Layout:
+ *   - Grid of scenario cards. Each card: what it does, downstream
+ *     effect (which webhook events fire, what alert rule shape
+ *     matches), an "Active" badge if the scenario is currently
+ *     running, a Trigger button.
+ *   - Global "Reset all" button — clears every 3-min override, stops
+ *     the ticker, cancels the running incident, and republishes
+ *     `device.status_changed` for each affected device so downstream
+ *     sees the "restored" state immediately.
+ *   - Live event feed (SSE on `/api/stream`) with the last ~40
+ *     events so you can watch webhooks fly by as you click.
+ *
+ * All calls hit same-origin API routes; the browser sends
+ * `Sec-Fetch-Site: same-origin` which the mock's auth layer accepts
+ * without Basic credentials (see `lib/auth.ts:isSameOriginRequest`).
+ */
+
+interface ScenarioStatus {
+  incident: { running: boolean; id: string | null };
+  traffic: { running: boolean };
+  overrides: Array<{
+    externalId: string;
+    reason: string;
+    expiresAt: number;
+    remainingMs: number;
+  }>;
+}
+
+interface FeedEvent {
+  type: string;
+  at: string;
+  payload: unknown;
+  seenAt: number;
+}
+
+type ScenarioName =
+  | "incident"
+  | "traffic"
+  | "radar-spike"
+  | "dms-alarm"
+  | "incident-cascade"
+  | "vms-inspection";
+
+interface ScenarioDef {
+  key: ScenarioName;
+  title: string;
+  emoji: string;
+  blurb: string;
+  emits: string;
+  matches: string;
+  /** Compute the "Active" badge from live status. */
+  isActive?(status: ScenarioStatus): boolean;
+}
+
+const SCENARIOS: ScenarioDef[] = [
+  {
+    key: "radar-spike",
+    title: "Radar occupancy spike",
+    emoji: "🚦",
+    blurb:
+      "One radar's occupancy jumps to 0.85 and mean speed drops to 18 km/h for 3 minutes. The classic 'jam forming' shape.",
+    emits: "device.status_changed × 2  (start + expiry)",
+    matches: "threshold rule where field=occupancy, op≥, value=0.7",
+    isActive: (s) =>
+      s.overrides.some((o) => o.reason.toLowerCase().includes("radar")),
+  },
+  {
+    key: "dms-alarm",
+    title: "DMS sign fault",
+    emoji: "🛑",
+    blurb:
+      "One DMS flips to shortStatus=0x0004, connectable=false, message='SIGN FAULT'. Reads as offline + alarmed downstream.",
+    emits: "device.status_changed × 2  (start + expiry)",
+    matches: "event rule for type=device.status_changed + kind=alarmed",
+    isActive: (s) =>
+      s.overrides.some((o) => o.reason.toLowerCase().includes("dms")),
+  },
+  {
+    key: "incident",
+    title: "Incident response",
+    emoji: "🚨",
+    blurb:
+      "Creates an AID-triggered incident and walks its status every 6 seconds: posted → acknowledged → en_route → on_scene → resolved.",
+    emits: "incident.posted + incident.status_changed (×4)",
+    matches: "event rule for type=incident.posted",
+    isActive: (s) => s.incident.running,
+  },
+  {
+    key: "traffic",
+    title: "Traffic flow ticker",
+    emoji: "📈",
+    blurb:
+      "Starts the 1 Hz VDS traffic loop across every radar. Stages a scripted slowdown on one radar 15 s in. Feeds live-graph demos.",
+    emits: "vds.tick (once per second, per radar)",
+    matches: "threshold rule where field=speed, op≤, value=30",
+    isActive: (s) => s.traffic.running,
+  },
+  {
+    key: "incident-cascade",
+    title: "Incident cascade",
+    emoji: "🔗",
+    blurb:
+      "Combines Incident + Radar spike + DMS fault with a 4 s stagger. Reproduces the 'something big just happened' cascade.",
+    emits: "incident.posted → device.status_changed × 2",
+    matches: "any of the above rules will fire",
+    isActive: (s) =>
+      s.incident.running &&
+      s.overrides.some((o) => o.reason.toLowerCase().includes("radar")),
+  },
+  {
+    key: "vms-inspection",
+    title: "VMS inspection world",
+    emoji: "🏗️",
+    blurb:
+      "Provisions a demo world scoped to the Western Ring VMS signs and returns the install URL. Not time-based — nothing to reset.",
+    emits: "no events (world provisioning only)",
+    matches: "n/a",
+  },
+];
+
+export function DemoControlPanel() {
+  const [status, setStatus] = useState<ScenarioStatus | null>(null);
+  const [busy, setBusy] = useState<ScenarioName | "reset" | null>(null);
+  const [lastResult, setLastResult] = useState<{
+    name: string;
+    body: unknown;
+    ok: boolean;
+    at: number;
+  } | null>(null);
+  const [feed, setFeed] = useState<FeedEvent[]>([]);
+  const [feedConnected, setFeedConnected] = useState(false);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/demo/status", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = (await res.json()) as ScenarioStatus;
+      setStatus(data);
+    } catch {
+      /* transient; poll again shortly */
+    }
+  }, []);
+
+  // Poll status every 3 s so countdowns + active badges stay fresh.
+  useEffect(() => {
+    void refreshStatus();
+    const iv = setInterval(refreshStatus, 3000);
+    return () => clearInterval(iv);
+  }, [refreshStatus]);
+
+  // Live event feed. Keeps the most recent ~40; older entries drop off.
+  useEffect(() => {
+    const es = new EventSource("/api/stream");
+    es.onopen = () => setFeedConnected(true);
+    es.onerror = () => setFeedConnected(false);
+    const onEvent = (e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data) as {
+          type: string;
+          at: string;
+          payload: unknown;
+        };
+        setFeed((prev) => {
+          const next = [{ ...parsed, seenAt: Date.now() }, ...prev];
+          return next.slice(0, 40);
+        });
+      } catch {
+        /* skip malformed frames */
+      }
+    };
+    for (const type of [
+      "device.status_changed",
+      "incident.posted",
+      "incident.status_changed",
+      "vds.tick",
+    ]) {
+      es.addEventListener(type, onEvent);
+    }
+    return () => es.close();
+  }, []);
+
+  const trigger = async (name: ScenarioName) => {
+    setBusy(name);
+    try {
+      const res = await fetch(`/api/demo/scenario/${name}`, {
+        method: "POST",
+      });
+      const body = await res.json().catch(() => null);
+      setLastResult({ name, body, ok: res.ok, at: Date.now() });
+      await refreshStatus();
+    } catch (err) {
+      setLastResult({
+        name,
+        body: { error: String(err) },
+        ok: false,
+        at: Date.now(),
+      });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const reset = async () => {
+    setBusy("reset");
+    try {
+      const res = await fetch(`/api/demo/scenario/reset`, { method: "POST" });
+      const body = await res.json().catch(() => null);
+      setLastResult({ name: "reset", body, ok: res.ok, at: Date.now() });
+      await refreshStatus();
+    } catch (err) {
+      setLastResult({
+        name: "reset",
+        body: { error: String(err) },
+        ok: false,
+        at: Date.now(),
+      });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const anythingActive = useMemo(() => {
+    if (!status) return false;
+    return (
+      status.incident.running ||
+      status.traffic.running ||
+      status.overrides.length > 0
+    );
+  }, [status]);
+
+  return (
+    <section>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 12,
+          marginBottom: 12,
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: 18 }}>Scenario runner</h2>
+        <button
+          type="button"
+          onClick={reset}
+          disabled={busy !== null || !anythingActive}
+          title={
+            anythingActive
+              ? "Clear every 3-minute override, stop the traffic ticker, cancel the running incident, and re-emit device.status_changed for each affected device."
+              : "Nothing to reset — no scenarios are active."
+          }
+          style={{
+            appearance: "none",
+            border: "1px solid #ef4444",
+            background: anythingActive ? "#ef4444" : "transparent",
+            color: anythingActive ? "white" : "#ef4444",
+            padding: "6px 14px",
+            borderRadius: 8,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: busy !== null || !anythingActive ? "not-allowed" : "pointer",
+            opacity: busy === "reset" ? 0.6 : 1,
+            transition: "background-color 150ms ease",
+          }}
+        >
+          {busy === "reset" ? "Resetting…" : "Reset all to normal"}
+        </button>
+      </div>
+
+      {status ? <ActiveSummary status={status} /> : null}
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+          gap: 12,
+          marginTop: 16,
+        }}
+      >
+        {SCENARIOS.map((s) => {
+          const active = status ? Boolean(s.isActive?.(status)) : false;
+          return (
+            <ScenarioCard
+              key={s.key}
+              def={s}
+              active={active}
+              busy={busy === s.key}
+              onTrigger={() => void trigger(s.key)}
+            />
+          );
+        })}
+      </div>
+
+      {lastResult ? (
+        <ResultChip result={lastResult} onDismiss={() => setLastResult(null)} />
+      ) : null}
+
+      <LiveFeed events={feed} connected={feedConnected} />
+    </section>
+  );
+}
+
+function ActiveSummary({ status }: { status: ScenarioStatus }) {
+  const chips: Array<{ label: string; tone: "hot" | "warn" }> = [];
+  if (status.incident.running) {
+    chips.push({
+      label: `Incident ${status.incident.id ? `#${status.incident.id.slice(0, 6)}` : ""} running`,
+      tone: "hot",
+    });
+  }
+  if (status.traffic.running) {
+    chips.push({ label: "Traffic ticker running", tone: "warn" });
+  }
+  for (const o of status.overrides) {
+    chips.push({
+      label: `${o.externalId} · ${formatRemaining(o.remainingMs)}`,
+      tone: "warn",
+    });
+  }
+  if (chips.length === 0) {
+    return (
+      <p style={{ color: "#64748b", fontSize: 13, margin: "0 0 4px 0" }}>
+        All quiet — no scenarios active.
+      </p>
+    );
+  }
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+      {chips.map((c) => (
+        <span
+          key={c.label}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "3px 10px",
+            borderRadius: 999,
+            fontSize: 12,
+            fontWeight: 500,
+            background: c.tone === "hot" ? "#7f1d1d" : "#78350f",
+            color: c.tone === "hot" ? "#fecaca" : "#fde68a",
+            border:
+              c.tone === "hot"
+                ? "1px solid #b91c1c"
+                : "1px solid #b45309",
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: c.tone === "hot" ? "#fecaca" : "#fde68a",
+            }}
+          />
+          {c.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ScenarioCard({
+  def,
+  active,
+  busy,
+  onTrigger,
+}: {
+  def: ScenarioDef;
+  active: boolean;
+  busy: boolean;
+  onTrigger: () => void;
+}) {
+  return (
+    <article
+      style={{
+        border: active ? "1px solid #f59e0b" : "1px solid #1e293b",
+        background: active ? "rgba(245, 158, 11, 0.08)" : "#0f172a",
+        borderRadius: 12,
+        padding: 14,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 20 }} aria-hidden>
+            {def.emoji}
+          </span>
+          <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>
+            {def.title}
+          </h3>
+        </div>
+        {active ? (
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              color: "#fde68a",
+              background: "rgba(245, 158, 11, 0.16)",
+              border: "1px solid #b45309",
+              padding: "2px 6px",
+              borderRadius: 999,
+              letterSpacing: "0.05em",
+              textTransform: "uppercase",
+            }}
+          >
+            Active
+          </span>
+        ) : null}
+      </header>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 12,
+          lineHeight: 1.5,
+          color: "#cbd5e1",
+        }}
+      >
+        {def.blurb}
+      </p>
+      <dl
+        style={{
+          margin: 0,
+          display: "grid",
+          gridTemplateColumns: "min-content 1fr",
+          columnGap: 8,
+          rowGap: 4,
+          fontSize: 11,
+        }}
+      >
+        <dt style={{ color: "#94a3b8" }}>Emits</dt>
+        <dd style={{ margin: 0, color: "#e2e8f0", fontFamily: "monospace" }}>
+          {def.emits}
+        </dd>
+        <dt style={{ color: "#94a3b8" }}>Matches</dt>
+        <dd style={{ margin: 0, color: "#e2e8f0", fontFamily: "monospace" }}>
+          {def.matches}
+        </dd>
+      </dl>
+      <button
+        type="button"
+        onClick={onTrigger}
+        disabled={busy}
+        style={{
+          appearance: "none",
+          alignSelf: "flex-start",
+          border: "1px solid #38bdf8",
+          background: busy ? "transparent" : "#0369a1",
+          color: busy ? "#38bdf8" : "white",
+          padding: "6px 12px",
+          borderRadius: 8,
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: busy ? "wait" : "pointer",
+          marginTop: "auto",
+        }}
+      >
+        {busy ? "Triggering…" : active ? "Trigger again" : "Trigger"}
+      </button>
+    </article>
+  );
+}
+
+function ResultChip({
+  result,
+  onDismiss,
+}: {
+  result: { name: string; body: unknown; ok: boolean; at: number };
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      style={{
+        marginTop: 12,
+        padding: 10,
+        border: "1px solid",
+        borderColor: result.ok ? "#166534" : "#7f1d1d",
+        background: result.ok ? "rgba(22, 101, 52, 0.15)" : "rgba(127, 29, 29, 0.15)",
+        borderRadius: 8,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 12,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ margin: 0, fontSize: 12, color: "#e2e8f0" }}>
+          <strong>{result.ok ? "Fired" : "Failed"}:</strong> {result.name}
+        </p>
+        <pre
+          style={{
+            marginTop: 6,
+            marginBottom: 0,
+            fontSize: 11,
+            fontFamily: "monospace",
+            color: "#cbd5e1",
+            background: "#020617",
+            padding: 8,
+            borderRadius: 6,
+            overflowX: "auto",
+            maxHeight: 160,
+          }}
+        >
+          {JSON.stringify(result.body, null, 2)}
+        </pre>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        style={{
+          appearance: "none",
+          background: "transparent",
+          border: "none",
+          color: "#94a3b8",
+          fontSize: 16,
+          cursor: "pointer",
+          padding: 4,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+function LiveFeed({
+  events,
+  connected,
+}: {
+  events: FeedEvent[];
+  connected: boolean;
+}) {
+  const scrollRef = useRef<HTMLUListElement | null>(null);
+  return (
+    <section style={{ marginTop: 28 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>
+          Live event feed
+        </h3>
+        <span
+          style={{
+            fontSize: 11,
+            color: connected ? "#4ade80" : "#94a3b8",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: connected ? "#4ade80" : "#94a3b8",
+            }}
+          />
+          {connected ? "SSE live" : "Reconnecting…"}
+        </span>
+      </div>
+      <p style={{ color: "#64748b", fontSize: 12, margin: "4px 0 8px 0" }}>
+        Every event that fires — webhooks fan out from here to any
+        registered consumer + the Klorad Mobility webhook endpoint if
+        wired.
+      </p>
+      {events.length === 0 ? (
+        <p style={{ color: "#94a3b8", fontSize: 12, margin: 0 }}>
+          Nothing yet. Trigger a scenario above to see events land.
+        </p>
+      ) : (
+        <ul
+          ref={scrollRef}
+          style={{
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            border: "1px solid #1e293b",
+            borderRadius: 8,
+            maxHeight: 260,
+            overflowY: "auto",
+          }}
+        >
+          {events.map((e, i) => (
+            <li
+              key={`${e.seenAt}-${i}`}
+              style={{
+                borderBottom:
+                  i === events.length - 1 ? "none" : "1px solid #1e293b",
+                padding: "6px 10px",
+                fontSize: 11,
+                fontFamily: "monospace",
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <span style={{ color: "#94a3b8", minWidth: 62 }}>
+                {formatClock(e.at)}
+              </span>
+              <span
+                style={{
+                  minWidth: 160,
+                  color:
+                    e.type === "vds.tick"
+                      ? "#38bdf8"
+                      : e.type.startsWith("incident.")
+                        ? "#f59e0b"
+                        : "#4ade80",
+                }}
+              >
+                {e.type}
+              </span>
+              <span
+                style={{
+                  color: "#e2e8f0",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {summarize(e.type, e.payload)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function formatClock(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toISOString().slice(11, 19);
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return "expired";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s left`;
+  return `${Math.floor(s / 60)}m ${s % 60}s left`;
+}
+
+/** One-liner summary per event type so the feed row stays scannable. */
+function summarize(type: string, payload: unknown): string {
+  const p = payload as Record<string, unknown> | null;
+  if (!p || typeof p !== "object") return "";
+  if (type === "vds.tick") {
+    const speed = p.speed;
+    const volume = p.volume;
+    const occupancy = p.occupancy;
+    const deviceId = p.deviceId;
+    return `${deviceId} · v=${volume} s=${speed} o=${occupancy}`;
+  }
+  if (type === "device.status_changed") {
+    const externalId = p.externalId ?? p.deviceId;
+    const subsystem = p.subsystem;
+    return `${subsystem ?? "?"} · ${externalId ?? "?"}`;
+  }
+  if (type.startsWith("incident.")) {
+    const id = p.id;
+    const status = p.status;
+    const title = p.title;
+    return `#${typeof id === "string" ? id.slice(0, 6) : "?"} · ${status ?? ""} · ${title ?? ""}`;
+  }
+  return JSON.stringify(payload).slice(0, 120);
+}

--- a/apps/mock-inet/app/api/demo/overrides/route.ts
+++ b/apps/mock-inet/app/api/demo/overrides/route.ts
@@ -6,14 +6,16 @@
  *   /status calls.
  */
 import { NextRequest, NextResponse } from "next/server";
-import { requireBasicAuth } from "@/lib/auth";
+import { isSameOriginRequest, requireBasicAuth } from "@/lib/auth";
 import { activeOverrides } from "@/lib/overrides";
 
 export const runtime = "nodejs";
 
 export async function GET(request: NextRequest) {
-  const denied = requireBasicAuth(request);
-  if (denied) return denied;
+  if (!isSameOriginRequest(request)) {
+    const denied = requireBasicAuth(request);
+    if (denied) return denied;
+  }
   const now = Date.now();
   return NextResponse.json({
     now,

--- a/apps/mock-inet/app/api/demo/scenario/[name]/route.ts
+++ b/apps/mock-inet/app/api/demo/scenario/[name]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireBasicAuth } from "@/lib/auth";
+import { isSameOriginRequest, requireBasicAuth } from "@/lib/auth";
 import {
+  resetAll,
   runDmsAlarm,
   runIncident,
   runIncidentCascade,
@@ -16,8 +17,13 @@ interface Params {
 }
 
 export async function POST(request: NextRequest, { params }: Params) {
-  const denied = requireBasicAuth(request);
-  if (denied) return denied;
+  // Demo triggers are the whole point of the /api/demo surface —
+  // the mock's own homepage should be able to fire them with a click.
+  // External callers (curl, CI, remote demos) still need Basic auth.
+  if (!isSameOriginRequest(request)) {
+    const denied = requireBasicAuth(request);
+    if (denied) return denied;
+  }
   const { name } = await params;
   const url = new URL(request.url);
   const host = `${url.protocol}//${url.host}`;
@@ -39,12 +45,14 @@ export async function POST(request: NextRequest, { params }: Params) {
         return NextResponse.json(runDmsAlarm(deviceId));
       case "incident-cascade":
         return NextResponse.json(runIncidentCascade());
+      case "reset":
+        return NextResponse.json(resetAll());
       default:
         return NextResponse.json(
           {
             error: "Unknown scenario",
             detail:
-              "Expected `incident`, `vms-inspection`, `traffic`, `radar-spike`, `dms-alarm`, or `incident-cascade`.",
+              "Expected `incident`, `vms-inspection`, `traffic`, `radar-spike`, `dms-alarm`, `incident-cascade`, or `reset`.",
           },
           { status: 400 },
         );

--- a/apps/mock-inet/app/api/demo/status/route.ts
+++ b/apps/mock-inet/app/api/demo/status/route.ts
@@ -1,0 +1,26 @@
+/**
+ * `GET /api/demo/status` — snapshot of what the mock's scripted state
+ * is currently doing (active incident? traffic ticker running? which
+ * device overrides are still hot and for how long?). Powers the demo
+ * control panel's "active" badges + countdown chips.
+ *
+ * Public to same-origin (the demo panel) so it can poll without a
+ * login prompt; external CLIs still hit Basic auth. Same rule as the
+ * `POST /api/demo/scenario/*` triggers.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { isSameOriginRequest, requireBasicAuth } from "@/lib/auth";
+import { getScenarioStatus } from "@/lib/scenarios";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  if (!isSameOriginRequest(request)) {
+    const denied = requireBasicAuth(request);
+    if (denied) return denied;
+  }
+  return NextResponse.json(getScenarioStatus(), {
+    // Never cache; the whole point is fresh state on every poll.
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/apps/mock-inet/app/api/stream/route.ts
+++ b/apps/mock-inet/app/api/stream/route.ts
@@ -7,7 +7,7 @@
  * Hobby). Client should reconnect with EventSource's built-in retry.
  */
 import { NextRequest } from "next/server";
-import { requireBasicAuth } from "@/lib/auth";
+import { isSameOriginRequest, requireBasicAuth } from "@/lib/auth";
 import { subscribe, parseEventFilter } from "@/lib/events";
 import type { StreamEventType } from "@/lib/types";
 
@@ -16,8 +16,14 @@ export const runtime = "nodejs";
 export const maxDuration = 300;
 
 export async function GET(request: NextRequest) {
-  const denied = requireBasicAuth(request);
-  if (denied) return denied;
+  // Same-origin bypass so the mock's own demo panel can subscribe
+  // to the live event feed without a browser Basic-auth prompt.
+  // External CLI subscribers (curl, dashboards, wireshark scripts)
+  // still hit the credential check.
+  if (!isSameOriginRequest(request)) {
+    const denied = requireBasicAuth(request);
+    if (denied) return denied;
+  }
 
   const url = new URL(request.url);
   const filter = parseEventFilter(url.searchParams.get("events"));

--- a/apps/mock-inet/app/page.tsx
+++ b/apps/mock-inet/app/page.tsx
@@ -1,34 +1,73 @@
+import { DemoControlPanel } from "./DemoControlPanel";
+
 /**
- * Developer-facing landing. Lists the endpoint surface so someone
- * hitting `/` in the browser knows what this is and how to poke it.
+ * Developer-facing landing page for the PSMdt-iNET mock.
+ *
+ * Top half is an interactive demo control panel (client component)
+ * with one card per scenario, live active-state badges, a reset
+ * button, and an SSE-driven event feed so you can watch the wire
+ * as you click. Bottom half is the classic endpoint reference for
+ * developers pointing curl / connectors at the mock.
  */
 export default function Home() {
-  const example = (path: string) => `GET ${path} — HTTP Basic (demo/demo)`;
   return (
-    <main style={{ maxWidth: 780, margin: "0 auto" }}>
-      <h1 style={{ marginTop: 0 }}>PSMdt-iNET Mock</h1>
-      <p style={{ color: "#94a3b8", marginTop: 0 }}>
-        Mock Parsons/iNET ATMS surface + demo scenario runners. Two layers,
-        one deploy.
-      </p>
+    <main
+      style={{
+        maxWidth: 980,
+        margin: "0 auto",
+        display: "flex",
+        flexDirection: "column",
+        gap: 40,
+      }}
+    >
+      <header>
+        <h1 style={{ marginTop: 0, marginBottom: 4, fontSize: 28 }}>
+          PSMdt-iNET Mock
+        </h1>
+        <p style={{ color: "#94a3b8", margin: 0 }}>
+          Mock Parsons/iNET ATMS surface + demo scenario runners.
+          Trigger a scenario below to drive alerts + webhooks against
+          a Klorad Mobility source pointed at this deploy.
+        </p>
+      </header>
 
+      <DemoControlPanel />
+
+      <ApiReference />
+
+      <footer style={{ color: "#64748b", fontSize: 13 }}>
+        Auth: HTTP Basic (<code>demo</code>/<code>demo</code> or the
+        <code>MOCK_USER</code>/<code>MOCK_PASS</code> env). This
+        page&apos;s Trigger + Reset buttons bypass Basic auth via a
+        same-origin check.
+      </footer>
+    </main>
+  );
+}
+
+/**
+ * Endpoint reference — kept below the control panel so people
+ * poking at curl still get a quick map without scrolling far.
+ * Static / server-rendered; no interactivity.
+ */
+function ApiReference() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
       <Section title="Layer 1 — iNET drop-in">
-        <p>
+        <p style={{ margin: "0 0 8px 0", color: "#cbd5e1" }}>
           Byte-compatible with the shape the Klorad{" "}
           <code>@klorad/connectors/inet-atms</code> connector talks to.
-          Point a Mobility source&apos;s <code>host</code> at this deploy and
-          sync as usual.
+          Point a Mobility source&apos;s <code>host</code> at this
+          deploy and sync as usual.
         </p>
         <List
           items={[
-            example("/atms/{subsystem}-rest/rest/{subsystem}/"),
-            example("/atms/{subsystem}-rest/rest/{subsystem}/{externalId}"),
-            example(
-              "/atms/dms-rest/rest/dms/{externalId}/status",
-            ),
+            "GET /atms/{subsystem}-rest/rest/{subsystem}/",
+            "GET /atms/{subsystem}-rest/rest/{subsystem}/{externalId}",
+            "GET /atms/dms-rest/rest/dms/{externalId}/status",
           ]}
         />
-        <p>
+        <p style={{ color: "#94a3b8", fontSize: 13, margin: "8px 0 0 0" }}>
           Subsystems: <code>cctv aid vms dms vsls radar</code>.
         </p>
       </Section>
@@ -41,42 +80,25 @@ export default function Home() {
             "GET /api/vds/live",
             "GET /api/stream (SSE)",
             "GET/POST /api/webhooks · DELETE /api/webhooks/:id",
+            "GET /api/demo/status · GET /api/demo/overrides",
+            "POST /api/demo/scenario/{name}",
           ]}
         />
       </Section>
-
-      <Section title="One-tap scenarios">
-        <List
-          items={[
-            "POST /api/demo/scenario/incident",
-            "POST /api/demo/scenario/vms-inspection",
-            "POST /api/demo/scenario/traffic",
-            "POST /api/demo/scenario/radar-spike (optional ?deviceId=…)",
-            "POST /api/demo/scenario/dms-alarm (optional ?deviceId=…)",
-            "POST /api/demo/scenario/incident-cascade",
-            "GET  /api/demo/overrides — inspect active status overrides",
-          ]}
-        />
-        <p style={{ marginTop: 12, color: "#94a3b8", fontSize: 13 }}>
-          Radar / DMS scenarios flip device status for 3 minutes and
-          emit <code>device.status_changed</code> events. Wire a
-          webhook against them from Mobility to drive the alert-rule
-          engine.
-        </p>
-      </Section>
-
-      <p style={{ marginTop: 40, color: "#64748b" }}>
-        Auth: HTTP Basic. Defaults <code>demo</code> / <code>demo</code>;
-        override with <code>MOCK_USER</code> / <code>MOCK_PASS</code>.
-      </p>
-    </main>
+    </div>
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
-    <section style={{ marginTop: 32 }}>
-      <h2 style={{ marginBottom: 8, fontSize: 18 }}>{title}</h2>
+    <section>
+      <h2 style={{ marginTop: 0, marginBottom: 8, fontSize: 16 }}>{title}</h2>
       {children}
     </section>
   );
@@ -84,10 +106,10 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function List({ items }: { items: string[] }) {
   return (
-    <ul style={{ margin: "8px 0", paddingLeft: 20, lineHeight: 1.7 }}>
+    <ul style={{ margin: "4px 0", paddingLeft: 20, lineHeight: 1.7 }}>
       {items.map((s) => (
         <li key={s}>
-          <code>{s}</code>
+          <code style={{ fontSize: 12 }}>{s}</code>
         </li>
       ))}
     </ul>

--- a/apps/mock-inet/lib/auth.ts
+++ b/apps/mock-inet/lib/auth.ts
@@ -37,6 +37,35 @@ export function requireBasicAuth(request: Request): NextResponse | null {
   return unauthorized();
 }
 
+/**
+ * Detect a request that came from the mock's own homepage / demo
+ * panel — one where the browser sends `Sec-Fetch-Site: same-origin`
+ * (fetch from a page on the same host). Used to skip Basic auth on
+ * `/api/demo/*` endpoints so the built-in demo control panel works
+ * without a login prompt, while external CLIs / demo runners still
+ * need `demo:demo` credentials.
+ *
+ * `Sec-Fetch-Site` is set by modern browsers on every `fetch`; it
+ * can't be spoofed by a page on another origin because browsers
+ * refuse to let scripts override it. Falls back to referer check
+ * for older browsers.
+ */
+export function isSameOriginRequest(request: Request): boolean {
+  const site = request.headers.get("sec-fetch-site");
+  if (site === "same-origin") return true;
+  // Sec-Fetch-Site missing (older browser or direct navigation) —
+  // fall back to a referer check against this deploy's host.
+  const referer = request.headers.get("referer");
+  if (!referer) return false;
+  try {
+    const refererHost = new URL(referer).host;
+    const selfHost = request.headers.get("host") ?? "";
+    return refererHost === selfHost && selfHost.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function unauthorized(): NextResponse {
   return NextResponse.json(
     { error: "Unauthorized" },

--- a/apps/mock-inet/lib/scenarios.ts
+++ b/apps/mock-inet/lib/scenarios.ts
@@ -11,10 +11,10 @@ import {
   pickIncidentAnchor,
 } from "./incidents";
 import { createWorld } from "./worlds";
-import { startTicker, stopTicker, triggerSlowdown } from "./vds";
+import { startTicker, stopTicker, tickerRunning, triggerSlowdown } from "./vds";
 import type { Device, IncidentStatus } from "./types";
-import { devicesBySubsystem } from "./devices";
-import { setOverride } from "./overrides";
+import { allDevices, devicesBySubsystem } from "./devices";
+import { setOverride, activeOverrides, clearOverride } from "./overrides";
 import { publish } from "./events";
 
 interface RunningIncident {
@@ -241,5 +241,105 @@ export function runIncidentCascade(): {
     incidentId: incident.incidentId,
     radarDeviceId,
     dmsDeviceId,
+  };
+}
+
+/**
+ * Reset everything back to nominal. The counterpart to the trigger
+ * scenarios — clears every 3-minute override, stops the traffic
+ * ticker, cancels the running incident, and publishes a fresh
+ * `device.status_changed` for each device that had an override so
+ * subscribers (webhooks, mobility alert engine) see the "restored"
+ * state without waiting for the 3-minute expiry.
+ *
+ * This is the "make the demo look normal again" button — critical
+ * for running the pitch back-to-back without a 3-minute cool-down.
+ */
+export function resetAll(): {
+  name: "reset";
+  status: "reset";
+  cleared: {
+    incident: boolean;
+    traffic: boolean;
+    overrides: number;
+  };
+} {
+  const hadIncident = runningIncident !== null;
+  if (runningIncident) {
+    clearInterval(runningIncident.timer);
+    runningIncident = null;
+  }
+
+  const hadTraffic = runningTraffic;
+  if (runningTraffic) {
+    stopTicker();
+    runningTraffic = false;
+  }
+
+  // Snapshot active overrides BEFORE clearing so we can re-publish
+  // the "back to normal" event for each affected device. Order
+  // matters — clear then publish (so subscribers that re-read
+  // /status see the clean value).
+  const active = activeOverrides();
+  for (const row of active) {
+    clearOverride(row.externalId);
+  }
+  // `activeOverrides()` only carries the externalId; look the device
+  // up in the flat pool since overrides are subsystem-agnostic.
+  const byExternalId = new Map<string, Device>();
+  for (const d of allDevices()) byExternalId.set(d.externalId, d);
+  for (const row of active) {
+    const device = byExternalId.get(row.externalId);
+    if (device) publishDeviceStatusChanged(device);
+  }
+
+  return {
+    name: "reset",
+    status: "reset",
+    cleared: {
+      incident: hadIncident,
+      traffic: hadTraffic,
+      overrides: active.length,
+    },
+  };
+}
+
+export interface ScenarioStatus {
+  incident: {
+    running: boolean;
+    id: string | null;
+  };
+  traffic: {
+    running: boolean;
+  };
+  overrides: Array<{
+    externalId: string;
+    reason: string;
+    expiresAt: number;
+    remainingMs: number;
+  }>;
+}
+
+/**
+ * Snapshot of what's currently "hot" — powers the demo panel's
+ * active-state badges. Reads authoritative state from each module
+ * rather than tracking it here twice.
+ */
+export function getScenarioStatus(): ScenarioStatus {
+  const now = Date.now();
+  return {
+    incident: {
+      running: runningIncident !== null,
+      id: runningIncident?.id ?? null,
+    },
+    traffic: {
+      running: tickerRunning(),
+    },
+    overrides: activeOverrides().map((o) => ({
+      externalId: o.externalId,
+      reason: o.reason,
+      expiresAt: o.expiresAt,
+      remainingMs: Math.max(0, o.expiresAt - now),
+    })),
   };
 }

--- a/apps/mock-inet/lib/vds.ts
+++ b/apps/mock-inet/lib/vds.ts
@@ -34,6 +34,14 @@ export function stopTicker(): void {
     clearInterval(ticker);
     ticker = null;
   }
+  slowdownExternalId = null;
+  slowdownUntil = 0;
+}
+
+/** Whether the VDS ticker is currently running. Powers the demo-
+ *  panel's "Traffic ticker: active" badge. */
+export function tickerRunning(): boolean {
+  return ticker !== null;
 }
 
 /** Trigger a scripted 30-second slowdown on one radar — Scenario 3


### PR DESCRIPTION
## Summary

Answers @prieston's ask: **make it easy to demonstrate the alert + real-time webhook pipeline**. The mock's homepage was a static endpoint list; it's now an interactive control panel where you can trigger a scenario, watch webhooks land, and reset back to normal with one click.

### How the alerts work today (short recap)

The pipeline is complete end-to-end:

1. **Mock** emits `device.status_changed` / `incident.*` / `vds.tick` on the SSE bus (`apps/mock-inet/lib/events.ts`).
2. **Bus** fans out to any registered webhook consumer (`apps/mock-inet/lib/webhooks.ts`).
3. **Mobility webhook endpoint** at `POST /api/webhooks/inet-atms/[sourceId]` verifies HMAC and calls `evaluateRules(event, rules)` (`apps/mobility/lib/mobility/alert-rules.ts`).
4. Matching rules → `openAlertAndDispatch()` → creates `MobilityAlert` + calls `sendPushToWorld(worldId, ...)` (`apps/mobility/lib/mobility/alert-dispatch.ts`).

**What was missing**: a way to trigger the scenarios without CLI/curl, and no "reset" so a demo could repeat without a 3-minute wait.

### What ships

**Scenario cards** (6, each with title, blurb, "Emits", "Matches" rule shape, Active badge, Trigger button):
- 🚦 Radar occupancy spike — occupancy → 0.85, speed → 18 for 3 min
- 🛑 DMS sign fault — connectable=false, shortStatus=0x0004 for 3 min
- 🚨 Incident response — AID incident, status auto-walks every 6 s
- 📈 Traffic ticker — 1 Hz VDS loop across every radar
- 🔗 Incident cascade — combines the above with a 4 s stagger
- 🏗️ VMS inspection world

**Reset all to normal**:
- New `resetAll()` in `lib/scenarios.ts` — clears every 3-min override, stops the traffic ticker, cancels the running incident, and re-emits `device.status_changed` for each restored device so downstream sees "back to normal" immediately (no wait).
- Wired to `POST /api/demo/scenario/reset`.
- Button in the panel is disabled when nothing is active.

**Live event feed**:
- SSE from `/api/stream` renders the last ~40 events with type + summary. "SSE live" pill turns green when connected. Watch webhooks fly out in real time as you click.

**Active-state polling**:
- New `GET /api/demo/status` returns which scenarios are active + every hot override with remaining ms. Polled every 3 s.

**Auth relaxation**:
- New `isSameOriginRequest()` helper (checks `Sec-Fetch-Site`, falls back to referer). `/api/demo/*` and `/api/stream` accept same-origin requests without Basic auth so the panel works out of the box; external CLI / dashboard callers still need `demo:demo`.

**Fixes**:
- `stopTicker()` clears its slowdown target so restarting after a reset doesn't drop into a stale slowdown window.

### Test plan

- [ ] Visit `/` on the mock deploy → panel renders, no Basic-auth prompt
- [ ] "SSE live" pill turns green within a second
- [ ] Trigger "Radar occupancy spike" → card gains Active badge; "Nothing active" chip is replaced with an override chip counting down from 3 m; feed shows a `device.status_changed` event
- [ ] Reset button becomes enabled; click → all badges clear, active summary shows "All quiet", feed gains a second `device.status_changed` for the restored device
- [ ] With a Mobility source + webhook wired against the mock, a rule matching occupancy≥0.7 fires a push after triggering the spike
- [ ] Curl `POST /api/demo/scenario/radar-spike` without Basic auth → 401 (external callers still gated)
- [ ] Curl same with `-u demo:demo` → 200
- [ ] Endpoint reference still renders below the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)