### PR TITLE
feat(mobility): Fly-to buttons that are actually visible (public + admin)

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -621,6 +621,25 @@ export function Operator({
             device={selected}
             onCurated={() => void mutate()}
             onClose={() => setSelectedId(null)}
+            onFlyTo={
+              selected.lat != null && selected.lng != null
+                ? () => {
+                    const map = mapRef.current;
+                    if (
+                      !map ||
+                      selected.lat == null ||
+                      selected.lng == null
+                    )
+                      return;
+                    map.flyTo({
+                      center: [selected.lng, selected.lat],
+                      zoom: Math.max(map.getZoom(), 17),
+                      duration: 900,
+                      essential: true,
+                    });
+                  }
+                : null
+            }
           />
         ) : (
           <NoSelection devices={devices} sourcesHref={sourcesHref} />
@@ -1146,10 +1165,14 @@ function DeviceDrawer({
   device,
   onCurated,
   onClose,
+  onFlyTo,
 }: {
   device: DeviceRow;
   onCurated: () => void;
   onClose: () => void;
+  /** Re-fly to this device on the map. Null when the device has no
+   *  coordinates (button hides). */
+  onFlyTo: (() => void) | null;
 }) {
   const { data: live, isLoading } = useSWR<LiveResponse>(
     `/api/devices/${device.id}/live`,
@@ -1201,14 +1224,27 @@ function DeviceDrawer({
             </p>
           )}
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close drawer"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-text-primary"
-        >
-          <X size={14} strokeWidth={1.8} />
-        </button>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {onFlyTo && (
+            <button
+              type="button"
+              onClick={onFlyTo}
+              aria-label="Fly to this device on the map"
+              className="inline-flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1 text-[11px] font-semibold text-accent-contrast transition-opacity hover:opacity-90"
+            >
+              <MapPin size={11} strokeWidth={2.2} aria-hidden />
+              Fly to
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close drawer"
+            className="flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-2 hover:text-text-primary"
+          >
+            <X size={14} strokeWidth={1.8} />
+          </button>
+        </div>
       </header>
 
       {/* ── Locator ────────────────────────────────────────────────── */}

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -1337,15 +1337,15 @@ function DeviceDrawer({
         <button
           type="button"
           onClick={onRecenter}
-          aria-label="Recenter map on this device"
-          title="Recenter"
-          className="rounded-full border p-1.5 transition-colors"
+          aria-label="Fly to this device on the map"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90"
           style={{
-            borderColor: "var(--w-border)",
-            color: "var(--w-fg-muted)",
+            backgroundColor: primary,
+            color: "var(--w-accent-contrast)",
           }}
         >
-          <MapPin size={12} strokeWidth={2} aria-hidden />
+          <MapPin size={12} strokeWidth={2.2} aria-hidden />
+          Fly to
         </button>
         <button
           type="button"

--- a/apps/mobility/app/(public)/w/[slug]/devices/DevicesList.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/devices/DevicesList.tsx
@@ -147,12 +147,16 @@ export function DevicesList({ slug, devices }: Props) {
           {filtered.map((d) => {
             const desc = subsystemDescriptor(d.subsystem);
             const Icon = desc.icon;
+            const hasLocation = d.lat != null && d.lng != null;
             return (
-              <li key={d.id}>
+              <li
+                key={d.id}
+                className="flex items-center gap-2 pr-2 transition-colors hover:bg-[var(--w-page,#f5f5f7)]"
+              >
                 <button
                   type="button"
                   onClick={() => setOpenId(d.id)}
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--w-page,#f5f5f7)]"
+                  className="flex flex-1 items-center gap-3 px-4 py-3 text-left"
                 >
                   <span
                     aria-hidden
@@ -173,11 +177,22 @@ export function DevicesList({ slug, devices }: Props) {
                       {d.primaryRoad ? ` · ${d.primaryRoad}` : ""}
                     </span>
                   </span>
-                  <ChevronRight
-                    size={14}
-                    className="text-[var(--w-fg-muted,#6b6b6b)]"
-                  />
                 </button>
+                {hasLocation && (
+                  <Link
+                    href={`/w/${slug}?device=${encodeURIComponent(d.id)}`}
+                    aria-label={`Fly to ${d.name} on the map`}
+                    title="Fly to this device on the map"
+                    className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--w-fg-muted,#6b6b6b)] transition-colors hover:bg-[var(--w-accent-soft,rgba(14,165,233,0.15))] hover:text-[var(--w-accent,#0ea5e9)]"
+                  >
+                    <MapPin size={14} strokeWidth={2} />
+                  </Link>
+                )}
+                <ChevronRight
+                  size={14}
+                  aria-hidden
+                  className="shrink-0 text-[var(--w-fg-muted,#6b6b6b)]"
+                />
               </li>
             );
           })}


### PR DESCRIPTION
## Where the Fly-to buttons now live

**Three places, all obvious:**

### 1. Public map drawer (visitor)
Tap a pin → drawer opens → **top-right of the header**, next to the Close arrow.

Was a 12 px pin-only icon-button. Now an accent-coloured pill with icon + "Fly to" text.

### 2. Public Devices tab — every row (visitor)
Each device row now has a **pin icon-link on the right** (before the chevron). Tapping it deep-links to \`/w/<slug>?device=<id>\` — the Map tab opens with the drawer up and the camera flying in. Skipped for devices with no coordinates.

The existing "Show on map" button inside the detail sheet stays.

### 3. Admin console operator drawer (operator dashboard)
Select a device on the operator map → the right-side drawer opens → **top-right of the header**, next to the Close ×. Accent pill with icon + "Fly to" text.

Previously the admin drawer had no fly-to button at all — the map auto-panned once on selection change and that was it.

## Shared flyTo semantics

All three call \`map.flyTo({ zoom: Math.max(current, 17), duration: 900, essential: true })\`. Zoom 17 is past the cluster breakpoint (14), so the pin always comes out solo regardless of density.

## Test plan

- [ ] Public map: tap a pin → drawer opens → accent pill "Fly to" visible in header
- [ ] Public Devices tab: every row with lat/lng has a pin icon on the right
- [ ] Tap the row's pin icon → jumps to Map tab, drawer opens, camera flies in
- [ ] Admin console: click a device on the map → right drawer opens → "Fly to" pill visible next to close
- [ ] Click it after panning away → camera returns to the device at zoom ≥ 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)