### PR TITLE
fix(mobility): admin overlay layout + drop Data sources chip + halo shows on alert deep-link

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/Operator.tsx
@@ -11,7 +11,6 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { toast } from "react-toastify";
 import {
-  ArrowUpRight,
   Bell,
   Box,
   CheckCircle2,
@@ -630,22 +629,27 @@ export function Operator({
             environment to render the map.
           </div>
         )}
-        <Legend devices={devices} />
-        <SubsystemFilterBar
-          available={availableSubsystems}
-          hidden={hiddenSubsystems}
-          onToggle={(subsystem) =>
-            setHiddenSubsystems((prev) => {
-              const next = new Set(prev);
-              if (next.has(subsystem)) next.delete(subsystem);
-              else next.add(subsystem);
-              return next;
-            })
-          }
-          onReset={() => setHiddenSubsystems(new Set())}
-        />
+        {/* Top-left overlay stack. On wide screens the Legend and
+            filter chips sit side by side; on narrow screens they
+            wrap. `max-w` reserves room for the right-side settings
+            chip so the two clusters never overlap. */}
+        <div className="pointer-events-auto absolute left-4 top-4 flex max-w-[calc(100%-6rem)] flex-wrap items-start gap-2">
+          <Legend devices={devices} />
+          <SubsystemFilterBar
+            available={availableSubsystems}
+            hidden={hiddenSubsystems}
+            onToggle={(subsystem) =>
+              setHiddenSubsystems((prev) => {
+                const next = new Set(prev);
+                if (next.has(subsystem)) next.delete(subsystem);
+                else next.add(subsystem);
+                return next;
+              })
+            }
+            onReset={() => setHiddenSubsystems(new Set())}
+          />
+        </div>
         <div className="pointer-events-auto absolute right-4 top-4 flex flex-col items-end gap-2">
-          <SourcesChip href={sourcesHref} />
           <ConsoleSettingsChip
             settings={settings}
             onChange={setSettings}
@@ -785,7 +789,7 @@ function Legend({ devices }: { devices: DeviceRow[] }) {
   const publicCount = devices.filter((d) => d.isPublic).length;
   return (
     <div
-      className="pointer-events-auto absolute left-4 top-4 max-w-[260px] overflow-hidden rounded-2xl border shadow-[0_8px_30px_rgba(0,0,0,0.18)] backdrop-blur-xl"
+      className="w-[220px] overflow-hidden rounded-2xl border shadow-[0_8px_30px_rgba(0,0,0,0.18)] backdrop-blur-xl"
       style={{
         backgroundColor: "var(--ov-bg)",
         borderColor: "var(--ov-border-strong)",
@@ -857,14 +861,16 @@ function Legend({ devices }: { devices: DeviceRow[] }) {
   );
 }
 
-/* ─── Subsystem filter chips (floating, top-left, below legend) ───── */
+/* ─── Subsystem filter chips (top-left, next to legend) ─────────── */
 
 /**
  * Chip row that toggles which subsystems render on the map. Empty
  * `hidden` set = everything visible (implicit default). Tap a chip to
  * hide, tap again to bring back. "All" button clears the filter.
- * Skipped entirely when the project has fewer than two subsystems —
- * a single-category filter isn't useful.
+ * Skipped entirely when the project has fewer than two subsystems.
+ *
+ * Positioned by the parent in a shared top-left overlay container
+ * that stacks it next to the Legend (or below on narrow screens).
  */
 function SubsystemFilterBar({
   available,
@@ -881,7 +887,7 @@ function SubsystemFilterBar({
   const anyHidden = hidden.size > 0;
   return (
     <div
-      className="pointer-events-auto absolute left-4 top-[7.5rem] flex max-w-[calc(100%-2rem)] flex-wrap items-center gap-1.5 rounded-2xl border p-2 shadow-[0_8px_30px_rgba(0,0,0,0.18)] backdrop-blur-xl"
+      className="flex max-w-[280px] flex-wrap items-center gap-1.5 rounded-2xl border p-2 shadow-[0_8px_30px_rgba(0,0,0,0.18)] backdrop-blur-xl"
       style={{
         backgroundColor: "var(--ov-bg)",
         borderColor: "var(--ov-border-strong)",
@@ -936,26 +942,6 @@ function SubsystemFilterBar({
         );
       })}
     </div>
-  );
-}
-
-/* ─── Floating top-right "Sources" link ────────────────────────────── */
-
-function SourcesChip({ href }: { href: string }) {
-  return (
-    <Link
-      href={href}
-      className="inline-flex items-center gap-1.5 rounded-full border px-3.5 py-2 text-xs font-semibold shadow-[0_4px_14px_rgba(0,0,0,0.16)] backdrop-blur-xl transition-all hover:border-accent hover:text-accent"
-      style={{
-        backgroundColor: "var(--ov-bg)",
-        borderColor: "var(--ov-border-strong)",
-        color: "var(--ov-fg)",
-      }}
-    >
-      <Database size={12} strokeWidth={2} aria-hidden />
-      Data sources
-      <ArrowUpRight size={11} strokeWidth={2} aria-hidden />
-    </Link>
   );
 }
 

--- a/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
+++ b/apps/mobility/app/(public)/w/[slug]/WorldViewer.tsx
@@ -517,8 +517,48 @@ export function WorldViewer({
         () => setSelectedId(null),
       );
       layersReadyRef.current = true;
+
+      // Seed the unclustered halo source with any pre-existing
+      // selection (from a `?device=` deep-link). Without this the
+      // halo effect no-ops the first time — it runs on mount before
+      // the map is ready and doesn't re-fire when layers finish
+      // attaching, so the halo only appeared after a manual
+      // deselect + reselect. Now the deep-link visitor sees the
+      // halo the instant the map paints.
+      const seedIds = Array.from(
+        new Set(
+          [latestSelectedRef.current, ...highlightIds].filter(
+            (id): id is string => Boolean(id),
+          ),
+        ),
+      );
+      if (seedIds.length > 0) {
+        const seedSource = map.getSource(SELECTED_SOURCE_ID) as
+          | GeoJSONSource
+          | undefined;
+        if (seedSource) {
+          const seedFeatures: GeoJSON.Feature<GeoJSON.Point>[] = devices
+            .filter(
+              (d): d is PublicWorldDevice & { lat: number; lng: number } =>
+                seedIds.includes(d.id) && d.lat != null && d.lng != null,
+            )
+            .map((d) => ({
+              type: "Feature",
+              geometry: { type: "Point", coordinates: [d.lng, d.lat] },
+              properties: {
+                id: d.id,
+                name: d.name,
+                subsystem: d.subsystem,
+              },
+            }));
+          seedSource.setData({
+            type: "FeatureCollection",
+            features: seedFeatures,
+          });
+        }
+      }
     },
-    [primary, highlightIds],
+    [primary, highlightIds, devices],
   );
 
   // Init map once. Camera + selection may be seeded from the URL so


### PR DESCRIPTION
## Three items

### 1. Filter chips sit next to the Legend on the admin map, not on top

Old: Legend was absolutely positioned top-left, filter chips were absolutely positioned at \`top-[7.5rem]\` below it. Worked in isolation but overlapped as soon as the Legend's "needs review" badge or public-map count grew — Legend expanded, filter sat on top.

Fix: both components lose their absolute positioning; parent places them in one \`flex flex-wrap\` container at top-left. Wide screens show them side by side; narrow screens stack. Container \`max-w-[calc(100%-6rem)]\` reserves room for the right-side settings chip so nothing collides.

### 2. "Data sources" chip removed

The floating top-right link wasn't earning its pixel budget (operator can already reach Sources from the sidebar). Dropped the \`SourcesChip\` component and the \`ArrowUpRight\` import. The \`sourcesHref\` prop threading stays because the \`NoSelection\` empty state inside the drawer still uses it.

### 3. Alert deep-link now shows the selection halo on first paint

**Root cause of "I have to deselect + reselect to see the circle":** the effect that populates the unclustered \`SELECTED_SOURCE_ID\` early-returns when \`layersReadyRef.current\` is false. On mount it runs before the map has initialised, no-ops, and doesn't re-fire when layers finish attaching (refs don't trigger effects). A later selection change was the only thing that made the effect run with the map ready.

Fix: after \`layersReadyRef.current = true\` in \`attachLayers\`, seed the halo source directly from the current selection. Deep-link visitor sees the halo the instant the map paints, same as the fly-to.

## Test plan

- [ ] Admin operator map: Legend and filter chips render side by side on desktop
- [ ] Wide "needs review" badge on the Legend no longer pushes the filter row on top
- [ ] Narrow browser: they wrap onto stacked rows without overlap
- [ ] Top-right settings chip still fits, no collision
- [ ] "Data sources" chip is gone
- [ ] Public map: tap a push notification with \`?device=<id>\` → map opens → device selected halo visible immediately, no need to deselect+reselect
- [ ] Same for opening \`/w/<slug>?device=<id>\` directly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)