### PR TITLE
fix(mock-inet): persist webhook registry + status overrides to Postgres

### DIFF
--- a/apps/mock-inet/app/api/demo/overrides/route.ts
+++ b/apps/mock-inet/app/api/demo/overrides/route.ts
@@ -17,9 +17,10 @@ export async function GET(request: NextRequest) {
     if (denied) return denied;
   }
   const now = Date.now();
+  const overrides = await activeOverrides();
   return NextResponse.json({
     now,
-    overrides: activeOverrides().map((o) => ({
+    overrides: overrides.map((o) => ({
       ...o,
       expiresInMs: Math.max(0, o.expiresAt - now),
     })),

--- a/apps/mock-inet/app/api/demo/scenario/[name]/route.ts
+++ b/apps/mock-inet/app/api/demo/scenario/[name]/route.ts
@@ -40,13 +40,13 @@ export async function POST(request: NextRequest, { params }: Params) {
       case "traffic":
         return NextResponse.json(runTraffic());
       case "radar-spike":
-        return NextResponse.json(runRadarSpike(deviceId));
+        return NextResponse.json(await runRadarSpike(deviceId));
       case "dms-alarm":
-        return NextResponse.json(runDmsAlarm(deviceId));
+        return NextResponse.json(await runDmsAlarm(deviceId));
       case "incident-cascade":
-        return NextResponse.json(runIncidentCascade());
+        return NextResponse.json(await runIncidentCascade());
       case "reset":
-        return NextResponse.json(resetAll());
+        return NextResponse.json(await resetAll());
       default:
         return NextResponse.json(
           {

--- a/apps/mock-inet/app/api/demo/status/route.ts
+++ b/apps/mock-inet/app/api/demo/status/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     const denied = requireBasicAuth(request);
     if (denied) return denied;
   }
-  return NextResponse.json(getScenarioStatus(), {
+  return NextResponse.json(await getScenarioStatus(), {
     // Never cache; the whole point is fresh state on every poll.
     headers: { "cache-control": "no-store" },
   });

--- a/apps/mock-inet/app/api/webhooks/[id]/route.ts
+++ b/apps/mock-inet/app/api/webhooks/[id]/route.ts
@@ -12,7 +12,7 @@ export async function DELETE(request: NextRequest, { params }: Params) {
   const denied = requireBasicAuth(request);
   if (denied) return denied;
   const { id } = await params;
-  const removed = deleteWebhook(id);
+  const removed = await deleteWebhook(id);
   if (!removed) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/apps/mock-inet/app/api/webhooks/route.ts
+++ b/apps/mock-inet/app/api/webhooks/route.ts
@@ -9,7 +9,8 @@ export async function GET(request: NextRequest) {
   const denied = requireBasicAuth(request);
   if (denied) return denied;
   // Never leak the secret on list; it's shown only on create.
-  const scrubbed = listWebhooks().map(({ secret: _secret, ...rest }) => rest);
+  const rows = await listWebhooks();
+  const scrubbed = rows.map(({ secret: _secret, ...rest }) => rest);
   return NextResponse.json(scrubbed);
 }
 
@@ -24,6 +25,6 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-  const wh = registerWebhook(parsed.data);
+  const wh = await registerWebhook(parsed.data);
   return NextResponse.json(wh, { status: 201 });
 }

--- a/apps/mock-inet/app/atms/[...path]/route.ts
+++ b/apps/mock-inet/app/atms/[...path]/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest, { params }: PathParams) {
   // ── /atms/{s}-rest/rest/{s}/{id}  → single
   if (!action) return singleResponse(subsystem, externalId);
   // ── /atms/{s}-rest/rest/{s}/{id}/status  → status
-  if (action === "status") return statusResponse(subsystem, externalId);
+  if (action === "status") return await statusResponse(subsystem, externalId);
   return notFound();
 }
 
@@ -93,16 +93,15 @@ function singleResponse(subsystem: Subsystem, externalId: string) {
   return NextResponse.json(device);
 }
 
-function statusResponse(subsystem: Subsystem, externalId: string) {
+async function statusResponse(subsystem: Subsystem, externalId: string) {
   const device = deviceByExternalId(
     fetchFromSubsystem(subsystem),
     externalId,
   );
   if (!device) return notFound();
-  // Live per-subsystem status — see `currentStatus()`. CCTV / AID /
-  // RADAR now return sensible shapes instead of `{}` so the operator
-  // drawer has data to render.
-  return NextResponse.json(currentStatus(device));
+  // Live per-subsystem status — see `currentStatus()`. Async now
+  // because overrides are Postgres-backed.
+  return NextResponse.json(await currentStatus(device));
 }
 
 function notFound() {

--- a/apps/mock-inet/lib/devices.ts
+++ b/apps/mock-inet/lib/devices.ts
@@ -151,14 +151,20 @@ export function fetchFromSubsystem(requested: Subsystem): Subsystem {
  * (volume/speed for radar, eventCount for aid) pass through into the
  * drawer's `live.status.raw` blob.
  */
-export function currentStatus(device: Device): Record<string, unknown> {
+export async function currentStatus(
+  device: Device,
+): Promise<Record<string, unknown>> {
   const raw = baseStatus(device);
   // Merge any active scenario override on top. Overrides let the
   // demo picker turn a single device "hot" for a few minutes without
   // touching the seed — spike radar occupancy, alarm a DMS, drop
   // reachability on a CCTV — and every subsequent /status call from
   // that scenario's demo window returns the mutated value.
-  const override = getOverride(device.externalId);
+  //
+  // Async because the override store is Postgres now (was in-memory
+  // per instance, which made cross-instance reads return baseline
+  // even during an active scenario).
+  const override = await getOverride(device.externalId);
   return override ? { ...raw, ...override.patch, timestamp: Date.now() } : raw;
 }
 

--- a/apps/mock-inet/lib/overrides.ts
+++ b/apps/mock-inet/lib/overrides.ts
@@ -1,16 +1,23 @@
 /**
- * Per-device status overrides driven by demo scenarios. Overrides
- * live in-memory with an expiry timestamp — `currentStatus()` merges
- * them on top of the deterministic base status so a scripted scenario
- * (radar slowdown, DMS alarm, incident cascade) shows up on every
- * subsequent `/status` call until the override lapses.
+ * Per-device status overrides driven by demo scenarios. Persisted to
+ * Postgres (`MockStatusOverride` table) — was a module-level `Map`
+ * that broke on Vercel serverless the same way the webhook registry
+ * did: a scenario POST set the override on one instance, but every
+ * other instance saw baseline values on `/status` reads, so the
+ * Mobility drawer view diverged from the alert row it just fired.
  *
- * Vercel serverless quirk (same one that applies to the event bus):
- * each cold instance has its own overrides map. For a demo where the
- * scenario POST and the /status GET land on the same warm instance
- * this is fine; the connector polling on 15s intervals will hit the
- * same instance within the demo window.
+ * TTL is enforced at read time (`WHERE expiresAt > NOW()`). Expired
+ * rows are best-effort deleted on read so the table doesn't grow
+ * unbounded — demo scale (max ~10 concurrent overrides) doesn't
+ * warrant a scheduled cleanup.
  */
+import { prisma } from "./prisma";
+
+// The workspace's shared Prisma singleton is typed as `any` to work
+// around the Accelerate extension's union-type inference (see
+// `packages/prisma/index.ts`), so the JSON column doesn't need a
+// strict `InputJsonValue` cast. Plain object shapes flow through.
+
 export interface StatusOverride {
   /** Epoch ms after which the override is discarded. */
   expiresAt: number;
@@ -20,63 +27,97 @@ export interface StatusOverride {
   reason: string;
 }
 
-const overrides = new Map<string, StatusOverride>();
-
-export function setOverride(
+export async function setOverride(
   externalId: string,
   patch: Record<string, unknown>,
   durationMs: number,
   reason: string,
-): void {
-  overrides.set(externalId, {
-    expiresAt: Date.now() + durationMs,
-    patch,
-    reason,
+): Promise<void> {
+  const expiresAt = new Date(Date.now() + durationMs);
+  // Prisma's InputJsonValue is a union of JSON primitives + arrays +
+  // objects; `Record<string, unknown>` isn't structurally assignable
+  // without a cast even though every real payload we send is valid
+  // JSON. Cast at the boundary keeps callers ergonomic.
+  const patchJson = patch as unknown as Parameters<
+    typeof prisma.mockStatusOverride.upsert
+  >[0]["create"]["patch"];
+  await prisma.mockStatusOverride.upsert({
+    where: { externalId },
+    create: {
+      externalId,
+      patch: patchJson,
+      reason,
+      expiresAt,
+    },
+    update: {
+      patch: patchJson,
+      reason,
+      expiresAt,
+    },
   });
 }
 
 /** Return the active override for a device, or `null` if none/expired.
- *  Auto-purges expired entries as a side effect so the map doesn't
- *  grow unbounded across a long-lived instance. */
-export function getOverride(externalId: string): StatusOverride | null {
-  const row = overrides.get(externalId);
+ *  Purges an expired row as a side effect. */
+export async function getOverride(
+  externalId: string,
+): Promise<StatusOverride | null> {
+  const row = await prisma.mockStatusOverride.findUnique({
+    where: { externalId },
+  });
   if (!row) return null;
-  if (row.expiresAt < Date.now()) {
-    overrides.delete(externalId);
+  const expiresAt = row.expiresAt.getTime();
+  if (expiresAt < Date.now()) {
+    await prisma.mockStatusOverride
+      .delete({ where: { externalId } })
+      .catch(() => undefined);
     return null;
   }
-  return row;
+  return {
+    expiresAt,
+    patch: row.patch as Record<string, unknown>,
+    reason: row.reason,
+  };
 }
 
-export function clearOverride(externalId: string): void {
-  overrides.delete(externalId);
+export async function clearOverride(externalId: string): Promise<void> {
+  await prisma.mockStatusOverride
+    .delete({ where: { externalId } })
+    .catch(() => undefined);
 }
 
-/** For the /overrides debug endpoint — list every active override. */
-export function activeOverrides(): Array<{
-  externalId: string;
-  expiresAt: number;
-  reason: string;
-  patch: Record<string, unknown>;
-}> {
-  const now = Date.now();
-  const out: Array<{
+/** For the /overrides debug endpoint — list every non-expired override.
+ *  Purges expired rows opportunistically so the caller only sees hot
+ *  entries. */
+export async function activeOverrides(): Promise<
+  Array<{
     externalId: string;
     expiresAt: number;
     reason: string;
     patch: Record<string, unknown>;
-  }> = [];
-  for (const [externalId, row] of overrides.entries()) {
-    if (row.expiresAt < now) {
-      overrides.delete(externalId);
-      continue;
-    }
-    out.push({
-      externalId,
-      expiresAt: row.expiresAt,
+  }>
+> {
+  const now = new Date();
+  // Prune the tail first — a single DELETE is cheaper than filtering
+  // in application code, and keeps the table tidy for the demo panel.
+  await prisma.mockStatusOverride
+    .deleteMany({ where: { expiresAt: { lt: now } } })
+    .catch(() => undefined);
+  const rows = await prisma.mockStatusOverride.findMany({
+    where: { expiresAt: { gt: now } },
+    orderBy: { expiresAt: "asc" },
+  });
+  return rows.map(
+    (row: {
+      externalId: string;
+      expiresAt: Date;
+      reason: string;
+      patch: unknown;
+    }) => ({
+      externalId: row.externalId,
+      expiresAt: row.expiresAt.getTime(),
       reason: row.reason,
-      patch: row.patch,
-    });
-  }
-  return out;
+      patch: row.patch as Record<string, unknown>,
+    }),
+  );
 }

--- a/apps/mock-inet/lib/prisma.ts
+++ b/apps/mock-inet/lib/prisma.ts
@@ -1,24 +1,7 @@
 /**
- * Prisma client for `apps/mock-inet`. Same singleton pattern as
- * mobility uses — cache on `globalThis` so hot-module reload doesn't
- * spawn a fresh connection on every save in dev.
- *
- * The mock only reads/writes its own `MockWebhook` table — nothing
- * else in the schema is touched from here. `DATABASE_URL` must be set
- * on the deployed environment (pointing at the same Postgres mobility
- * uses is fine and the intended setup).
+ * Re-export the shared Prisma singleton so mock code can just
+ * `import { prisma } from "@/lib/prisma"` — same connection pool
+ * mobility uses, no duplicate client. Requires `DATABASE_URL` on
+ * the mock's deploy env (same Postgres URL mobility uses).
  */
-import { PrismaClient } from "@prisma/client";
-
-const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
-
-export const prisma =
-  globalForPrisma.prisma ??
-  new PrismaClient({
-    log:
-      process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
-  });
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
-}
+export { prisma } from "@klorad/prisma";

--- a/apps/mock-inet/lib/prisma.ts
+++ b/apps/mock-inet/lib/prisma.ts
@@ -1,0 +1,24 @@
+/**
+ * Prisma client for `apps/mock-inet`. Same singleton pattern as
+ * mobility uses — cache on `globalThis` so hot-module reload doesn't
+ * spawn a fresh connection on every save in dev.
+ *
+ * The mock only reads/writes its own `MockWebhook` table — nothing
+ * else in the schema is touched from here. `DATABASE_URL` must be set
+ * on the deployed environment (pointing at the same Postgres mobility
+ * uses is fine and the intended setup).
+ */
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/apps/mock-inet/lib/scenarios.ts
+++ b/apps/mock-inet/lib/scenarios.ts
@@ -127,7 +127,8 @@ function pickRandom<T>(items: T[]): T | null {
   return items[Math.floor(Math.random() * items.length)]!;
 }
 
-function publishDeviceStatusChanged(device: Device): void {
+async function publishDeviceStatusChanged(device: Device): Promise<void> {
+  const status = await currentStatus(device);
   publish({
     type: "device.status_changed",
     at: new Date().toISOString(),
@@ -136,10 +137,8 @@ function publishDeviceStatusChanged(device: Device): void {
     // Klorad Mobility alert engine's threshold evaluator reads
     // `event.payload.status[field]` directly — if we only ship the
     // device it sees `status: null` and every threshold rule silently
-    // drops. Radars in particular don't have baseline status on the
-    // seed, so this was the bug preventing radar-spike alerts from
-    // firing end-to-end.
-    payload: { ...device, status: currentStatus(device) },
+    // drops.
+    payload: { ...device, status },
   });
 }
 
@@ -154,24 +153,31 @@ function publishDeviceStatusChanged(device: Device): void {
  * fires on — the mock provides the trigger data on demand instead
  * of waiting for real rush-hour traffic.
  */
-export function runRadarSpike(deviceId?: string): {
+export async function runRadarSpike(deviceId?: string): Promise<{
   name: "radar-spike";
   status: "started";
   deviceId: string;
-} {
+}> {
   const pool = devicesBySubsystem("radar");
   const device = deviceId
     ? pool.find((d) => d.externalId === deviceId) ?? pickRandom(pool)
     : pickRandom(pool);
   if (!device) throw new Error("No radar devices seeded");
-  setOverride(
+  await setOverride(
     device.externalId,
     { occupancy: 0.85, speed: 18, volume: 105 },
     OVERRIDE_MS,
     "Scenario: radar occupancy spike",
   );
-  publishDeviceStatusChanged(device);
-  setTimeout(() => publishDeviceStatusChanged(device), OVERRIDE_MS + 200);
+  await publishDeviceStatusChanged(device);
+  // Restore event fires after the override lapses. Best-effort — a
+  // cold start between now and OVERRIDE_MS drops the timer, but the
+  // override itself still expires on read via `expiresAt`, so the
+  // /status endpoint returns baseline correctly either way. The only
+  // thing that's lost is the closing `device.status_changed` webhook.
+  setTimeout(() => {
+    void publishDeviceStatusChanged(device);
+  }, OVERRIDE_MS + 200);
   return { name: "radar-spike", status: "started", deviceId: device.externalId };
 }
 
@@ -183,17 +189,17 @@ export function runRadarSpike(deviceId?: string): {
  * without any actual outage. Feeds "alert me when a sign faults"
  * rules downstream.
  */
-export function runDmsAlarm(deviceId?: string): {
+export async function runDmsAlarm(deviceId?: string): Promise<{
   name: "dms-alarm";
   status: "started";
   deviceId: string;
-} {
+}> {
   const pool = devicesBySubsystem("dms");
   const device = deviceId
     ? pool.find((d) => d.externalId === deviceId) ?? pickRandom(pool)
     : pickRandom(pool);
   if (!device) throw new Error("No DMS devices seeded");
-  setOverride(
+  await setOverride(
     device.externalId,
     {
       connectable: false,
@@ -204,8 +210,10 @@ export function runDmsAlarm(deviceId?: string): {
     OVERRIDE_MS,
     "Scenario: DMS alarm",
   );
-  publishDeviceStatusChanged(device);
-  setTimeout(() => publishDeviceStatusChanged(device), OVERRIDE_MS + 200);
+  await publishDeviceStatusChanged(device);
+  setTimeout(() => {
+    void publishDeviceStatusChanged(device);
+  }, OVERRIDE_MS + 200);
   return { name: "dms-alarm", status: "started", deviceId: device.externalId };
 }
 
@@ -218,26 +226,28 @@ export function runDmsAlarm(deviceId?: string): {
  * message asking traffic to slow. Rule editors can wire distinct
  * push targets to each of the three underlying events.
  */
-export function runIncidentCascade(): {
+export async function runIncidentCascade(): Promise<{
   name: "incident-cascade";
   status: "started";
   incidentId: string;
   radarDeviceId: string | null;
   dmsDeviceId: string | null;
-} {
+}> {
   const incident = runIncident();
   const radar = pickRandom(devicesBySubsystem("radar"));
   const dms = pickRandom(devicesBySubsystem("dms"));
   let radarDeviceId: string | null = null;
   let dmsDeviceId: string | null = null;
   if (radar) {
-    const spike = runRadarSpike(radar.externalId);
+    const spike = await runRadarSpike(radar.externalId);
     radarDeviceId = spike.deviceId;
   }
   // Stagger the DMS alarm 4s in so the demo watcher sees the events
   // arrive as a sequence, not all at once.
   if (dms) {
-    setTimeout(() => runDmsAlarm(dms.externalId), 4_000);
+    setTimeout(() => {
+      void runDmsAlarm(dms.externalId);
+    }, 4_000);
     dmsDeviceId = dms.externalId;
   }
   return {
@@ -260,7 +270,7 @@ export function runIncidentCascade(): {
  * This is the "make the demo look normal again" button — critical
  * for running the pitch back-to-back without a 3-minute cool-down.
  */
-export function resetAll(): {
+export async function resetAll(): Promise<{
   name: "reset";
   status: "reset";
   cleared: {
@@ -268,7 +278,7 @@ export function resetAll(): {
     traffic: boolean;
     overrides: number;
   };
-} {
+}> {
   const hadIncident = runningIncident !== null;
   if (runningIncident) {
     clearInterval(runningIncident.timer);
@@ -285,18 +295,18 @@ export function resetAll(): {
   // the "back to normal" event for each affected device. Order
   // matters — clear then publish (so subscribers that re-read
   // /status see the clean value).
-  const active = activeOverrides();
-  for (const row of active) {
-    clearOverride(row.externalId);
-  }
+  const active = await activeOverrides();
+  await Promise.all(active.map((row) => clearOverride(row.externalId)));
   // `activeOverrides()` only carries the externalId; look the device
   // up in the flat pool since overrides are subsystem-agnostic.
   const byExternalId = new Map<string, Device>();
   for (const d of allDevices()) byExternalId.set(d.externalId, d);
-  for (const row of active) {
-    const device = byExternalId.get(row.externalId);
-    if (device) publishDeviceStatusChanged(device);
-  }
+  await Promise.all(
+    active.map((row) => {
+      const device = byExternalId.get(row.externalId);
+      return device ? publishDeviceStatusChanged(device) : Promise.resolve();
+    }),
+  );
 
   return {
     name: "reset",
@@ -330,8 +340,9 @@ export interface ScenarioStatus {
  * active-state badges. Reads authoritative state from each module
  * rather than tracking it here twice.
  */
-export function getScenarioStatus(): ScenarioStatus {
+export async function getScenarioStatus(): Promise<ScenarioStatus> {
   const now = Date.now();
+  const overrides = await activeOverrides();
   return {
     incident: {
       running: runningIncident !== null,
@@ -340,7 +351,7 @@ export function getScenarioStatus(): ScenarioStatus {
     traffic: {
       running: tickerRunning(),
     },
-    overrides: activeOverrides().map((o) => ({
+    overrides: overrides.map((o) => ({
       externalId: o.externalId,
       reason: o.reason,
       expiresAt: o.expiresAt,

--- a/apps/mock-inet/lib/webhooks.ts
+++ b/apps/mock-inet/lib/webhooks.ts
@@ -24,8 +24,19 @@ import type {
   WebhookCreate,
 } from "./types";
 
+interface MockWebhookRow {
+  id: string;
+  url: string;
+  events: string[];
+  secret: string;
+  active: boolean;
+  createdAt: Date;
+  lastDeliveryAt: Date | null;
+  lastDeliveryStatus: number | null;
+}
+
 export async function listWebhooks(): Promise<Webhook[]> {
-  const rows = await prisma.mockWebhook.findMany({
+  const rows: MockWebhookRow[] = await prisma.mockWebhook.findMany({
     orderBy: { createdAt: "asc" },
   });
   return rows.map(fromRow);
@@ -64,7 +75,7 @@ export async function deleteWebhook(id: string): Promise<boolean> {
  * immediately.
  */
 export async function deliverEvent(event: StreamEvent): Promise<void> {
-  const targets = await prisma.mockWebhook.findMany({
+  const targets: MockWebhookRow[] = await prisma.mockWebhook.findMany({
     where: {
       active: true,
       // Postgres text[] "has" — accepts the event type in the
@@ -73,7 +84,9 @@ export async function deliverEvent(event: StreamEvent): Promise<void> {
       events: { has: event.type },
     },
   });
-  await Promise.all(targets.map((row) => sendWithRetry(fromRow(row), event)));
+  await Promise.all(
+    targets.map((row) => sendWithRetry(fromRow(row), event)),
+  );
 }
 
 async function sendWithRetry(
@@ -141,16 +154,7 @@ function sign(secret: string, body: string): string {
 
 /** Map a Prisma row into the caller-facing `Webhook` shape. Keeps
  *  the JSON API stable even if the DB columns drift. */
-function fromRow(row: {
-  id: string;
-  url: string;
-  events: string[];
-  secret: string;
-  active: boolean;
-  createdAt: Date;
-  lastDeliveryAt: Date | null;
-  lastDeliveryStatus: number | null;
-}): Webhook {
+function fromRow(row: MockWebhookRow): Webhook {
   return {
     id: row.id,
     url: row.url,

--- a/apps/mock-inet/lib/webhooks.ts
+++ b/apps/mock-inet/lib/webhooks.ts
@@ -2,54 +2,88 @@
  * Webhook registry + delivery. Same events that flow over SSE fan
  * out here via HTTP POST — HMAC-signed with the webhook's own secret.
  *
+ * Registry is persisted to Postgres (`MockWebhook` table). Was
+ * previously a module-level `Map` — that broke on Vercel serverless
+ * because each instance had its own registry: mobility registered
+ * with one warm instance, the scenario POST fired on a different
+ * one, and the fan-out found no webhooks. Now every instance queries
+ * the same table.
+ *
  * Retry: 3 attempts with exponential back-off (1s / 5s / 30s). After
  * the third failure the webhook is marked inactive; the operator can
- * unregister + re-register it.
+ * unregister + re-register it. `lastDeliveryAt` + `lastDeliveryStatus`
+ * are best-effort — a race between two events can lose one of the
+ * stamps, but the operator UI treats them as informational.
  */
 import { createHmac, randomBytes, randomUUID } from "node:crypto";
-import type { StreamEvent, Webhook, WebhookCreate } from "./types";
+import { prisma } from "./prisma";
+import type {
+  StreamEvent,
+  StreamEventType,
+  Webhook,
+  WebhookCreate,
+} from "./types";
 
-const registry: Map<string, Webhook> = new Map();
-
-export function listWebhooks(): Webhook[] {
-  return Array.from(registry.values());
+export async function listWebhooks(): Promise<Webhook[]> {
+  const rows = await prisma.mockWebhook.findMany({
+    orderBy: { createdAt: "asc" },
+  });
+  return rows.map(fromRow);
 }
 
-export function registerWebhook(input: WebhookCreate): Webhook {
+export async function registerWebhook(input: WebhookCreate): Promise<Webhook> {
   const id = randomUUID();
-  const wh: Webhook = {
-    id,
-    url: input.url,
-    events: [...input.events],
-    secret: input.secret ?? randomBytes(24).toString("hex"),
-    active: true,
-    createdAt: new Date().toISOString(),
-    lastDeliveryAt: null,
-    lastDeliveryStatus: null,
-  };
-  registry.set(id, wh);
-  return wh;
+  const row = await prisma.mockWebhook.create({
+    data: {
+      id,
+      url: input.url,
+      events: [...input.events],
+      secret: input.secret ?? randomBytes(24).toString("hex"),
+      active: true,
+    },
+  });
+  return fromRow(row);
 }
 
-export function deleteWebhook(id: string): boolean {
-  return registry.delete(id);
+export async function deleteWebhook(id: string): Promise<boolean> {
+  try {
+    await prisma.mockWebhook.delete({ where: { id } });
+    return true;
+  } catch {
+    // Prisma throws P2025 when the row doesn't exist — treat as
+    // "already gone" so the caller's contract (bool) is honoured.
+    return false;
+  }
 }
 
 /**
  * Fan `event` out to every active webhook whose `events` filter
  * includes the event's type. Non-blocking — errors are logged.
+ * Reads the registry fresh on every event so a webhook registered
+ * seconds ago on a different serverless instance is picked up
+ * immediately.
  */
 export async function deliverEvent(event: StreamEvent): Promise<void> {
-  const targets = Array.from(registry.values()).filter(
-    (w) => w.active && w.events.includes(event.type),
-  );
-  await Promise.all(targets.map((w) => sendWithRetry(w, event)));
+  const targets = await prisma.mockWebhook.findMany({
+    where: {
+      active: true,
+      // Postgres text[] "has" — accepts the event type in the
+      // whitelist. A future "*" wildcard should be added here if we
+      // ever want a firehose subscriber.
+      events: { has: event.type },
+    },
+  });
+  await Promise.all(targets.map((row) => sendWithRetry(fromRow(row), event)));
 }
 
-async function sendWithRetry(webhook: Webhook, event: StreamEvent): Promise<void> {
+async function sendWithRetry(
+  webhook: Webhook,
+  event: StreamEvent,
+): Promise<void> {
   const body = JSON.stringify(event);
   const signature = sign(webhook.secret, body);
   const backoffs = [1000, 5000, 30000];
+  let lastStatus: number | null = null;
   for (let attempt = 0; attempt < backoffs.length; attempt += 1) {
     try {
       const res = await fetch(webhook.url, {
@@ -62,14 +96,12 @@ async function sendWithRetry(webhook: Webhook, event: StreamEvent): Promise<void
         },
         body,
       });
-      webhook.lastDeliveryAt = new Date().toISOString();
-      webhook.lastDeliveryStatus = res.status;
+      lastStatus = res.status;
+      await stampDelivery(webhook.id, res.status);
       if (res.ok) return;
-      // 2xx failure — the subscriber should stop retrying. 4xx / 5xx
-      // are considered transient except 410 Gone (semantic
-      // deactivation) which disables the webhook immediately.
+      // 410 Gone → semantic deactivation. Any other 4xx / 5xx retries.
       if (res.status === 410) {
-        webhook.active = false;
+        await deactivate(webhook.id);
         return;
       }
     } catch (err) {
@@ -80,9 +112,57 @@ async function sendWithRetry(webhook: Webhook, event: StreamEvent): Promise<void
       await new Promise((r) => setTimeout(r, backoffs[attempt]));
     }
   }
-  webhook.active = false;
+  await deactivate(webhook.id);
+  // Preserve the last observed status when giving up so the operator
+  // UI still shows why the webhook was deactivated.
+  if (lastStatus != null) {
+    await stampDelivery(webhook.id, lastStatus);
+  }
+}
+
+async function stampDelivery(id: string, status: number): Promise<void> {
+  await prisma.mockWebhook
+    .update({
+      where: { id },
+      data: { lastDeliveryAt: new Date(), lastDeliveryStatus: status },
+    })
+    .catch(() => undefined);
+}
+
+async function deactivate(id: string): Promise<void> {
+  await prisma.mockWebhook
+    .update({ where: { id }, data: { active: false } })
+    .catch(() => undefined);
 }
 
 function sign(secret: string, body: string): string {
   return createHmac("sha256", secret).update(body).digest("hex");
+}
+
+/** Map a Prisma row into the caller-facing `Webhook` shape. Keeps
+ *  the JSON API stable even if the DB columns drift. */
+function fromRow(row: {
+  id: string;
+  url: string;
+  events: string[];
+  secret: string;
+  active: boolean;
+  createdAt: Date;
+  lastDeliveryAt: Date | null;
+  lastDeliveryStatus: number | null;
+}): Webhook {
+  return {
+    id: row.id,
+    url: row.url,
+    // Postgres stores as plain `text[]` — the caller-facing type is
+    // the discriminated union `StreamEventType[]`. Zod on the create
+    // path already validates values against the union, so anything
+    // we ever wrote to this column is a valid `StreamEventType`.
+    events: row.events as StreamEventType[],
+    secret: row.secret,
+    active: row.active,
+    createdAt: row.createdAt.toISOString(),
+    lastDeliveryAt: row.lastDeliveryAt?.toISOString() ?? null,
+    lastDeliveryStatus: row.lastDeliveryStatus,
+  };
 }

--- a/apps/mock-inet/package.json
+++ b/apps/mock-inet/package.json
@@ -17,6 +17,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@klorad/prisma": "workspace:*",
+    "@prisma/client": "^5.22.0",
     "next": "15.5.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/prisma/migrations/20260720170000_mock_webhook/migration.sql
+++ b/packages/prisma/migrations/20260720170000_mock_webhook/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "MockWebhook" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "events" TEXT[],
+    "secret" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastDeliveryAt" TIMESTAMP(3),
+    "lastDeliveryStatus" INTEGER,
+
+    CONSTRAINT "MockWebhook_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MockWebhook_active_idx" ON "MockWebhook"("active");

--- a/packages/prisma/migrations/20260720180000_mock_status_override/migration.sql
+++ b/packages/prisma/migrations/20260720180000_mock_status_override/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "MockStatusOverride" (
+    "externalId" TEXT NOT NULL,
+    "patch" JSONB NOT NULL DEFAULT '{}',
+    "reason" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MockStatusOverride_pkey" PRIMARY KEY ("externalId")
+);
+
+-- CreateIndex
+CREATE INDEX "MockStatusOverride_expiresAt_idx" ON "MockStatusOverride"("expiresAt");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1307,3 +1307,45 @@ model MobilityDeviceStyle {
   @@unique([projectId, subsystem])
   @@index([projectId])
 }
+
+/// Webhook registry for `apps/mock-inet` — mirrors what the mock
+/// used to keep in a module-level `Map` (see the pre-persistence
+/// version of `apps/mock-inet/lib/webhooks.ts`). Persisted here
+/// because Vercel serverless has no cross-instance state: the
+/// registration POST from Mobility lands on one warm instance, but
+/// the scenario POST that fires the webhook can land on any other
+/// instance, so an in-memory registry silently drops every event.
+///
+/// The table is intentionally isolated from `Mobility*` device data
+/// — it's the mock's own bookkeeping, not part of the ATMS domain.
+/// Kept in this schema (rather than a separate mock-only DB) because
+/// the mock + Mobility already share the same Postgres in every
+/// deployment and provisioning a second connection string per
+/// deploy is more friction than it's worth.
+///
+/// No FK to anything; the "subscriber" here is anonymous (an
+/// arbitrary URL Mobility gave us with a shared secret). Deletion is
+/// operator-triggered via DELETE /api/webhooks/{id} on the mock.
+model MockWebhook {
+  id                 String   @id
+  /// Absolute URL the mock POSTs each matching event to. This is
+  /// mobility's `/api/webhooks/inet-atms/{sourceId}` in practice, but
+  /// the table doesn't assume it — any HTTPS endpoint works.
+  url                String
+  /// Whitelist of event types this webhook wants. `["*"]` means all.
+  /// Postgres `text[]`, populated from `WebhookCreate.events`.
+  events             String[]
+  /// HMAC secret both sides share. Never returned by list/get — only
+  /// echoed on the create response so the caller can persist it once.
+  secret             String
+  /// Auto-deactivated after 3 failed retries (see `sendWithRetry`).
+  active             Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  lastDeliveryAt     DateTime?
+  /// HTTP status of the most recent delivery attempt. Null before
+  /// the first fire. Used only by the /api/webhooks GET list for
+  /// operator visibility — no logic depends on it.
+  lastDeliveryStatus Int?
+
+  @@index([active])
+}

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -1349,3 +1349,40 @@ model MockWebhook {
 
   @@index([active])
 }
+
+/// Per-device status override applied by the mock's demo scenarios.
+/// Was an in-memory Map in apps/mock-inet/lib/overrides.ts — same
+/// serverless multi-instance problem as MockWebhook: a scenario POST
+/// set the override on the instance that handled it, but every other
+/// instance saw baseline values on the atms status endpoint. That
+/// made Mobility's device-drawer inspection view diverge from the
+/// alert message it just fired ("observed 0.85" in the alert row,
+/// drawer still shows 0). Persisting here makes the whole override
+/// picture instance-agnostic.
+///
+/// TTL semantics: `expiresAt` is enforced at read time — every query
+/// filters `WHERE expiresAt > NOW()`. A best-effort DELETE runs on
+/// read of an expired row so the table doesn't grow unbounded; a
+/// scheduled cleanup isn't needed for demo-scale volume (max ~10
+/// active overrides at any time).
+///
+/// One row per device (`externalId` is the PK) — a later scenario
+/// on the same device overwrites the previous override, matching
+/// the in-memory `Map.set()` semantics it replaces.
+model MockStatusOverride {
+  externalId String   @id
+  /// Merged over the base status shape by `currentStatus()`. Kept
+  /// as opaque JSON so scenarios can patch any subsystem's shape
+  /// without a schema change.
+  patch      Json     @default("{}")
+  /// Human label for the /overrides debug endpoint (e.g. "Scenario:
+  /// radar occupancy spike"). Not read by any evaluator.
+  reason     String
+  /// Absolute expiry timestamp. TTL is 3 minutes for the current
+  /// scenarios; the value is the caller's decision, not enforced
+  /// on this table.
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+
+  @@index([expiresAt])
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,6 +707,12 @@ importers:
 
   apps/mock-inet:
     dependencies:
+      '@klorad/prisma':
+        specifier: workspace:*
+        version: link:../../packages/prisma
+      '@prisma/client':
+        specifier: ^5.22.0
+        version: 5.22.0(prisma@5.22.0)
       next:
         specifier: ^15.1.9
         version: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -14033,8 +14039,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -14064,7 +14070,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14075,7 +14081,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14094,14 +14100,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14116,7 +14122,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14127,7 +14133,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What this ships

Two commits that together fix the "no alerts firing" problem end-to-end:

1. **Cherry-pick of `1b58c137`** — persist the webhook registry (was pushed to PR #269's branch after it merged, so it never made it to main).
2. **New `8ecd0b7f`** — persist status overrides too, so the drawer view stays consistent with the alert row it just fired.

## Why the DB is needed

The mock stored two things in module-level JavaScript Maps: the webhook registry and the scenario overrides. On Vercel serverless, each warm instance runs its own copy of that process, so:

- Mobility registered the webhook with **instance A** → A's Map has the URL. Scenario POST lands on **instance B** → B iterates B's Map → 0 URLs → nothing fires.
- Scenario POST sets an override on **instance A** → A returns spike values on `/status`. Drawer polling lands on **instance B** → B has no override → returns baseline. Alert row says "observed 0.85", drawer shows 0.

Postgres solves both. Every instance queries the same tables.

## What actually changes

- **Two new Prisma models** — `MockWebhook`, `MockStatusOverride`. Orphan tables, no FKs, mirror exactly what the Maps held.
- **Two migrations** — `20260720170000_mock_webhook`, `20260720180000_mock_status_override`.
- **Mock's `webhooks.ts` + `overrides.ts`** — rewritten async, Prisma-backed. `overrides.ts` uses upsert (Map.set semantics) and TTL-at-read-time (`WHERE expiresAt > NOW()`).
- **Every caller updated** — `currentStatus()`, `publishDeviceStatusChanged()`, `runRadarSpike/Dms/Cascade`, `resetAll`, `getScenarioStatus`, plus the API routes that call them.
- **Local `prisma.ts`** — thin re-export of the shared `@klorad/prisma` singleton. Same connection pool as mobility.

## Zero conflict with device data

- Seed devices (JSON, coordinates, IDs) — untouched
- Runtime radar VDS ticker jitter — untouched
- `MobilityDevice` / `MobilityAlert*` — untouched
- The two new `Mock*` tables are isolated from everything else in the schema

## Deployment requirements

- `DATABASE_URL` on the mock's Vercel env (same one mobility uses). ✅ Already set by the user.
- Vercel auto-redeploys on merge.
- Existing webhook registrations in mobility's Postgres are still there, but the mock's in-memory copy is gone across every instance. The user needs to hit **Register webhook** once from the Sources page after merge to seed the new `MockWebhook` table.

## Test plan

- [ ] Migrations deploy cleanly (already applied on dev DB).
- [ ] Mock redeploys with new env.
- [ ] Sources page → **Register webhook** (writes to Postgres now).
- [ ] Mock homepage → **Trigger** Radar spike.
- [ ] Alert Rules → "Recent webhook activity" panel shows `Processed` within ~3 s.
- [ ] Alerts tab has a new row with `observed 0.85`.
- [ ] Open the device drawer for the affected radar → live values show the spike (0.85), NOT baseline.
- [ ] After 3 min: drawer returns to baseline, restore webhook fires with baseline values.
- [ ] Reset button clears every override + republishes restore events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)