### PR TITLE
fix(mobility+mock): persist mock webhook registry to Postgres + activity panel to diagnose

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/RulesClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/alerts/rules/RulesClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import useSWR from "swr";
 import { toast } from "react-toastify";
 import {
+  Activity,
   AlertTriangle,
   ArrowLeft,
   Bell,
@@ -213,8 +214,285 @@ export function RulesClient({
           </ul>
         )}
       </section>
+
+      <ActivityPanel projectId={projectId} />
     </main>
   );
+}
+
+// ─── Recent webhook activity ───────────────────────────────────────
+
+interface RuleOutcomeRow {
+  ruleId: string;
+  ruleName: string;
+  matched: boolean;
+  reason: string;
+}
+
+type WebhookOutcomeKind =
+  | "unknown_source"
+  | "not_registered"
+  | "source_disabled"
+  | "bad_signature"
+  | "invalid_json"
+  | "malformed_event"
+  | "no_rules"
+  | "no_matches"
+  | "processed";
+
+interface WebhookReceiptRow {
+  id: string;
+  at: number;
+  sourceId: string;
+  outcome: WebhookOutcomeKind;
+  eventType: string | null;
+  payloadPreview: string | null;
+  rules: RuleOutcomeRow[];
+  alertsCreated: number;
+  pushesDelivered: number;
+  note: string | null;
+}
+
+/**
+ * Live feed of the last ~50 webhook receipts. Auto-refreshes every
+ * 3 s. Each row shows the outcome (delivered vs bounced), matched vs
+ * unmatched rules with a per-rule reason, and any dispatch note
+ * (e.g. "no MobilityDevice row for externalId=…").
+ *
+ * The point: when an operator triggers a scenario on the mock and
+ * doesn't see an alert, this panel tells them exactly where in the
+ * pipeline it stopped — no need to read Vercel logs.
+ */
+function ActivityPanel({ projectId }: { projectId: string }) {
+  const { data, mutate, isLoading } = useSWR<{
+    receipts: WebhookReceiptRow[];
+  }>(
+    `/api/projects/${projectId}/alert-rules/recent-activity`,
+    fetcher,
+    { refreshInterval: 3000, revalidateOnFocus: true },
+  );
+  const receipts = data?.receipts ?? [];
+
+  return (
+    <section className="mt-8 rounded-2xl border border-line-soft bg-bg">
+      <div className="flex items-center justify-between gap-3 border-b border-line-soft px-6 py-4">
+        <div>
+          <h2 className="flex items-center gap-2 text-lg font-medium text-text-primary">
+            <Activity size={16} strokeWidth={1.7} className="text-accent" />
+            Recent webhook activity
+          </h2>
+          <p className="mt-0.5 text-[11px] text-text-tertiary">
+            Last {receipts.length} receipts, most recent first. Auto-refreshes
+            every 3 s. In-memory — cleared on a serverless cold start.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void mutate()}
+          className="text-xs text-text-tertiary hover:text-accent"
+        >
+          Refresh
+        </button>
+      </div>
+      {isLoading && receipts.length === 0 ? (
+        <p className="px-6 py-8 text-sm text-text-tertiary">Loading…</p>
+      ) : receipts.length === 0 ? (
+        <p className="px-6 py-8 text-sm text-text-tertiary">
+          No webhook receipts yet. Trigger a scenario on the mock; if
+          nothing shows up here after a few seconds, the webhook isn&apos;t
+          reaching this deploy (check the source&apos;s webhook
+          registration on the{" "}
+          <span className="font-medium text-text-secondary">Sources</span>{" "}
+          page).
+        </p>
+      ) : (
+        <ul className="divide-y divide-line-soft">
+          {receipts.map((r) => (
+            <ReceiptRow key={r.id} receipt={r} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ReceiptRow({ receipt }: { receipt: WebhookReceiptRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const tone = outcomeTone(receipt.outcome);
+  const matchedCount = receipt.rules.filter((r) => r.matched).length;
+
+  return (
+    <li className="px-6 py-3">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-start gap-3 text-left"
+      >
+        <span
+          aria-hidden
+          className={`mt-1 h-2 w-2 shrink-0 rounded-full ${tone.dotClass}`}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-baseline gap-2">
+            <span className={`text-xs font-medium ${tone.textClass}`}>
+              {tone.label}
+            </span>
+            {receipt.eventType && (
+              <span className="font-mono text-[11px] text-text-secondary">
+                {receipt.eventType}
+              </span>
+            )}
+            <span className="ml-auto text-[10px] uppercase tracking-[0.14em] text-text-tertiary">
+              {relativeFrom(receipt.at)}
+            </span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-text-tertiary">
+            {receipt.outcome === "processed" && (
+              <>
+                <span>{matchedCount}/{receipt.rules.length} matched</span>
+                <span>·</span>
+                <span>
+                  {receipt.alertsCreated} alert
+                  {receipt.alertsCreated === 1 ? "" : "s"}
+                </span>
+                <span>·</span>
+                <span>
+                  {receipt.pushesDelivered} push
+                  {receipt.pushesDelivered === 1 ? "" : "es"}
+                </span>
+              </>
+            )}
+            {receipt.note && (
+              <>
+                {receipt.outcome === "processed" && <span>·</span>}
+                <span className="text-amber-500">{receipt.note}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-3 rounded-md border border-line-soft bg-surface-2 p-3">
+          {receipt.rules.length > 0 && (
+            <div>
+              <p className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+                Per-rule outcome
+              </p>
+              <ul className="space-y-1">
+                {receipt.rules.map((r) => (
+                  <li
+                    key={r.ruleId}
+                    className="flex items-baseline gap-2 text-[11px]"
+                  >
+                    <span
+                      aria-hidden
+                      className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${
+                        r.matched ? "bg-accent" : "bg-text-tertiary"
+                      }`}
+                    />
+                    <span className="font-medium text-text-primary">
+                      {r.ruleName}
+                    </span>
+                    <span className="text-text-secondary">— {r.reason}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {receipt.payloadPreview && (
+            <div>
+              <p className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-text-tertiary">
+                Payload preview
+              </p>
+              <pre className="overflow-x-auto rounded bg-bg px-2 py-1.5 font-mono text-[10px] text-text-secondary">
+                {receipt.payloadPreview}
+              </pre>
+            </div>
+          )}
+          <p className="text-[10px] text-text-tertiary">
+            source <code>{receipt.sourceId}</code>
+          </p>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function outcomeTone(outcome: WebhookOutcomeKind): {
+  label: string;
+  dotClass: string;
+  textClass: string;
+} {
+  switch (outcome) {
+    case "processed":
+      return {
+        label: "Processed",
+        dotClass: "bg-emerald-500",
+        textClass: "text-emerald-500",
+      };
+    case "no_matches":
+      return {
+        label: "No matches",
+        dotClass: "bg-amber-500",
+        textClass: "text-amber-500",
+      };
+    case "no_rules":
+      return {
+        label: "No rules",
+        dotClass: "bg-amber-500",
+        textClass: "text-amber-500",
+      };
+    case "source_disabled":
+      return {
+        label: "Source disabled",
+        dotClass: "bg-amber-500",
+        textClass: "text-amber-500",
+      };
+    case "not_registered":
+      return {
+        label: "Not registered",
+        dotClass: "bg-red-500",
+        textClass: "text-red-500",
+      };
+    case "unknown_source":
+      return {
+        label: "Unknown source",
+        dotClass: "bg-red-500",
+        textClass: "text-red-500",
+      };
+    case "bad_signature":
+      return {
+        label: "Bad signature",
+        dotClass: "bg-red-500",
+        textClass: "text-red-500",
+      };
+    case "invalid_json":
+    case "malformed_event":
+      return {
+        label: "Malformed",
+        dotClass: "bg-red-500",
+        textClass: "text-red-500",
+      };
+    default:
+      return {
+        label: outcome,
+        dotClass: "bg-text-tertiary",
+        textClass: "text-text-secondary",
+      };
+  }
+}
+
+function relativeFrom(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 0) return "just now";
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return new Date(ts).toLocaleString();
 }
 
 // ─── Seed demo rules button ────────────────────────────────────────

--- a/apps/mobility/app/api/projects/[projectId]/alert-rules/recent-activity/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/alert-rules/recent-activity/route.ts
@@ -1,0 +1,32 @@
+/**
+ * `GET /api/projects/[projectId]/alert-rules/recent-activity` — the
+ * last ~50 webhook receipts for this project, most recent first.
+ * Powers the Alert Rules "Recent webhook activity" panel.
+ *
+ * Read from an in-memory ring buffer; a Vercel cold start clears
+ * history but that's fine for the live-debug loop this panel is
+ * for. Read-only, no cache.
+ *
+ * Requires project `read`.
+ */
+import { NextResponse } from "next/server";
+import { requireProjectAccess } from "@/lib/authz";
+import { recentReceipts } from "@/lib/mobility/webhook-audit";
+
+type Params = Promise<{ projectId: string }>;
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId } = await params;
+  const denied = await requireProjectAccess(projectId, "read");
+  if (denied) return denied;
+
+  return NextResponse.json(
+    { receipts: recentReceipts(projectId) },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/apps/mobility/app/api/webhooks/inet-atms/[sourceId]/route.ts
+++ b/apps/mobility/app/api/webhooks/inet-atms/[sourceId]/route.ts
@@ -4,11 +4,15 @@
  *   that follows the same envelope). Verifies the HMAC signature on
  *   the request body against the source's stored `webhookSecret`,
  *   parses the event, walks the project's enabled alert rules, and
- *   opens a `MobilityAlert` per matching rule.
+ *   opens a `MobilityAlert` per matching rule (which also dispatches
+ *   pushes via `openAlertAndDispatch`).
  *
- * The push fan-out to world subscribers is Arc C PR3 — this endpoint
- * only inserts the alert rows and returns the count. Once PR3 lands
- * the same insert path also dispatches pushes.
+ * Every terminal exit path records a `WebhookReceipt` on the
+ * `webhook-audit` ring buffer so the Alert Rules "Recent webhook
+ * activity" panel can surface what actually happened — invalid
+ * signature, no matches, no matching device row, etc. Debugging a
+ * silent "no alerts" then becomes a UI query instead of tail-ing
+ * server logs.
  *
  * Auth: HMAC only. No session, no CSRF token, no rate-limit yet —
  * upstream is the mock, which controls the secret.
@@ -16,8 +20,17 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { evaluateRules, type StoredRule, type UpstreamEvent } from "@/lib/mobility/alert-rules";
+import {
+  evaluateRules,
+  explainRules,
+  type StoredRule,
+  type UpstreamEvent,
+} from "@/lib/mobility/alert-rules";
 import { openAlertAndDispatch } from "@/lib/mobility/alert-dispatch";
+import {
+  previewPayload,
+  record as recordReceipt,
+} from "@/lib/mobility/webhook-audit";
 
 export const runtime = "nodejs";
 
@@ -35,15 +48,45 @@ export async function POST(
     select: { id: true, projectId: true, webhookSecret: true, enabled: true },
   });
   if (!source) {
+    recordReceipt(null, {
+      sourceId,
+      outcome: "unknown_source",
+      eventType: null,
+      payloadPreview: null,
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: "source id not found",
+    });
     return NextResponse.json({ error: "Unknown source" }, { status: 404 });
   }
   if (!source.webhookSecret) {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "not_registered",
+      eventType: null,
+      payloadPreview: null,
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: "source has no webhookSecret — click Register webhook on the source",
+    });
     return NextResponse.json(
       { error: "Webhook not registered for this source" },
       { status: 400 },
     );
   }
   if (!source.enabled) {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "source_disabled",
+      eventType: null,
+      payloadPreview: null,
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: "source is disabled — events are ignored until re-enabled",
+    });
     // Return 200 with a note so the upstream doesn't retry and
     // eventually deactivate the webhook while the source is paused.
     return NextResponse.json({ ok: true, ignored: "source disabled" });
@@ -54,6 +97,18 @@ export async function POST(
   const rawBody = await req.text();
   const signatureHeader = req.headers.get(SIGNATURE_HEADER);
   if (!verifySignature(rawBody, source.webhookSecret, signatureHeader)) {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "bad_signature",
+      eventType: null,
+      payloadPreview: previewPayload({ rawBody: rawBody.slice(0, 200) }),
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: signatureHeader
+        ? "signature header present but did not verify — secret out of sync?"
+        : "no signature header on request",
+    });
     return NextResponse.json({ error: "Bad signature" }, { status: 401 });
   }
 
@@ -61,18 +116,37 @@ export async function POST(
   try {
     event = JSON.parse(rawBody) as UpstreamEvent;
   } catch {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "invalid_json",
+      eventType: null,
+      payloadPreview: previewPayload({ rawBody: rawBody.slice(0, 200) }),
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: "body was not valid JSON",
+    });
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   if (!event || typeof event !== "object" || typeof event.type !== "string") {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "malformed_event",
+      eventType: null,
+      payloadPreview: previewPayload(event),
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: "event JSON missing `type` string field",
+    });
     return NextResponse.json({ error: "Malformed event" }, { status: 400 });
   }
 
   const rules = await prisma.mobilityAlertRule.findMany({
     where: {
       projectId: source.projectId,
-      enabled: true,
-      // Rules scoped to a source only match webhooks from that source;
-      // project-wide rules (sourceId = null) match every source.
+      // Include disabled rules so the audit panel can show that a
+      // rule was intentionally muted rather than mismatched.
       OR: [{ sourceId: null }, { sourceId: source.id }],
     },
     select: {
@@ -85,8 +159,39 @@ export async function POST(
     },
   });
 
+  if (rules.length === 0) {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "no_rules",
+      eventType: event.type,
+      payloadPreview: previewPayload(event.payload),
+      rules: [],
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: "no rules configured for this project (try Seed demo rules)",
+    });
+    return NextResponse.json({ ok: true, matched: 0, note: "no rules" });
+  }
+
+  const explanations = explainRules(event, rules as StoredRule[]);
   const matches = evaluateRules(event, rules as StoredRule[]);
+
   if (matches.length === 0) {
+    recordReceipt(source.projectId, {
+      sourceId,
+      outcome: "no_matches",
+      eventType: event.type,
+      payloadPreview: previewPayload(event.payload),
+      rules: explanations.map((e) => ({
+        ruleId: e.ruleId,
+        ruleName: e.ruleName,
+        matched: e.matched,
+        reason: e.reason,
+      })),
+      alertsCreated: 0,
+      pushesDelivered: 0,
+      note: null,
+    });
     return NextResponse.json({ ok: true, matched: 0 });
   }
 
@@ -112,10 +217,19 @@ export async function POST(
 
   let inserted = 0;
   let pushedCount = 0;
+  const dispatchNotes: string[] = [];
   for (const match of matches) {
-    if (!match.externalId) continue;
+    if (!match.externalId) {
+      dispatchNotes.push(`${match.ruleName}: matched but payload had no externalId/deviceId`);
+      continue;
+    }
     const deviceId = deviceIdByExternal.get(match.externalId);
-    if (!deviceId) continue;
+    if (!deviceId) {
+      dispatchNotes.push(
+        `${match.ruleName}: matched externalId="${match.externalId}" but no MobilityDevice row for this source (needs a sync)`,
+      );
+      continue;
+    }
     const result = await openAlertAndDispatch({
       projectId: source.projectId,
       deviceId,
@@ -128,6 +242,22 @@ export async function POST(
     inserted += 1;
     pushedCount += result.pushed.reduce((a, p) => a + p.delivered, 0);
   }
+
+  recordReceipt(source.projectId, {
+    sourceId,
+    outcome: "processed",
+    eventType: event.type,
+    payloadPreview: previewPayload(event.payload),
+    rules: explanations.map((e) => ({
+      ruleId: e.ruleId,
+      ruleName: e.ruleName,
+      matched: e.matched,
+      reason: e.reason,
+    })),
+    alertsCreated: inserted,
+    pushesDelivered: pushedCount,
+    note: dispatchNotes.length > 0 ? dispatchNotes.join(" · ") : null,
+  });
 
   return NextResponse.json({
     ok: true,

--- a/apps/mobility/lib/mobility/alert-rules.ts
+++ b/apps/mobility/lib/mobility/alert-rules.ts
@@ -141,6 +141,116 @@ export function evaluateRules(
   return out;
 }
 
+/** Per-rule outcome for the "Recent webhook activity" panel. Explains
+ *  why each rule matched or didn't so the operator can see, at a
+ *  glance, whether a subsystem/field/value mismatch is the reason
+ *  their radar spike didn't fire.
+ *
+ *  Kept separate from `evaluateRules` so the hot webhook path pays no
+ *  overhead for producing debug strings — this is called immediately
+ *  after `evaluateRules` when we're already going to record a receipt. */
+export interface RuleExplanation {
+  ruleId: string;
+  ruleName: string;
+  matched: boolean;
+  reason: string;
+}
+
+export function explainRules(
+  event: UpstreamEvent,
+  rules: StoredRule[],
+): RuleExplanation[] {
+  return rules.map((rule) => {
+    if (!rule.enabled) {
+      return {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        matched: false,
+        reason: "no match: rule disabled",
+      };
+    }
+    if (rule.kind === "threshold") {
+      const parsed = ThresholdConfig.safeParse(rule.config);
+      if (!parsed.success) {
+        return {
+          ruleId: rule.id,
+          ruleName: rule.name,
+          matched: false,
+          reason: "no match: rule config invalid",
+        };
+      }
+      const cfg = parsed.data;
+      if (event.type !== "device.status_changed") {
+        return {
+          ruleId: rule.id,
+          ruleName: rule.name,
+          matched: false,
+          reason: `no match: event type is "${event.type}", threshold rules need "device.status_changed"`,
+        };
+      }
+      const eventSubsystem = event.payload.subsystem ?? null;
+      if (eventSubsystem !== cfg.subsystem) {
+        return {
+          ruleId: rule.id,
+          ruleName: rule.name,
+          matched: false,
+          reason: `no match: rule subsystem "${cfg.subsystem}" ≠ payload subsystem "${eventSubsystem ?? "(missing)"}"`,
+        };
+      }
+      const outcome = evaluateThresholdOnStatus(event.payload.status, cfg);
+      if (outcome.observed === null) {
+        const status = event.payload.status;
+        const statusPresent =
+          status && typeof status === "object" ? "present" : "missing/null";
+        return {
+          ruleId: rule.id,
+          ruleName: rule.name,
+          matched: false,
+          reason: `no match: field "${cfg.field}" not a number on payload.status (status ${statusPresent})`,
+        };
+      }
+      if (!outcome.matched) {
+        return {
+          ruleId: rule.id,
+          ruleName: rule.name,
+          matched: false,
+          reason: `no match: observed ${outcome.observed} did not satisfy ${cfg.op} ${cfg.value}`,
+        };
+      }
+      return {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        matched: true,
+        reason: `matched: ${cfg.field}=${outcome.observed} ${cfg.op} ${cfg.value}`,
+      };
+    }
+    // Event rule.
+    const parsed = EventConfig.safeParse(rule.config);
+    if (!parsed.success) {
+      return {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        matched: false,
+        reason: "no match: rule config invalid",
+      };
+    }
+    if (parsed.data.eventType !== event.type) {
+      return {
+        ruleId: rule.id,
+        ruleName: rule.name,
+        matched: false,
+        reason: `no match: rule listens for "${parsed.data.eventType}", event was "${event.type}"`,
+      };
+    }
+    return {
+      ruleId: rule.id,
+      ruleName: rule.name,
+      matched: true,
+      reason: `matched: event ${event.type}`,
+    };
+  });
+}
+
 function matchThreshold(
   event: DeviceStatusEvent,
   cfg: ThresholdConfig,

--- a/apps/mobility/lib/mobility/webhook-audit.ts
+++ b/apps/mobility/lib/mobility/webhook-audit.ts
@@ -1,0 +1,119 @@
+/**
+ * In-memory ring buffer for the last N webhook receipts per project.
+ * Powers the Alert Rules "Recent webhook activity" panel — the answer
+ * to "I triggered a scenario but nothing happened, where did it go?".
+ *
+ * Every terminal step of `/api/webhooks/inet-atms/[sourceId]` calls
+ * `record(...)` with an outcome so the operator can see, in real time:
+ *
+ *   - whether the webhook is even reaching mobility
+ *   - whether the HMAC is valid (source registered + secret matches)
+ *   - which rules matched vs which didn't and why
+ *   - whether device rows exist for the matched externalId
+ *   - whether alerts were opened + pushes delivered
+ *
+ * Vercel serverless caveat: this is process-local. A cold start
+ * clears the buffer. That's acceptable for a live-debug session —
+ * during the "trigger → observe" loop the operator is running the
+ * mock + mobility calls land on the same warm instance. If we ever
+ * need cross-instance history the receipts belong in a Prisma table
+ * (or on the existing `MobilityWorldEvent` audit stream); for now
+ * ephemeral is fine.
+ */
+
+export type WebhookOutcomeKind =
+  | "unknown_source"
+  | "not_registered"
+  | "source_disabled"
+  | "bad_signature"
+  | "invalid_json"
+  | "malformed_event"
+  | "no_rules"
+  | "no_matches"
+  | "processed";
+
+export interface RuleOutcome {
+  ruleId: string;
+  ruleName: string;
+  matched: boolean;
+  /** Human-readable reason — either "matched: ..." or "no match: ...". */
+  reason: string;
+}
+
+export interface WebhookReceipt {
+  id: string;
+  at: number;
+  sourceId: string;
+  outcome: WebhookOutcomeKind;
+  eventType: string | null;
+  /** Truncated JSON of the event payload (first 400 chars). Handy
+   *  when a rule doesn't match to eyeball what actually arrived. */
+  payloadPreview: string | null;
+  rules: RuleOutcome[];
+  alertsCreated: number;
+  pushesDelivered: number;
+  /** Short human note — the "why" for terminal outcomes that skipped
+   *  processing (missing signature header, etc.). */
+  note: string | null;
+}
+
+/** Buffer size per project. Fifty is enough for a full demo session
+ *  (each scenario emits at most 2 events × 6 scenarios = 12) with
+ *  slack for repeats. */
+const CAP = 50;
+
+const store = new Map<string, WebhookReceipt[]>();
+
+export function record(
+  projectId: string | null,
+  receipt: Omit<WebhookReceipt, "id" | "at"> & {
+    id?: string;
+    at?: number;
+  },
+): void {
+  // Unknown-source outcomes have no projectId — bucket them under a
+  // sentinel key so we still surface them somewhere. In practice the
+  // panel only queries per project, so these end up dropped, but they
+  // stay in memory in case a future "system webhook feed" wants them.
+  const key = projectId ?? "__no_project__";
+  const ring = store.get(key) ?? [];
+  ring.unshift({
+    id: receipt.id ?? randomId(),
+    at: receipt.at ?? Date.now(),
+    sourceId: receipt.sourceId,
+    outcome: receipt.outcome,
+    eventType: receipt.eventType,
+    payloadPreview: receipt.payloadPreview,
+    rules: receipt.rules,
+    alertsCreated: receipt.alertsCreated,
+    pushesDelivered: receipt.pushesDelivered,
+    note: receipt.note,
+  });
+  if (ring.length > CAP) ring.length = CAP;
+  store.set(key, ring);
+}
+
+export function recentReceipts(projectId: string): WebhookReceipt[] {
+  return store.get(projectId) ?? [];
+}
+
+/** Rounds trip an unknown value into a short preview string for the
+ *  panel. Truncated so a massive VDS tick payload doesn't dominate
+ *  the response. */
+export function previewPayload(payload: unknown, max = 400): string {
+  try {
+    const s = JSON.stringify(payload);
+    if (s.length <= max) return s;
+    return s.slice(0, max) + "…";
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function randomId(): string {
+  // Enough uniqueness for a client list key. Not security-sensitive.
+  return (
+    Math.random().toString(36).slice(2, 10) +
+    Date.now().toString(36).slice(-4)
+  );
+}


### PR DESCRIPTION
## Summary — two changes, one arc

**The bug (root cause of no alerts and no push notifications).** The mock stored its webhook registry in a module-level `Map`, which is per-serverless-instance state. On Vercel: mobility registered with instance A → A's Map has the webhook. Scenario POST lands on instance B → B's Map is empty → nothing fires. Symptom in the mock's SSE feed: "Nothing yet" even with active scenarios (the SSE listener lives on yet another instance).

**Fix (this PR):**
1. **Persist mock's webhook registry to Postgres** — new `MockWebhook` model in the shared schema. Every mock instance queries the same table, so a registration on any instance is visible to a scenario POST on any other.
2. **Activity panel on the Alert Rules page** — every terminal exit path of the receiver logs a `WebhookReceipt` with the outcome, so the operator can see with certainty whether webhooks arrive and what happens to each.

Together: (2) tells you what's broken; (1) fixes the specific thing that was broken.

### Persistence — what changes and what doesn't

- **New**: `MockWebhook` table + `apps/mock-inet/lib/prisma.ts` client + `apps/mock-inet/lib/webhooks.ts` rewritten async, Postgres-backed.
- **Unchanged**: seed devices (still JSON), overrides (still in-memory — the scenario POST and the webhook fire happen synchronously in the same request, so the override is guaranteed present when the payload is built), all Mobility models, all connector code.
- **No conflict** with device data — `MockWebhook` is an orphan table with no FK, mirrors exactly what the Map used to hold, has zero relationship to `MobilityDevice` / `MobilityAlert*` / etc.

Requires `DATABASE_URL` set on the mock's Vercel env (point it at the same Postgres mobility uses).

### Activity panel — every outcome named

New section under the rules table, auto-refreshes every 3s. One row per webhook receipt, expandable to per-rule reasoning + payload preview.

Outcomes:
- `Processed` (green) — matched N/M rules, opened X alerts, delivered Y pushes.
- `No matches` (amber) — expand for the per-rule reason (`no match: rule subsystem "radar" ≠ payload subsystem "vsls"`, etc.).
- `No rules` (amber) — hint to click Seed demo rules.
- `Not registered` (red) — source has no `webhookSecret`.
- `Bad signature` (red) — secret drift.
- `Source disabled` (amber) — enable it.
- `Unknown source` (red) — source id in URL doesn't exist.
- `Malformed` (red) — invalid JSON / missing `type`.

Also names the specific dispatch-skip reason: `matched externalId="RADAR-K9" but no MobilityDevice row for this source — needs a sync`.

## Test plan

- [ ] Migration deploys cleanly on prod (already applied on dev DB).
- [ ] Set `DATABASE_URL` on mock's Vercel env if not already.
- [ ] Redeploy mock.
- [ ] Sources page → **Register webhook** (fresh registration in Postgres).
- [ ] Mock homepage → **Trigger** any scenario.
- [ ] Within ~3s: Alert Rules → "Recent webhook activity" panel shows a receipt with `Processed` outcome + matched rule count.
- [ ] Alerts tab shows new alert rows.
- [ ] Subscribed world visitors get a push.
- [ ] Cross-instance sanity: hit the mock repeatedly in a burst so different Vercel warm instances handle scenarios — receipts still land on mobility (was the failure mode before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)