### PR TITLE
fix(mock-inet): include current status in device.status_changed payload

### DIFF
--- a/apps/mock-inet/lib/scenarios.ts
+++ b/apps/mock-inet/lib/scenarios.ts
@@ -13,7 +13,7 @@ import {
 import { createWorld } from "./worlds";
 import { startTicker, stopTicker, tickerRunning, triggerSlowdown } from "./vds";
 import type { Device, IncidentStatus } from "./types";
-import { allDevices, devicesBySubsystem } from "./devices";
+import { allDevices, currentStatus, devicesBySubsystem } from "./devices";
 import { setOverride, activeOverrides, clearOverride } from "./overrides";
 import { publish } from "./events";
 
@@ -131,10 +131,15 @@ function publishDeviceStatusChanged(device: Device): void {
   publish({
     type: "device.status_changed",
     at: new Date().toISOString(),
-    // We forward the *device record* verbatim (matches the wire shape
-    // downstream connectors expect); the consumer can call /status to
-    // read the fresh values including our override.
-    payload: device,
+    // Payload has to carry the CURRENT status (with any active
+    // override merged in), not just the seed device record. The
+    // Klorad Mobility alert engine's threshold evaluator reads
+    // `event.payload.status[field]` directly — if we only ship the
+    // device it sees `status: null` and every threshold rule silently
+    // drops. Radars in particular don't have baseline status on the
+    // seed, so this was the bug preventing radar-spike alerts from
+    // firing end-to-end.
+    payload: { ...device, status: currentStatus(device) },
   });
 }
 


### PR DESCRIPTION
## Summary

**This is the missing fix** that was pushed to \`feat/mock-inet-demo-panel\` after PR #266 was already merged — so it never landed on main. It's the single-line change that makes end-to-end alerts actually work.

### The bug

Mock's \`publishDeviceStatusChanged(device)\` was shipping the raw seed device record as the webhook payload. Radars and CCTVs have **no baseline \`status\` field on the seed** — status is derived at read time in \`currentStatus()\`. So the webhook payload arrived at mobility with \`status: null\`.

### The consequence

Klorad Mobility's alert-rule engine reads \`event.payload.status[field]\` directly (\`alert-rules.ts:153\`). A null status makes every threshold rule silently return \`{matched: false, observed: null}\`.

**Symptom**: mock's live \`GET /status\` correctly merged the override (radar occupancy 0.85 during a spike), so the live map + drawer looked healthy. But the webhook path shipped null → threshold rules never matched → no alerts, no pushes.

### The fix

One line: publish \`{ ...device, status: currentStatus(device) }\` — the same merge \`GET /status\` uses. Webhook payload now carries the override-merged values and the alert engine matches.

Also fires cleanly on the "restore" republish 3 minutes later, so the alert closes when the override expires.

### Once merged

The seeded demo rules from PR #267 will fire on the corresponding mock scenarios out of the box:
- Radar spike → \`radar.occupancy >= 0.7\` matches
- Traffic slowdown → \`radar.speed <= 30\` matches
- DMS alarm → \`dms.shortStatus > 0\` matches
- Incident → \`incident.posted\` matches

Push notifications to subscribed worlds happen automatically since the seed sets \`targets.worldIds\` to every world in the project.

## Test plan

- [ ] Sources page → **Register webhook** on the source pointing at the mock (if not already)
- [ ] Alert Rules page → **Seed demo rules** (if not already; safe to click if they exist)
- [ ] Subscribe a world visitor to push notifications on the world's PWA
- [ ] Mock homepage → **Trigger** Radar spike
- [ ] Within a few seconds: alert row appears in Mobility's Alerts page
- [ ] Push notification lands on the subscribed device

🤖 Generated with [Claude Code](https://claude.com/claude-code)