### PR TITLE
feat(mobility): delete broadcasts from the Reach tab

### DIFF
--- a/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/reach/ReachClient.tsx
+++ b/apps/mobility/app/(dashboard)/org/[orgId]/projects/[projectId]/reach/ReachClient.tsx
@@ -8,8 +8,10 @@ import {
   Bell,
   CheckCircle2,
   Eye,
+  Loader2,
   Megaphone,
   Send,
+  Trash2,
   Users,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -320,7 +322,13 @@ export function ReachClient({
         ) : (
           <ul className="divide-y divide-line-soft">
             {broadcasts.map((b) => (
-              <BroadcastRow key={b.id} broadcast={b} />
+              <BroadcastRow
+                key={b.id}
+                broadcast={b}
+                projectId={projectId}
+                canManage={canSend}
+                onDeleted={() => void mutate()}
+              />
             ))}
           </ul>
         )}
@@ -331,11 +339,48 @@ export function ReachClient({
 
 /* ─── Row ──────────────────────────────────────────────────────────── */
 
-function BroadcastRow({ broadcast }: { broadcast: Broadcast }) {
+function BroadcastRow({
+  broadcast,
+  projectId,
+  canManage,
+  onDeleted,
+}: {
+  broadcast: Broadcast;
+  projectId: string;
+  canManage: boolean;
+  onDeleted: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
   const openRate =
     broadcast.delivered > 0
       ? Math.round((broadcast.opened / broadcast.delivered) * 100)
       : null;
+
+  const remove = async () => {
+    if (
+      !confirm(
+        `Delete "${broadcast.title}"? It will also disappear from every visitor's Notifications feed.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/broadcasts/${broadcast.id}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        toast.error("Delete failed");
+        return;
+      }
+      toast.success("Deleted");
+      onDeleted();
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <li className="grid items-start gap-3 px-5 py-4 md:grid-cols-[auto_1fr_auto]">
       <span
@@ -374,6 +419,22 @@ function BroadcastRow({ broadcast }: { broadcast: Broadcast }) {
           sub={openRate != null ? `${openRate}%` : undefined}
           tone={broadcast.opened > 0 ? "success" : "muted"}
         />
+        {canManage && (
+          <button
+            type="button"
+            onClick={remove}
+            disabled={busy}
+            aria-label={`Delete "${broadcast.title}"`}
+            title="Delete this broadcast and remove it from every visitor's Notifications feed"
+            className="rounded-md p-1.5 text-text-tertiary transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
+          >
+            {busy ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Trash2 size={14} />
+            )}
+          </button>
+        )}
       </div>
     </li>
   );

--- a/apps/mobility/app/api/projects/[projectId]/broadcasts/[broadcastId]/route.ts
+++ b/apps/mobility/app/api/projects/[projectId]/broadcasts/[broadcastId]/route.ts
@@ -1,0 +1,36 @@
+/**
+ * DELETE /api/projects/[projectId]/broadcasts/[broadcastId]
+ *   Remove a Broadcast row. Used by the Reach tab's per-row Delete
+ *   action so operators can prune the visitor Notifications feed
+ *   without touching the `MobilityAlert` audit log (alert rows keep
+ *   their `closedAt` timestamp for history).
+ *
+ * Requires project `write` — same gate as create.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireProjectAccess } from "@/lib/authz";
+
+type Params = Promise<{ projectId: string; broadcastId: string }>;
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Params },
+): Promise<NextResponse> {
+  const { projectId, broadcastId } = await params;
+  const denied = await requireProjectAccess(projectId, "write");
+  if (denied) return denied;
+
+  // Confirm the broadcast belongs to this project before deleting —
+  // stops a stray id from a URL edit reaching another org's rows.
+  const row = await prisma.broadcast.findFirst({
+    where: { id: broadcastId, projectId },
+    select: { id: true },
+  });
+  if (!row) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await prisma.broadcast.delete({ where: { id: broadcastId } });
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary

**Answers "why do the alerts I delete keep showing in the PWA":** the admin's alerts panel only sets \`MobilityAlert.closedAt\`. The Broadcast row that actually feeds the visitor's Notifications feed is a separate table with no cascade — the two lived independent lives.

Fix: direct delete on the broadcast side, from the Reach tab where the operator already sees the broadcast history.

## What ships

- **Per-row Trash icon-button** on each broadcast in the Reach tab's history list. Confirms first (message includes "will also disappear from every visitor's Notifications feed" so it's clear what happens), then removes.
- **New endpoint** \`DELETE /api/projects/[projectId]/broadcasts/[broadcastId]\`. Scopes by \`projectId\` so a stray id from a URL edit can't reach another org's rows. Requires project \`write\`.
- Delete gated on the same \`canSend\` check that controls the composer (owner / admin / member). Public viewers see no delete button.
- On success: SWR mutate refreshes the list. Deleted row disappears from the visitor feed on their next request.

## What stays

- MobilityAlert rows keep \`closedAt\` for the audit trail. Deleting a broadcast doesn't touch the alert.
- The alerts panel's ack/close semantics are unchanged.
- Manual broadcasts and alert-fired broadcasts are both eligible for deletion — same table.

## Test plan

- [ ] Reach tab: history list shows Trash icon on the right of each row
- [ ] Public viewer role: no Trash icon
- [ ] Click Trash → confirm → row disappears + toast
- [ ] Refresh \`/w/<slug>/notifications\` → deleted broadcast is gone
- [ ] Admin alerts panel: closing an alert still only sets \`closedAt\`, doesn't touch broadcasts (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)